### PR TITLE
deps: use reth release 1.0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,25 +18,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "aead"
-version = "0.4.3"
+name = "adler2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
-dependencies = [
- "generic-array",
-]
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
-name = "aes"
-version = "0.7.5"
+name = "aead"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "cfg-if",
- "cipher 0.3.0",
- "cpufeatures",
- "ctr 0.8.0",
- "opaque-debug",
+ "crypto-common",
+ "generic-array",
 ]
 
 [[package]]
@@ -46,20 +40,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher 0.4.4",
+ "cipher",
  "cpufeatures",
 ]
 
 [[package]]
 name = "aes-gcm"
-version = "0.9.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc3be92e19a7ef47457b8e6f90707e12b6ac5d20c6f3866584fa3be0787d839f"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
  "aead",
- "aes 0.7.5",
- "cipher 0.3.0",
- "ctr 0.7.0",
+ "aes",
+ "cipher",
+ "ctr",
  "ghash",
  "subtle",
 ]
@@ -109,9 +103,9 @@ checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "alloy-chains"
-version = "0.1.23"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1752d7d62e2665da650a36d84abbf239f812534475d51f072a49a533513b7cdd"
+checksum = "bb07629a5d0645d29f68d2fb6f4d0cf15c89ec0965be915f303967180929743f"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -123,9 +117,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58047cc851e58c26224521d1ecda466e3d746ebca0274cd5427aa660a88c353"
+checksum = "7198a527b4c4762cb88d54bcaeb0428f4298b72552c9c8ec4af614b4a4990c59"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -138,35 +132,63 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "0.7.7"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413902aa18a97569e60f679c23f46a18db1656d87ab4d4e49d0e1e52042f66df"
+checksum = "ba5b68572f5dfa99ede0a491d658c9842626c956b840d0b97d0bbc9637742504"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
  "alloy-sol-type-parser",
  "alloy-sol-types",
  "const-hex",
- "derive_more",
+ "derive_more 0.99.18",
  "itoa",
  "serde",
  "serde_json",
- "winnow 0.6.15",
+ "winnow",
+]
+
+[[package]]
+name = "alloy-eip2930"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0069cf0642457f87a01a014f6dc29d5d893cd4fd8fddf0c3cdfad1bb3ebafc41"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "arbitrary",
+ "rand 0.8.5",
+ "serde",
+]
+
+[[package]]
+name = "alloy-eip7702"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37d319bb544ca6caeab58c39cea8921c55d924d4f68f2c60f24f914673f9a74a"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "arbitrary",
+ "k256",
+ "rand 0.8.5",
+ "serde",
 ]
 
 [[package]]
 name = "alloy-eips"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32a3e14fa0d152d00bd8daf605eb74ad397efb0f54bd7155585823dddb4401e"
+checksum = "159eab0e4e15b88571f55673af37314f4b8f17630dc1b393c3d70f2128a1d494"
 dependencies = [
+ "alloy-eip2930",
+ "alloy-eip7702",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
  "arbitrary",
  "c-kzg",
- "derive_more",
- "k256",
+ "derive_more 1.0.0",
  "once_cell",
  "serde",
  "sha2 0.10.8",
@@ -174,9 +196,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cb76c8a3913f2466c5488f3a915e3a15d15596bdc935558c1a9be75e9ec508"
+checksum = "210f4b358d724f85df8adaec753c583defb58169ad3cad3d48c80d1a25a6ff0e"
 dependencies = [
  "alloy-primitives",
  "alloy-serde",
@@ -185,9 +207,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "0.7.7"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc05b04ac331a9f07e3a4036ef7926e49a8bf84a99a1ccfc7e2ab55a5fcbb372"
+checksum = "299d2a937b6c60968df3dad2a988b0f0e03277b344639a4f7a31bd68e6285e59"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -197,11 +219,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e76a9feec2352c78545d1a37415699817bae8dc41654bd1bfe57d6cdd5433bd"
+checksum = "f7733446dd531f8eb877331fea02f6c40bdbb47444a17dc3464bf75319cc073a"
 dependencies = [
  "alloy-primitives",
+ "alloy-sol-types",
  "serde",
  "serde_json",
  "thiserror",
@@ -210,13 +233,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3223d71dc78f464b2743418d0be8b5c894313e272105a6206ad5e867d67b3ce2"
+checksum = "b80851d1697fc4fa2827998e3ee010a3d1fc59c7d25e87070840169fcf465832"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-json-rpc",
+ "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-serde",
@@ -229,10 +253,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-primitives"
-version = "0.7.7"
+name = "alloy-network-primitives"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccb3ead547f4532bc8af961649942f0b9c16ee9226e26caa3f38420651cc0bf4"
+checksum = "d76a2336889f3d0624b18213239d27f4f34eb476eb35bef22f6a8cc24e0c0078"
+dependencies = [
+ "alloy-primitives",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
+name = "alloy-primitives"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a767e59c86900dd7c3ce3ecef04f3ace5ac9631ee150beb8b7d22f7fa3bbb2d7"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -240,15 +275,14 @@ dependencies = [
  "cfg-if",
  "const-hex",
  "derive_arbitrary",
- "derive_more",
- "ethereum_ssz",
+ "derive_more 0.99.18",
  "getrandom 0.2.15",
  "hex-literal",
  "itoa",
  "k256",
  "keccak-asm",
  "proptest",
- "proptest-derive 0.4.0",
+ "proptest-derive",
  "rand 0.8.5",
  "ruint",
  "serde",
@@ -257,15 +291,16 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29da7457d853cb8199ec04b227d5d2ef598be3e59fc2bbad70c8be213292f32"
+checksum = "f2d2a195caa6707f5ce13905794865765afc6d9ea92c3a56e3a973c168d703bc"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
  "alloy-eips",
  "alloy-json-rpc",
  "alloy-network",
+ "alloy-network-primitives",
  "alloy-primitives",
  "alloy-pubsub",
  "alloy-rpc-client",
@@ -276,7 +311,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "auto_impl",
- "dashmap 5.5.3",
+ "dashmap",
  "futures",
  "futures-utils-wasm",
  "lru",
@@ -284,6 +319,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio",
  "tracing",
  "url",
@@ -291,9 +327,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f64acfec654ade392cecfa9bba0408eb2a337d55f1b857925da79970cb70f3d6"
+checksum = "b4c59e13200322138fe4279b4676b0d78c4f55502de127f5a448495d3ddfaa43"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -310,9 +346,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a43b18702501396fa9bcdeecd533bc85fac75150d308fc0f6800a01e6234a003"
+checksum = "26154390b1d205a4a7ac7352aa2eb4f81f391399d4e2f546fb81a2f8bb383f62"
 dependencies = [
  "alloy-rlp-derive",
  "arrayvec",
@@ -321,20 +357,20 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp-derive"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83524c1f6162fcb5b0decf775498a125066c86dda6066ed609531b0e912f85a"
+checksum = "4d0f2d905ebd295e7effec65e5f6868d153936130ae718352771de3e7d03c75c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
 name = "alloy-rpc-client"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a9e609524fa31c2c70eb24c0da60796809193ad4787a6dfe6d0db0d3ac112d"
+checksum = "ed31cdba2b23d71c555505b06674f8e7459496abfd7f4875d268434ef5a99ee6"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -356,9 +392,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e5d76f1e8b22f48b7b8f985782b68e7eb3938780e50e8b646a53e41a598cdf5"
+checksum = "e2d758f65aa648491c6358335c578de45cd7de6fdf2877c3cef61f2c9bebea21"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -369,9 +405,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "137f0014c3a61ccc5168289fcc214d7296c389c0bf60425c0f898cff1d7e4bec"
+checksum = "7e41c33bbddaec71ca1bd7a4df38f95f408ef4fa3b3c29a7e9cc8d0e43be5fbe"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -381,9 +417,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4282c002a4ae9f57887dae57083fcca6dca09cb6685bf98b8582ea93cb3df97d"
+checksum = "fa5ee4ffe3e687a6372dd02e998f4f65e512ffdfe0d2c248db822649814c36cd"
 dependencies = [
  "alloy-primitives",
  "alloy-serde",
@@ -392,9 +428,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b47dcc8e3bebea57b1c9495a7e6f3313e99d355c0f5b80473cfbdfcbdd6ebea"
+checksum = "3173bf0239a59d3616f4f4ab1682de25dd30b13fb8f52bf7ee7503729354f3c4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -406,9 +442,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73445fbc5c02258e3d0d977835c92366a4d91545fd456c3fc8601c61810bc9f6"
+checksum = "24e800d959606fa19b36b31d7c24d68ef75b970c654b7aa581dce23de82db0a5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -425,12 +461,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "605fa8462732bb8fd0645a9941e12961e079d45ae6a44634c826f8229c187bdf"
+checksum = "c0ba05d6ee4db0d89113294a614137940f79abfc2c40a9a3bee2995660358776"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
+ "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
@@ -444,9 +481,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ffcb83a5a91d327c40ba2157a19016bb883c1426f1708fea5f9e042032fd73e"
+checksum = "9a0b28949d1077826684b5912fe9ab1c752a863af0419b1ba9abff19006d61b1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -457,9 +494,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f561a8cdd377b6ac3beab805b9df5ec2c7d99bb6139aab23c317f26df6fb346"
+checksum = "cd2af822ed58f2b6dd7cfccf88bf69f42c9a8cbf4663316227646a8a3e5a591f"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -471,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06a4bd39910631c11148c5b2c55e2c61f8626affd2a612e382c668d5e5971ce"
+checksum = "1a8fbdf39e93a9b213df39541be51671e93e6e8b142c3602ddb4ff6219a1bc85"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -483,9 +520,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c5b9057acc02aee1b8aac2b5a0729cb0f73d080082c111313e5d1f92a96630"
+checksum = "bfd260ede54f0b53761fdd04133acc10ae70427f66a69aa9590529bbd066cd58"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -495,9 +532,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37f10592696f4ab8b687d5a8ab55e998a14ea0ca5f8eb20ad74a96ad671bb54a"
+checksum = "7b5193ee6b370b89db154d7dc40c6a8e6ce11213865baaf2b418a9f2006be762"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -508,68 +545,85 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-sol-macro"
-version = "0.7.7"
+name = "alloy-signer-local"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b40397ddcdcc266f59f959770f601ce1280e699a91fc1862f29cef91707cd09"
+checksum = "bf6b19bbb231c7f941af07f363d4c74d356dfcdfcd7dfa85a41a504ae856a6d5"
+dependencies = [
+ "alloy-consensus",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-signer",
+ "async-trait",
+ "k256",
+ "rand 0.8.5",
+ "thiserror",
+]
+
+[[package]]
+name = "alloy-sol-macro"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183bcfc0f3291d9c41a3774172ee582fb2ce6eb6569085471d8f225de7bb86fc"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "0.7.7"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "867a5469d61480fea08c7333ffeca52d5b621f5ca2e44f271b117ec1fc9a0525"
+checksum = "71c4d842beb7a6686d04125603bc57614d5ed78bf95e4753274db3db4ba95214"
 dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
  "heck 0.5.0",
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
  "syn-solidity",
  "tiny-keccak",
 ]
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "0.7.7"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e482dc33a32b6fadbc0f599adea520bd3aaa585c141a80b404d0a3e3fa72528"
+checksum = "1306e8d3c9e6e6ecf7a39ffaf7291e73a5f655a2defd366ee92c2efebcdf7fee"
 dependencies = [
  "const-hex",
  "dunce",
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
  "syn-solidity",
 ]
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "0.7.7"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbcba3ca07cf7975f15d871b721fb18031eec8bce51103907f6dcce00b255d98"
+checksum = "f4691da83dce9c9b4c775dd701c87759f173bd3021cbf2e60cde00c5fe6d7241"
 dependencies = [
  "serde",
- "winnow 0.6.15",
+ "winnow",
 ]
 
 [[package]]
 name = "alloy-sol-types"
-version = "0.7.7"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91ca40fa20793ae9c3841b83e74569d1cc9af29a2f5237314fd3452d51e38c7"
+checksum = "577e262966e92112edbd15b1b2c0947cc434d6e8311df96d3329793fe8047da9"
 dependencies = [
+ "alloy-json-abi",
  "alloy-primitives",
  "alloy-sol-macro",
  "const-hex",
@@ -578,9 +632,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b44b0f6f4a2593b258fa7b6cae8968e6a4c404d9ef4f5bc74401f2d04fa23fa"
+checksum = "454220c714857cf68af87d788d1f0638ad8766268b94f6a49fed96cbc2ab382c"
 dependencies = [
  "alloy-json-rpc",
  "base64 0.22.1",
@@ -597,9 +651,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d8f1eefa8cb9e7550740ee330feba4fed303a77ad3085707546f9152a88c380"
+checksum = "377f2353d7fea03a2dba6b9ffbb7d610402c040dd5700d1fae8b9ec2673eed9b"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -612,14 +666,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15ccc1c8f8ae415e93ec0e7851bd4cdf4afdd48793d13a91b860317da1f36104"
+checksum = "26d43ba8e9a3a7fef626d5fd93cc87ff2d6d2c81acfb866f068b3dce31dda060"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
  "futures",
- "http 1.1.0",
+ "http",
  "rustls",
  "serde_json",
  "tokio",
@@ -630,15 +684,19 @@ dependencies = [
 
 [[package]]
 name = "alloy-trie"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03704f265cbbb943b117ecb5055fd46e8f41e7dc8a58b1aed20bcd40ace38c15"
+checksum = "cd491aade72a82d51db430379f48a44a1d388ff03711a2023f1faa302c5b675d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "derive_more",
+ "arbitrary",
+ "derive_arbitrary",
+ "derive_more 1.0.0",
  "hashbrown 0.14.5",
  "nybbles",
+ "proptest",
+ "proptest-derive",
  "serde",
  "smallvec",
  "tracing",
@@ -661,9 +719,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -676,33 +734,33 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
+checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
 dependencies = [
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
 dependencies = [
  "anstyle",
  "windows-sys 0.52.0",
@@ -725,7 +783,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -771,7 +829,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "paste",
- "rustc_version 0.4.0",
+ "rustc_version 0.4.1",
  "zeroize",
 ]
 
@@ -869,9 +927,9 @@ checksum = "9d151e35f61089500b617991b791fc8bfd237ae50cd5950803758a179b41e67a"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "asn1_der"
@@ -892,7 +950,7 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "zstd 0.13.2",
- "zstd-safe 7.2.0",
+ "zstd-safe 7.2.1",
 ]
 
 [[package]]
@@ -914,7 +972,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -925,7 +983,7 @@ checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -936,7 +994,7 @@ checksum = "b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c"
 dependencies = [
  "futures",
  "pharos",
- "rustc_version 0.4.0",
+ "rustc_version 0.4.1",
 ]
 
 [[package]]
@@ -963,7 +1021,7 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -994,7 +1052,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.7.4",
  "object",
  "rustc-demangle",
 ]
@@ -1034,15 +1092,6 @@ name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
-
-[[package]]
-name = "beef"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bimap"
@@ -1085,7 +1134,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -1175,166 +1224,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "bls12_381"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7bc6d6292be3a19e6379786dac800f551e5865a5bb51ebbe3064ab80433f403"
-dependencies = [
- "ff",
- "group",
- "pairing",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
 name = "blst"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62dc83a094a71d43eeadd254b1ec2d24cb6a0bb6cadce00df51f0db594711a32"
+checksum = "4378725facc195f1a538864863f6de233b500a8862747e7f165078a419d5e874"
 dependencies = [
  "cc",
  "glob",
  "threadpool",
  "zeroize",
-]
-
-[[package]]
-name = "boa_ast"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49637e7ecb7c541c46c3e885d4c49326ad8076dbfb88bef2cf3165d8ea7df2b"
-dependencies = [
- "bitflags 2.6.0",
- "boa_interner",
- "boa_macros",
- "indexmap 2.2.6",
- "num-bigint",
- "rustc-hash 2.0.0",
-]
-
-[[package]]
-name = "boa_engine"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "411558b4cbc7d0303012e26721815e612fed78179313888fd5dd8d6c50d70099"
-dependencies = [
- "arrayvec",
- "bitflags 2.6.0",
- "boa_ast",
- "boa_gc",
- "boa_interner",
- "boa_macros",
- "boa_parser",
- "boa_profiler",
- "boa_string",
- "bytemuck",
- "cfg-if",
- "dashmap 5.5.3",
- "fast-float",
- "hashbrown 0.14.5",
- "icu_normalizer",
- "indexmap 2.2.6",
- "intrusive-collections",
- "itertools 0.13.0",
- "num-bigint",
- "num-integer",
- "num-traits",
- "num_enum",
- "once_cell",
- "pollster",
- "portable-atomic",
- "rand 0.8.5",
- "regress",
- "rustc-hash 2.0.0",
- "ryu-js",
- "serde",
- "serde_json",
- "sptr",
- "static_assertions",
- "tap",
- "thin-vec",
- "thiserror",
- "time",
-]
-
-[[package]]
-name = "boa_gc"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eff345a85a39cf9b8ed863198947d61e6df2b1d774002b57341158b0ce2c525"
-dependencies = [
- "boa_macros",
- "boa_profiler",
- "boa_string",
- "hashbrown 0.14.5",
- "thin-vec",
-]
-
-[[package]]
-name = "boa_interner"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b779280420804c70da9043d152c84eb96e2f7c9e7d1ec3262decf59f9349df"
-dependencies = [
- "boa_gc",
- "boa_macros",
- "hashbrown 0.14.5",
- "indexmap 2.2.6",
- "once_cell",
- "phf",
- "rustc-hash 2.0.0",
- "static_assertions",
-]
-
-[[package]]
-name = "boa_macros"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e0097fa69cde4c95f9869654004340fbbe2bcf3ce9189ba2a31a65ac40e0a1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.72",
- "synstructure",
-]
-
-[[package]]
-name = "boa_parser"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd63fe8faf62561fc8c50f9402687e8cfde720b57d292fb3b4ac17c821878ac1"
-dependencies = [
- "bitflags 2.6.0",
- "boa_ast",
- "boa_interner",
- "boa_macros",
- "boa_profiler",
- "fast-float",
- "icu_properties",
- "num-bigint",
- "num-traits",
- "regress",
- "rustc-hash 2.0.0",
-]
-
-[[package]]
-name = "boa_profiler"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9da895f0df9e2a97b36c1f98e0c5d2ab963abc8679d80f2a66f7bcb211ce90"
-
-[[package]]
-name = "boa_string"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9ca6668df83fcd3c2903f6f296b7180421908c5b478ebe0d1c468be9fd60e1c"
-dependencies = [
- "fast-float",
- "paste",
- "rustc-hash 2.0.0",
- "sptr",
- "static_assertions",
 ]
 
 [[package]]
@@ -1378,9 +1276,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.9.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
+checksum = "40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c"
 dependencies = [
  "memchr",
  "regex-automata 0.4.7",
@@ -1401,23 +1299,9 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
 name = "bytemuck"
-version = "1.16.1"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b236fc92302c97ed75b38da1f4917b5cdda4984745740f153a5d3059e48d725e"
-dependencies = [
- "bytemuck_derive",
-]
-
-[[package]]
-name = "bytemuck_derive"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee891b04274a59bd38b412188e24b849617b2e45a0fd8d057deb63e7403761b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.72",
-]
+checksum = "773d90827bc3feecfb67fab12e24de0749aad83c74b9504ecde46237b5cd24e2"
 
 [[package]]
 name = "byteorder"
@@ -1427,9 +1311,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.1"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
+checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 dependencies = [
  "serde",
 ]
@@ -1457,15 +1341,16 @@ dependencies = [
 
 [[package]]
 name = "c-kzg"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdf100c4cea8f207e883ff91ca886d621d8a166cb04971dfaa9bb8fd99ed95df"
+checksum = "f0307f72feab3300336fb803a57134159f6e20139af1357f36c54cb90d8e8928"
 dependencies = [
  "blst",
  "cc",
  "glob",
  "hex",
  "libc",
+ "once_cell",
  "serde",
 ]
 
@@ -1501,9 +1386,9 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.1.7"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0ec6b951b160caa93cc0c7b209e5a3bff7aae9062213451ac99493cd844c239"
+checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
 dependencies = [
  "serde",
 ]
@@ -1548,12 +1433,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.6"
+version = "1.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aba8f4e9906c7ce3c73463f62a7f0c65183ada1a2d47e397cc8810827f9694f"
+checksum = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6"
 dependencies = [
  "jobserver",
  "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -1594,15 +1480,6 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
@@ -1624,9 +1501,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.10"
+version = "4.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f6b81fb3c84f5563d509c59b5a48d935f689e993afa90fe39047f05adef9142"
+checksum = "ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1634,9 +1511,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.10"
+version = "4.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca6706fd5224857d9ac5eb9355f6683563cc0541c7cd9d014043b57cbec78ac"
+checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1646,27 +1523,27 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.8"
+version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085"
+checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "combine"
@@ -1710,18 +1587,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d72c1252426a83be2092dd5884a5f6e3b8e7180f6891b6263d2c21b92ec8816"
 dependencies = [
  "digest 0.10.7",
-]
-
-[[package]]
-name = "confy"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45b1f4c00870f07dc34adcac82bb6a72cc5aabca8536ba1797e01df51d2ce9a0"
-dependencies = [
- "directories",
- "serde",
- "thiserror",
- "toml",
 ]
 
 [[package]]
@@ -1809,9 +1674,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core2"
@@ -1824,9 +1689,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
 dependencies = [
  "libc",
 ]
@@ -1939,6 +1804,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1954,29 +1820,11 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a232f92a03f37dd7d7dd2adc67166c77e9cd88de5b019b9a9eecfaeaf7bfd481"
-dependencies = [
- "cipher 0.3.0",
-]
-
-[[package]]
-name = "ctr"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
-dependencies = [
- "cipher 0.3.0",
-]
-
-[[package]]
-name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
- "cipher 0.4.4",
+ "cipher",
 ]
 
 [[package]]
@@ -2004,7 +1852,7 @@ dependencies = [
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
- "rustc_version 0.4.0",
+ "rustc_version 0.4.1",
  "subtle",
  "zeroize",
 ]
@@ -2017,7 +1865,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -2041,7 +1889,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -2052,20 +1900,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.72",
-]
-
-[[package]]
-name = "dashmap"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core 0.9.10",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -2163,7 +1998,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -2175,8 +2010,30 @@ dependencies = [
  "convert_case 0.4.0",
  "proc-macro2",
  "quote",
- "rustc_version 0.4.0",
- "syn 2.0.72",
+ "rustc_version 0.4.1",
+ "syn 2.0.76",
+]
+
+[[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "convert_case 0.6.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.76",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -2198,15 +2055,6 @@ dependencies = [
  "const-oid",
  "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "directories"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
-dependencies = [
- "dirs-sys",
 ]
 
 [[package]]
@@ -2253,14 +2101,15 @@ dependencies = [
 
 [[package]]
 name = "discv5"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cafb8ed8d460b7d1c8d4c970270d45ecb5e283179a3945143196624c55cda6ac"
+checksum = "f569b8c367554666c8652305621e8bae3634a2ff5c6378081d5bd8c399c99f23"
 dependencies = [
- "aes 0.7.5",
+ "aes",
  "aes-gcm",
  "alloy-rlp",
  "arrayvec",
+ "ctr",
  "delay_map",
  "enr",
  "fnv",
@@ -2269,9 +2118,10 @@ dependencies = [
  "hex",
  "hkdf",
  "lazy_static",
- "libp2p",
+ "libp2p-identity",
  "lru",
  "more-asserts",
+ "multiaddr",
  "parking_lot 0.11.2",
  "rand 0.8.5",
  "smallvec",
@@ -2283,17 +2133,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "displaydoc"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.72",
-]
-
-[[package]]
 name = "doctest-file"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2301,9 +2140,9 @@ checksum = "aac81fa3e28d21450aa4d2ac065992ba96a1d7303efbce51a95f4fd175b67562"
 
 [[package]]
 name = "dunce"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
@@ -2422,18 +2261,18 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
 name = "enumn"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fd000fd6988e73bbe993ea3db9b1aa64906ab88766d654973924340c8cddb42"
+checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -2450,44 +2289,6 @@ checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "ethbloom"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c22d4b5885b6aa2fe5e8b9329fb8d232bf739e434e6b87347c63bdd00c120f60"
-dependencies = [
- "crunchy",
- "fixed-hash",
- "impl-rlp",
- "impl-serde",
- "tiny-keccak",
-]
-
-[[package]]
-name = "ethereum-types"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d215cbf040552efcbe99a38372fe80ab9d00268e20012b79fcd0f073edd8ee"
-dependencies = [
- "ethbloom",
- "fixed-hash",
- "impl-rlp",
- "impl-serde",
- "primitive-types",
- "uint",
-]
-
-[[package]]
-name = "ethereum_ssz"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3627f83d8b87b432a5fad9934b4565260722a141a2c40f371f8080adec9425"
-dependencies = [
- "ethereum-types",
- "itertools 0.10.5",
- "smallvec",
 ]
 
 [[package]]
@@ -2513,16 +2314,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
-name = "fast-float"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95765f67b4b18863968b4a1bd5bb576f732b29a4a28c7cd84c09fa3e2875f33c"
-
-[[package]]
 name = "fastrand"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "fastrlp"
@@ -2551,7 +2346,6 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "bitvec",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -2568,7 +2362,6 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
- "arbitrary",
  "byteorder",
  "rand 0.8.5",
  "rustc-hex",
@@ -2577,12 +2370,12 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.30"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
+checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.8.0",
 ]
 
 [[package]]
@@ -2646,7 +2439,6 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
- "num_cpus",
 ]
 
 [[package]]
@@ -2663,7 +2455,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -2749,9 +2541,9 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.4.4"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1583cc1656d7839fd3732b80cf4f38850336cdb9b8ded1cd399ca62958de3c99"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
 dependencies = [
  "opaque-debug",
  "polyval",
@@ -2771,15 +2563,15 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "gloo-net"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43aaa242d1239a8822c15c645f02166398da4f8b5c4bae795c1f5b44e9eee173"
+checksum = "c06f627b1a58ca3d42b45d6104bf1e1a03799df472df00988b6ba21accc10580"
 dependencies = [
  "futures-channel",
  "futures-core",
  "futures-sink",
  "gloo-utils",
- "http 0.2.12",
+ "http",
  "js-sys",
  "pin-project",
  "serde",
@@ -2828,22 +2620,28 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
+checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.1.0",
- "indexmap 2.2.6",
+ "http",
+ "indexmap 2.4.0",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hash-db"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d23bd4e7b5eda0d0f3a307e8b381fdc8ba9000f26fbe912250c0a4cc3956364a"
 
 [[package]]
 name = "hashbrown"
@@ -2981,17 +2779,6 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
@@ -3008,7 +2795,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.1.0",
+ "http",
 ]
 
 [[package]]
@@ -3019,7 +2806,7 @@ checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
  "futures-util",
- "http 1.1.0",
+ "http",
  "http-body",
  "pin-project-lite",
 ]
@@ -3074,7 +2861,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "h2",
- "http 1.1.0",
+ "http",
  "http-body",
  "httparse",
  "httpdate",
@@ -3092,11 +2879,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
 dependencies = [
  "futures-util",
- "http 1.1.0",
+ "http",
  "hyper",
  "hyper-util",
  "log",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -3106,14 +2894,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab92f4f49ee4fb4f997c784b7a2e0fa70050211e0b6a287f898c3c9785ca956"
+checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.1.0",
+ "http",
  "http-body",
  "hyper",
  "pin-project-lite",
@@ -3145,124 +2933,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "icu_collections"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
-
-[[package]]
-name = "icu_normalizer"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
-
-[[package]]
-name = "icu_properties"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_locid_transform",
- "icu_properties_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
-
-[[package]]
-name = "icu_provider"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_provider_macros",
- "stable_deref_trait",
- "tinystr",
- "writeable",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.72",
 ]
 
 [[package]]
@@ -3298,24 +2968,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
 dependencies = [
  "parity-scale-codec",
-]
-
-[[package]]
-name = "impl-rlp"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
-dependencies = [
- "rlp",
-]
-
-[[package]]
-name = "impl-serde"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -3367,9 +3019,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
@@ -3411,15 +3063,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "intrusive-collections"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b694dc9f70c3bda874626d2aed13b780f137aab435f4e9814121955cf706122e"
-dependencies = [
- "memoffset",
-]
-
-[[package]]
 name = "ipconfig"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3428,7 +3071,7 @@ dependencies = [
  "socket2 0.5.7",
  "widestring",
  "windows-sys 0.48.0",
- "winreg 0.50.0",
+ "winreg",
 ]
 
 [[package]]
@@ -3449,9 +3092,9 @@ dependencies = [
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.0"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -3517,18 +3160,18 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
 dependencies = [
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "jsonrpsee"
-version = "0.23.2"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b089779ad7f80768693755a031cc14a7766aba707cbe886674e3f79e9b7e47"
+checksum = "5ec465b607a36dc5dd45d48b7689bc83f679f66a3ac6b6b21cc787a11e0f8685"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
@@ -3544,15 +3187,15 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-client-transport"
-version = "0.23.2"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08163edd8bcc466c33d79e10f695cdc98c00d1e6ddfb95cec41b6b0279dd5432"
+checksum = "90f0977f9c15694371b8024c35ab58ca043dbbf4b51ccb03db8858a021241df1"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
  "futures-util",
  "gloo-net",
- "http 1.1.0",
+ "http",
  "jsonrpsee-core",
  "pin-project",
  "rustls",
@@ -3569,24 +3212,22 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-core"
-version = "0.23.2"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79712302e737d23ca0daa178e752c9334846b08321d439fd89af9a384f8c830b"
+checksum = "e942c55635fbf5dc421938b8558a8141c7e773720640f4f1dbe1f4164ca4e221"
 dependencies = [
- "anyhow",
  "async-trait",
- "beef",
  "bytes",
  "futures-timer",
  "futures-util",
- "http 1.1.0",
+ "http",
  "http-body",
  "http-body-util",
  "jsonrpsee-types",
  "parking_lot 0.12.3",
  "pin-project",
  "rand 0.8.5",
- "rustc-hash 1.1.0",
+ "rustc-hash 2.0.0",
  "serde",
  "serde_json",
  "thiserror",
@@ -3598,9 +3239,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-http-client"
-version = "0.23.2"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d90064e04fb9d7282b1c71044ea94d0bbc6eff5621c66f1a0bce9e9de7cf3ac"
+checksum = "e33774602df12b68a2310b38a535733c477ca4a498751739f89fe8dbbb62ec4c"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3623,26 +3264,25 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-proc-macros"
-version = "0.23.2"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7895f186d5921065d96e16bd795e5ca89ac8356ec423fafc6e3d7cf8ec11aee4"
+checksum = "6b07a2daf52077ab1b197aea69a5c990c060143835bf04c77070e98903791715"
 dependencies = [
  "heck 0.5.0",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
 name = "jsonrpsee-server"
-version = "0.23.2"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "654afab2e92e5d88ebd8a39d6074483f3f2bfdf91c5ac57fe285e7127cdd4f51"
+checksum = "038fb697a709bec7134e9ccbdbecfea0e2d15183f7140254afef7c5610a3f488"
 dependencies = [
- "anyhow",
  "futures-util",
- "http 1.1.0",
+ "http",
  "http-body",
  "http-body-util",
  "hyper",
@@ -3664,12 +3304,11 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-types"
-version = "0.23.2"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c465fbe385238e861fdc4d1c85e04ada6c1fd246161d26385c1b311724d2af"
+checksum = "23b67d6e008164f027afbc2e7bb79662650158d26df200040282d2aa1cbb093b"
 dependencies = [
- "beef",
- "http 1.1.0",
+ "http",
  "serde",
  "serde_json",
  "thiserror",
@@ -3677,9 +3316,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-wasm-client"
-version = "0.23.2"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4727ac037f834c6f04c0912cada7532dbddb54e92fbc64e33d6cb8c24af313c9"
+checksum = "0470d0ae043ffcb0cd323797a631e637fb4b55fe3eaa6002934819458bba62a7"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
@@ -3688,11 +3327,11 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-ws-client"
-version = "0.23.2"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c28759775f5cb2f1ea9667672d3fe2b0e701d1f4b7b67954e60afe7fd058b5e"
+checksum = "992bf67d1132f88edf4a4f8cff474cf01abb2be203004a2b8e11c2b20795b99e"
 dependencies = [
- "http 1.1.0",
+ "http",
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
  "jsonrpsee-types",
@@ -3737,20 +3376,20 @@ dependencies = [
  "kakarot-pool",
  "once_cell",
  "reth",
- "reth-chainspec",
- "reth-ethereum-engine-primitives",
- "reth-execution-errors",
- "reth-execution-types",
- "reth-exex",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-ethereum-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-exex 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
  "reth-exex-test-utils",
- "reth-node-api",
- "reth-node-builder",
- "reth-node-ethereum",
- "reth-primitives",
- "reth-provider",
- "reth-revm",
+ "reth-node-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-node-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-node-ethereum 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
  "reth-testing-utils",
- "reth-tracing",
+ "reth-tracing 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
  "rusqlite",
  "serde",
  "serde_json",
@@ -3762,11 +3401,11 @@ name = "kakarot-node"
 version = "0.1.0"
 dependencies = [
  "kakarot-pool",
- "reth-chainspec",
- "reth-ethereum-engine-primitives",
- "reth-node-api",
- "reth-node-builder",
- "reth-node-ethereum",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-ethereum-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-node-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-node-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-node-ethereum 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
  "serde",
 ]
 
@@ -3774,10 +3413,10 @@ dependencies = [
 name = "kakarot-pool"
 version = "0.1.0"
 dependencies = [
- "reth-chainspec",
- "reth-node-ethereum",
- "reth-primitives",
- "reth-transaction-pool",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-node-ethereum 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
 ]
 
 [[package]]
@@ -3791,9 +3430,9 @@ dependencies = [
 
 [[package]]
 name = "keccak-asm"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47a3633291834c4fbebf8673acbc1b04ec9d151418ff9b8e26dcd79129928758"
+checksum = "422fbc7ff2f2f5bdffeb07718e5a5324dca72b0c9293d50df4026652385e3314"
 dependencies = [
  "digest 0.10.7",
  "sha3-asm",
@@ -3805,12 +3444,12 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "kakarot-node",
- "reth-chainspec",
- "reth-cli-runner",
- "reth-db",
- "reth-node-builder",
- "reth-node-core",
- "reth-primitives",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-cli-runner 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-node-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-node-core 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
  "tracing",
  "tracing-subscriber",
 ]
@@ -3829,21 +3468,6 @@ name = "konst_macro_rules"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
-
-[[package]]
-name = "kzg-rs"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9920cd4460ce3cbca19c62f3bb9a9611562478a4dc9d2c556f4a7d049c5b6b"
-dependencies = [
- "bls12_381",
- "glob",
- "hex",
- "once_cell",
- "serde",
- "serde_derive",
- "serde_yaml",
-]
 
 [[package]]
 name = "lambdaworks-crypto"
@@ -3884,9 +3508,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "libloading"
@@ -3905,81 +3529,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
-name = "libp2p"
-version = "0.53.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "681fb3f183edfbedd7a57d32ebe5dcdc0b9f94061185acf3c30249349cc6fc99"
-dependencies = [
- "bytes",
- "either",
- "futures",
- "futures-timer",
- "getrandom 0.2.15",
- "instant",
- "libp2p-allow-block-list",
- "libp2p-connection-limits",
- "libp2p-core",
- "libp2p-identity",
- "libp2p-swarm",
- "multiaddr",
- "pin-project",
- "rw-stream-sink",
- "thiserror",
-]
-
-[[package]]
-name = "libp2p-allow-block-list"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "107b238b794cb83ab53b74ad5dcf7cca3200899b72fe662840cfb52f5b0a32e6"
-dependencies = [
- "libp2p-core",
- "libp2p-identity",
- "libp2p-swarm",
- "void",
-]
-
-[[package]]
-name = "libp2p-connection-limits"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7cd50a78ccfada14de94cbacd3ce4b0138157f376870f13d3a8422cd075b4fd"
-dependencies = [
- "libp2p-core",
- "libp2p-identity",
- "libp2p-swarm",
- "void",
-]
-
-[[package]]
-name = "libp2p-core"
-version = "0.41.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5a8920cbd8540059a01950c1e5c96ea8d89eb50c51cd366fc18bdf540a6e48f"
-dependencies = [
- "either",
- "fnv",
- "futures",
- "futures-timer",
- "libp2p-identity",
- "multiaddr",
- "multihash",
- "multistream-select",
- "once_cell",
- "parking_lot 0.12.3",
- "pin-project",
- "quick-protobuf",
- "rand 0.8.5",
- "rw-stream-sink",
- "smallvec",
- "thiserror",
- "tracing",
- "unsigned-varint 0.8.0",
- "void",
- "web-time",
-]
-
-[[package]]
 name = "libp2p-identity"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3992,33 +3541,10 @@ dependencies = [
  "libsecp256k1",
  "multihash",
  "quick-protobuf",
- "rand 0.8.5",
  "sha2 0.10.8",
  "thiserror",
  "tracing",
  "zeroize",
-]
-
-[[package]]
-name = "libp2p-swarm"
-version = "0.44.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80cae6cb75f89dbca53862f9ebe0b9f463aa7b302762fcfaafb9e51dcc9b0f7e"
-dependencies = [
- "either",
- "fnv",
- "futures",
- "futures-timer",
- "instant",
- "libp2p-core",
- "libp2p-identity",
- "lru",
- "multistream-select",
- "once_cell",
- "rand 0.8.5",
- "smallvec",
- "tracing",
- "void",
 ]
 
 [[package]]
@@ -4123,12 +3649,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
-name = "litemap"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
-
-[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4146,9 +3666,9 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "lru"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
+checksum = "37ee39891760e7d94734f6f63fedc29a2e4a152f836120753a72503f09fcf904"
 dependencies = [
  "hashbrown 0.14.5",
 ]
@@ -4208,15 +3728,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "metrics"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4233,7 +3744,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4f0c8427b39666bf970460908b213ec09b3b350f20c0c2eabcbba51704a08e6"
 dependencies = [
  "base64 0.22.1",
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "metrics",
  "metrics-util",
  "quanta",
@@ -4265,7 +3776,7 @@ dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown 0.14.5",
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "metrics",
  "num_cpus",
  "ordered-float",
@@ -4306,6 +3817,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4319,9 +3839,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -4371,7 +3891,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "static_assertions",
- "unsigned-varint 0.7.2",
+ "unsigned-varint",
  "url",
 ]
 
@@ -4393,21 +3913,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "076d548d76a0e2a0d4ab471d0b1c36c577786dfc4471242035d97a12a735c492"
 dependencies = [
  "core2",
- "unsigned-varint 0.7.2",
-]
-
-[[package]]
-name = "multistream-select"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0df8e5eec2298a62b326ee4f0d7fe1a6b90a09dfcf9df37b38f947a8c42f19"
-dependencies = [
- "bytes",
- "futures",
- "log",
- "pin-project",
- "smallvec",
- "unsigned-varint 0.7.2",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -4569,23 +4075,22 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02339744ee7253741199f897151b38e72257d13802d4ee837285cc2990a90845"
+checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
 dependencies = [
  "num_enum_derive",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
+checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -4604,6 +4109,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95f06be0417d97f81fe4e5c86d7d01b392655a9cac9c19a848aa033e18937b23"
 dependencies = [
  "alloy-rlp",
+ "arbitrary",
  "const-hex",
  "proptest",
  "serde",
@@ -4612,9 +4118,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.1"
+version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
+checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
 dependencies = [
  "memchr",
 ]
@@ -4624,6 +4130,63 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "op-alloy-consensus"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0db6e3a9bbbcef7cef19d77aa2cc76d61377376e3bb86f89167e7e3f30ea023"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "derive_more 1.0.0",
+ "serde",
+]
+
+[[package]]
+name = "op-alloy-network"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66184e6c92269ba4ef1f80e8566ce11d41b584884ce7476d4b1b5e0e38503ecb"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "op-alloy-consensus",
+ "op-alloy-rpc-types",
+]
+
+[[package]]
+name = "op-alloy-rpc-types"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c604cd3b9680d0edd0b7127f3550bcff634c2d2efe27b2b4853e72320186a8"
+dependencies = [
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "op-alloy-consensus",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "op-alloy-rpc-types-engine"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "620e645c36cc66220909bf97e6632e7a154a2309356221cbf33ae78bf5294478"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types-engine",
+ "alloy-serde",
+ "serde",
+]
 
 [[package]]
 name = "opaque-debug"
@@ -4645,9 +4208,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
-version = "4.2.1"
+version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ff2cf528c6c03d9ed653d6c4ce1dc0582dc4af309790ad92f07c1cd551b0be"
+checksum = "4a91171844676f8c7990ce64959210cd2eaef32c2612c50f9fae9f8aaa6065a6"
 dependencies = [
  "num-traits",
 ]
@@ -4666,15 +4229,6 @@ checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "pairing"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
-dependencies = [
- "group",
 ]
 
 [[package]]
@@ -4828,49 +4382,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
 dependencies = [
  "futures",
- "rustc_version 0.4.0",
-]
-
-[[package]]
-name = "phf"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
-dependencies = [
- "phf_macros",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
-dependencies = [
- "phf_shared",
- "rand 0.8.5",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
-dependencies = [
- "phf_generator",
- "phf_shared",
- "proc-macro2",
- "quote",
- "syn 2.0.72",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
-dependencies = [
- "siphasher",
+ "rustc_version 0.4.1",
 ]
 
 [[package]]
@@ -4890,7 +4402,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -4922,16 +4434,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
-name = "pollster"
-version = "0.3.0"
+name = "plain_hasher"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22686f4785f02a4fcc856d3b3bb19bf6c8160d103f7a99cc258bddd0251dc7f2"
+checksum = "1e19e6491bdde87c2c43d70f4c194bc8a758f2eb732df00f61e43f7362e3b4cc"
+dependencies = [
+ "crunchy",
+]
 
 [[package]]
 name = "polyval"
-version = "0.5.3"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -4953,9 +4468,12 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "primitive-types"
@@ -4965,18 +4483,16 @@ checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
 dependencies = [
  "fixed-hash",
  "impl-codec",
- "impl-rlp",
- "impl-serde",
  "uint",
 ]
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
- "toml_edit 0.21.1",
+ "toml_edit",
 ]
 
 [[package]]
@@ -5070,24 +4586,13 @@ dependencies = [
 
 [[package]]
 name = "proptest-derive"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf16337405ca084e9c78985114633b6827711d22b9e6ef6c6c0d665eb3f0b6e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "proptest-derive"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ff7ff745a347b87471d859a377a9a404361e7efc2a971d73424a6d183c0fc77"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -5122,16 +4627,17 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4ceeeeabace7857413798eb1ffa1e9c905a9946a57d81fb69b4b71c4d8eb3ad"
+checksum = "b22d8e7369034b9a7132bc2008cac12f2013c8132b45e0554e6e20e2617f2156"
 dependencies = [
  "bytes",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 1.1.0",
+ "rustc-hash 2.0.0",
  "rustls",
+ "socket2 0.5.7",
  "thiserror",
  "tokio",
  "tracing",
@@ -5139,14 +4645,14 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.3"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddf517c03a109db8100448a4be38d498df8a210a99fe0e1b9eaf39e78c640efe"
+checksum = "ba92fb39ec7ad06ca2582c0ca834dfeadcaf06ddfc8e635c80aa7e1c05315fdd"
 dependencies = [
  "bytes",
  "rand 0.8.5",
  "ring",
- "rustc-hash 1.1.0",
+ "rustc-hash 2.0.0",
  "rustls",
  "slab",
  "thiserror",
@@ -5163,14 +4669,15 @@ dependencies = [
  "libc",
  "once_cell",
  "socket2 0.5.7",
+ "tracing",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -5347,9 +4854,9 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom 0.2.15",
  "libredox",
@@ -5358,9 +4865,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5401,26 +4908,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
-name = "regress"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16fe0a24af5daaae947294213d2fd2646fbf5e1fbacc1d4ba3e84b2393854842"
-dependencies = [
- "hashbrown 0.14.5",
- "memchr",
-]
-
-[[package]]
 name = "reqwest"
-version = "0.12.5"
+version = "0.12.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
+checksum = "f8f4955649ef5c38cc7f9e8aa41761d48fb9677197daea9984dc54f56aad5e63"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.1.0",
+ "http",
  "http-body",
  "http-body-util",
  "hyper",
@@ -5435,6 +4932,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pemfile",
  "rustls-pki-types",
  "serde",
@@ -5449,7 +4947,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots",
- "winreg 0.52.0",
+ "windows-registry",
 ]
 
 [[package]]
@@ -5464,14 +4962,13 @@ dependencies = [
 
 [[package]]
 name = "reth"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "alloy-rlp",
  "aquamarine",
  "backon",
  "clap",
- "confy",
  "discv5",
  "eyre",
  "fdlimit",
@@ -5479,59 +4976,61 @@ dependencies = [
  "itertools 0.13.0",
  "libc",
  "metrics-process",
- "reth-basic-payload-builder",
- "reth-beacon-consensus",
- "reth-blockchain-tree",
- "reth-chainspec",
+ "reth-basic-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-blockchain-tree 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
  "reth-cli-commands",
- "reth-cli-runner",
- "reth-cli-util",
- "reth-config",
- "reth-consensus",
- "reth-consensus-common",
- "reth-db",
- "reth-db-api",
- "reth-db-common",
- "reth-downloaders",
- "reth-engine-util",
- "reth-errors",
- "reth-ethereum-payload-builder",
- "reth-evm",
- "reth-execution-types",
- "reth-exex",
- "reth-fs-util",
- "reth-network",
- "reth-network-api",
- "reth-network-p2p",
- "reth-node-api",
- "reth-node-builder",
- "reth-node-core",
- "reth-node-ethereum",
- "reth-node-events",
+ "reth-cli-runner 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-cli-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-consensus-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-db-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-downloaders 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-engine-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-ethereum-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-exex 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-node-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-node-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-node-core 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-node-ethereum 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-node-events 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-node-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
  "reth-optimism-primitives",
- "reth-payload-builder",
- "reth-payload-primitives",
- "reth-payload-validator",
- "reth-primitives",
- "reth-provider",
- "reth-prune",
- "reth-revm",
- "reth-rpc",
- "reth-rpc-api",
- "reth-rpc-builder",
- "reth-rpc-eth-types",
- "reth-rpc-server-types",
- "reth-rpc-types",
- "reth-rpc-types-compat",
- "reth-stages",
- "reth-stages-api",
- "reth-static-file",
- "reth-static-file-types",
- "reth-tasks",
- "reth-tracing",
- "reth-transaction-pool",
- "reth-trie",
- "reth-trie-db",
+ "reth-optimism-rpc",
+ "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-payload-validator 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-prune 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-eth-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-server-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-stages 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-stages-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-static-file 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-static-file-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-tracing 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-trie-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
  "serde",
  "serde_json",
  "similar-asserts",
@@ -5544,26 +5043,55 @@ dependencies = [
 
 [[package]]
 name = "reth-auto-seal-consensus"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "futures-util",
- "reth-beacon-consensus",
- "reth-chainspec",
- "reth-consensus",
- "reth-engine-primitives",
- "reth-evm",
- "reth-execution-errors",
- "reth-execution-types",
- "reth-network-p2p",
- "reth-network-peers",
- "reth-primitives",
- "reth-provider",
- "reth-revm",
- "reth-rpc-types",
- "reth-stages-api",
- "reth-tokio-util",
- "reth-transaction-pool",
+ "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-stages-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
+name = "reth-auto-seal-consensus"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "futures-util",
+ "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-stages-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -5571,22 +5099,45 @@ dependencies = [
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "alloy-rlp",
  "futures-core",
  "futures-util",
  "metrics",
- "reth-chainspec",
- "reth-metrics",
- "reth-payload-builder",
- "reth-payload-primitives",
- "reth-primitives",
- "reth-provider",
- "reth-revm",
- "reth-tasks",
- "reth-transaction-pool",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "revm",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "reth-basic-payload-builder"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "alloy-rlp",
+ "futures-core",
+ "futures-util",
+ "metrics",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "revm",
  "tokio",
  "tracing",
@@ -5594,31 +5145,65 @@ dependencies = [
 
 [[package]]
 name = "reth-beacon-consensus"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "futures",
  "itertools 0.13.0",
  "metrics",
- "reth-blockchain-tree-api",
- "reth-chainspec",
- "reth-db-api",
- "reth-engine-primitives",
- "reth-errors",
- "reth-ethereum-consensus",
- "reth-metrics",
- "reth-network-p2p",
- "reth-payload-builder",
- "reth-payload-primitives",
- "reth-payload-validator",
- "reth-primitives",
- "reth-provider",
- "reth-prune",
- "reth-rpc-types",
- "reth-stages-api",
- "reth-static-file",
- "reth-tasks",
- "reth-tokio-util",
+ "reth-blockchain-tree-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-ethereum-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-payload-validator 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-prune 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-stages-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-static-file 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "schnellru",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
+name = "reth-beacon-consensus"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "futures",
+ "itertools 0.13.0",
+ "metrics",
+ "reth-blockchain-tree-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-ethereum-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-payload-validator 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-prune 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-stages-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-static-file 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "schnellru",
  "thiserror",
  "tokio",
@@ -5628,61 +5213,132 @@ dependencies = [
 
 [[package]]
 name = "reth-blockchain-tree"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "aquamarine",
  "linked_hash_set",
  "metrics",
  "parking_lot 0.12.3",
- "reth-blockchain-tree-api",
- "reth-consensus",
- "reth-db",
- "reth-db-api",
- "reth-evm",
- "reth-execution-errors",
- "reth-execution-types",
- "reth-metrics",
- "reth-network",
- "reth-primitives",
- "reth-provider",
- "reth-prune-types",
- "reth-revm",
- "reth-stages-api",
- "reth-storage-errors",
- "reth-trie",
- "reth-trie-db",
- "reth-trie-parallel",
+ "reth-blockchain-tree-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-stages-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-trie-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-trie-parallel 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "reth-blockchain-tree"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "aquamarine",
+ "linked_hash_set",
+ "metrics",
+ "parking_lot 0.12.3",
+ "reth-blockchain-tree-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-network 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-stages-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-trie-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-trie-parallel 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "reth-blockchain-tree-api"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
- "reth-consensus",
- "reth-execution-errors",
- "reth-primitives",
- "reth-storage-errors",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "thiserror",
+]
+
+[[package]]
+name = "reth-blockchain-tree-api"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "thiserror",
 ]
 
 [[package]]
 name = "reth-chain-state"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "auto_impl",
- "derive_more",
+ "derive_more 1.0.0",
+ "metrics",
+ "parking_lot 0.12.3",
+ "pin-project",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
+name = "reth-chain-state"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "alloy-signer",
+ "alloy-signer-local",
+ "auto_impl",
+ "derive_more 1.0.0",
+ "metrics",
  "parking_lot 0.12.3",
  "pin-project",
  "rand 0.8.5",
- "reth-chainspec",
- "reth-execution-types",
- "reth-primitives",
- "reth-trie",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "revm",
  "tokio",
  "tokio-stream",
@@ -5691,67 +5347,101 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "alloy-chains",
  "alloy-eips",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-trie",
- "derive_more",
+ "auto_impl",
+ "derive_more 1.0.0",
  "once_cell",
- "reth-ethereum-forks",
- "reth-network-peers",
- "reth-primitives-traits",
- "reth-trie-common",
+ "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
  "serde_json",
 ]
 
 [[package]]
+name = "reth-chainspec"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "alloy-chains",
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-primitives",
+ "alloy-trie",
+ "auto_impl",
+ "derive_more 1.0.0",
+ "once_cell",
+ "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "serde_json",
+]
+
+[[package]]
+name = "reth-cli"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "clap",
+ "eyre",
+ "reth-cli-runner 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+]
+
+[[package]]
 name = "reth-cli-commands"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "ahash",
  "backon",
  "clap",
  "comfy-table",
- "confy",
  "crossterm",
  "eyre",
  "fdlimit",
  "futures",
  "human_bytes",
  "itertools 0.13.0",
- "metrics-process",
  "ratatui",
- "reth-beacon-consensus",
- "reth-chainspec",
- "reth-cli-runner",
- "reth-cli-util",
- "reth-config",
- "reth-consensus",
- "reth-db",
- "reth-db-api",
- "reth-db-common",
- "reth-downloaders",
- "reth-evm",
- "reth-exex",
- "reth-fs-util",
- "reth-network",
- "reth-network-p2p",
- "reth-node-builder",
- "reth-node-core",
- "reth-node-events",
- "reth-primitives",
- "reth-provider",
- "reth-prune",
- "reth-stages",
- "reth-static-file",
- "reth-static-file-types",
- "reth-trie",
- "reth-trie-db",
+ "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-cli-runner 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-cli-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-db-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-downloaders 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-ecies 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-eth-wire 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-exex 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-node-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-node-core 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-node-events 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-node-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-prune 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-stages 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-static-file 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-static-file-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-trie-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "secp256k1",
  "serde",
  "serde_json",
  "tokio",
@@ -5761,33 +5451,58 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
- "reth-tasks",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "reth-cli-runner"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "reth-cli-util"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "eyre",
  "libc",
  "rand 0.8.5",
- "reth-fs-util",
+ "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "secp256k1",
+ "thiserror",
+]
+
+[[package]]
+name = "reth-cli-util"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "eyre",
+ "libc",
+ "rand 0.8.5",
+ "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "secp256k1",
  "thiserror",
 ]
 
 [[package]]
 name = "reth-codecs"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5796,58 +5511,120 @@ dependencies = [
  "alloy-trie",
  "bytes",
  "modular-bitfield",
- "reth-codecs-derive",
+ "reth-codecs-derive 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "serde",
+]
+
+[[package]]
+name = "reth-codecs"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-primitives",
+ "alloy-trie",
+ "bytes",
+ "modular-bitfield",
+ "reth-codecs-derive 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "serde",
 ]
 
 [[package]]
 name = "reth-codecs-derive"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
+]
+
+[[package]]
+name = "reth-codecs-derive"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "convert_case 0.6.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.76",
 ]
 
 [[package]]
 name = "reth-config"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
- "confy",
+ "eyre",
  "humantime-serde",
- "reth-network-types",
- "reth-prune-types",
- "reth-stages-types",
+ "reth-network-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
  "serde",
+ "toml",
+]
+
+[[package]]
+name = "reth-config"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "eyre",
+ "humantime-serde",
+ "reth-network-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "serde",
+ "toml",
 ]
 
 [[package]]
 name = "reth-consensus"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "auto_impl",
- "reth-primitives",
- "thiserror-no-std",
+ "derive_more 1.0.0",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+]
+
+[[package]]
+name = "reth-consensus"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "auto_impl",
+ "derive_more 1.0.0",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
 ]
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
- "reth-chainspec",
- "reth-consensus",
- "reth-primitives",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+]
+
+[[package]]
+name = "reth-consensus-common"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
 ]
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5856,12 +5633,35 @@ dependencies = [
  "eyre",
  "futures",
  "reqwest",
- "reth-node-api",
- "reth-node-core",
- "reth-rpc-api",
- "reth-rpc-builder",
- "reth-rpc-types",
- "reth-tracing",
+ "reth-node-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-node-core 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-tracing 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "ringbuffer",
+ "serde",
+ "tokio",
+]
+
+[[package]]
+name = "reth-consensus-debug-client"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-provider",
+ "auto_impl",
+ "eyre",
+ "futures",
+ "reqwest",
+ "reth-node-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-node-core 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-tracing 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "ringbuffer",
  "serde",
  "tokio",
@@ -5869,27 +5669,57 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "bytes",
- "derive_more",
+ "derive_more 1.0.0",
  "eyre",
  "metrics",
  "page_size",
  "paste",
- "reth-db-api",
- "reth-fs-util",
- "reth-libmdbx",
- "reth-metrics",
- "reth-nippy-jar",
- "reth-primitives",
- "reth-primitives-traits",
- "reth-prune-types",
- "reth-stages-types",
- "reth-storage-errors",
- "reth-tracing",
- "reth-trie-common",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-libmdbx 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-nippy-jar 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-tracing 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "rustc-hash 2.0.0",
+ "serde",
+ "strum",
+ "sysinfo",
+ "thiserror",
+]
+
+[[package]]
+name = "reth-db"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "bytes",
+ "derive_more 1.0.0",
+ "eyre",
+ "metrics",
+ "page_size",
+ "paste",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-libmdbx 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-nippy-jar 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-tracing 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "rustc-hash 2.0.0",
  "serde",
  "strum",
@@ -5900,46 +5730,68 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
+dependencies = [
+ "bytes",
+ "derive_more 1.0.0",
+ "metrics",
+ "modular-bitfield",
+ "parity-scale-codec",
+ "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-db-models 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "serde",
+]
+
+[[package]]
+name = "reth-db-api"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "arbitrary",
  "bytes",
- "derive_more",
+ "derive_more 1.0.0",
  "metrics",
  "modular-bitfield",
  "parity-scale-codec",
  "proptest",
- "reth-codecs",
- "reth-primitives",
- "reth-primitives-traits",
- "reth-prune-types",
- "reth-stages-types",
- "reth-storage-errors",
- "reth-trie-common",
+ "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-db-models 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "serde",
 ]
 
 [[package]]
 name = "reth-db-common"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "alloy-genesis",
  "boyer-moore-magiclen",
  "eyre",
- "reth-chainspec",
- "reth-codecs",
- "reth-config",
- "reth-db",
- "reth-db-api",
- "reth-etl",
- "reth-fs-util",
- "reth-primitives",
- "reth-provider",
- "reth-stages-types",
- "reth-trie",
- "reth-trie-db",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-etl 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-trie-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
  "serde",
  "serde_json",
  "thiserror",
@@ -5947,9 +5799,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-db-common"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "alloy-genesis",
+ "boyer-moore-magiclen",
+ "eyre",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-etl 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-trie-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "reth-db-models"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
+dependencies = [
+ "bytes",
+ "modular-bitfield",
+ "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "serde",
+]
+
+[[package]]
+name = "reth-db-models"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "arbitrary",
+ "bytes",
+ "modular-bitfield",
+ "proptest",
+ "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "serde",
+]
+
+[[package]]
 name = "reth-discv4"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -5957,10 +5861,34 @@ dependencies = [
  "enr",
  "generic-array",
  "parking_lot 0.12.3",
- "reth-ethereum-forks",
- "reth-net-banlist",
- "reth-net-nat",
- "reth-network-peers",
+ "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-net-banlist 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-net-nat 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "schnellru",
+ "secp256k1",
+ "serde",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
+name = "reth-discv4"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "discv5",
+ "enr",
+ "generic-array",
+ "parking_lot 0.12.3",
+ "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-net-banlist 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-net-nat 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "schnellru",
  "secp256k1",
  "serde",
@@ -5972,24 +5900,46 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "derive_more",
+ "derive_more 1.0.0",
  "discv5",
  "enr",
  "futures",
  "itertools 0.13.0",
- "libp2p-identity",
  "metrics",
- "multiaddr",
  "rand 0.8.5",
- "reth-chainspec",
- "reth-ethereum-forks",
- "reth-metrics",
- "reth-network-peers",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "secp256k1",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "reth-discv5"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "derive_more 1.0.0",
+ "discv5",
+ "enr",
+ "futures",
+ "itertools 0.13.0",
+ "metrics",
+ "rand 0.8.5",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "secp256k1",
  "thiserror",
  "tokio",
@@ -5998,17 +5948,39 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
  "enr",
  "linked_hash_set",
  "parking_lot 0.12.3",
- "reth-ethereum-forks",
- "reth-network-peers",
- "reth-tokio-util",
+ "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "schnellru",
+ "secp256k1",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "trust-dns-resolver",
+]
+
+[[package]]
+name = "reth-dns-discovery"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "alloy-primitives",
+ "data-encoding",
+ "enr",
+ "linked_hash_set",
+ "parking_lot 0.12.3",
+ "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "schnellru",
  "secp256k1",
  "thiserror",
@@ -6020,8 +5992,8 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "alloy-rlp",
  "futures",
@@ -6030,14 +6002,41 @@ dependencies = [
  "metrics",
  "pin-project",
  "rayon",
- "reth-config",
- "reth-consensus",
- "reth-metrics",
- "reth-network-p2p",
- "reth-network-peers",
- "reth-primitives",
- "reth-storage-api",
- "reth-tasks",
+ "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "reth-downloaders"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "alloy-rlp",
+ "futures",
+ "futures-util",
+ "itertools 0.13.0",
+ "metrics",
+ "pin-project",
+ "rayon",
+ "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -6047,24 +6046,55 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
- "aes 0.8.4",
+ "aes",
  "alloy-primitives",
  "alloy-rlp",
  "block-padding",
  "byteorder",
- "cipher 0.4.4",
+ "cipher",
  "concat-kdf",
- "ctr 0.9.2",
+ "ctr",
  "digest 0.10.7",
  "futures",
  "generic-array",
  "hmac 0.12.1",
  "pin-project",
  "rand 0.8.5",
- "reth-network-peers",
+ "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "secp256k1",
+ "sha2 0.10.8",
+ "sha3",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "typenum",
+]
+
+[[package]]
+name = "reth-ecies"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "aes",
+ "alloy-primitives",
+ "alloy-rlp",
+ "block-padding",
+ "byteorder",
+ "cipher",
+ "concat-kdf",
+ "ctr",
+ "digest 0.10.7",
+ "futures",
+ "generic-array",
+ "hmac 0.12.1",
+ "pin-project",
+ "rand 0.8.5",
+ "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "secp256k1",
  "sha2 0.10.8",
  "sha3",
@@ -6078,107 +6108,270 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
- "reth-chainspec",
- "reth-payload-primitives",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
  "serde",
 ]
 
 [[package]]
-name = "reth-engine-tree"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+name = "reth-engine-primitives"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
- "aquamarine",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "serde",
+]
+
+[[package]]
+name = "reth-engine-service"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
+dependencies = [
+ "futures",
+ "pin-project",
+ "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-engine-tree 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-payload-validator 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-prune 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-stages-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "thiserror",
+]
+
+[[package]]
+name = "reth-engine-service"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "futures",
+ "pin-project",
+ "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-engine-tree 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-payload-validator 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-prune 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-stages-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "thiserror",
+]
+
+[[package]]
+name = "reth-engine-tree"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
+dependencies = [
  "futures",
  "metrics",
- "parking_lot 0.12.3",
- "reth-beacon-consensus",
- "reth-blockchain-tree",
- "reth-blockchain-tree-api",
- "reth-chain-state",
- "reth-chainspec",
- "reth-consensus",
- "reth-db",
- "reth-db-api",
- "reth-engine-primitives",
- "reth-errors",
- "reth-ethereum-consensus",
- "reth-evm",
- "reth-metrics",
- "reth-network-p2p",
- "reth-payload-builder",
- "reth-payload-primitives",
- "reth-payload-validator",
- "reth-primitives",
- "reth-provider",
- "reth-prune",
- "reth-prune-types",
- "reth-revm",
- "reth-rpc-types",
- "reth-stages-api",
- "reth-stages-types",
- "reth-static-file",
- "reth-tasks",
- "reth-tokio-util",
- "reth-trie",
- "revm",
+ "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-blockchain-tree 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-blockchain-tree-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-chain-state 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-payload-validator 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-prune 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-stages-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "thiserror",
  "tokio",
- "tokio-stream",
+ "tracing",
+]
+
+[[package]]
+name = "reth-engine-tree"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "futures",
+ "metrics",
+ "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-blockchain-tree 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-blockchain-tree-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-chain-state 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-payload-validator 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-prune 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-stages-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "thiserror",
+ "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "reth-engine-util"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "eyre",
  "futures",
+ "itertools 0.13.0",
  "pin-project",
- "reth-beacon-consensus",
- "reth-engine-primitives",
- "reth-fs-util",
- "reth-rpc",
- "reth-rpc-types",
+ "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-payload-validator 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "revm-primitives",
  "serde",
  "serde_json",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "reth-engine-util"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "eyre",
+ "futures",
+ "itertools 0.13.0",
+ "pin-project",
+ "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-payload-validator 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "revm-primitives",
+ "serde",
+ "serde_json",
+ "tokio",
  "tokio-util",
  "tracing",
 ]
 
 [[package]]
 name = "reth-errors"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
- "reth-blockchain-tree-api",
- "reth-consensus",
- "reth-execution-errors",
- "reth-fs-util",
- "reth-storage-errors",
+ "reth-blockchain-tree-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "thiserror",
+]
+
+[[package]]
+name = "reth-errors"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "reth-blockchain-tree-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "thiserror",
 ]
 
 [[package]]
 name = "reth-eth-wire"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "alloy-rlp",
  "bytes",
- "derive_more",
+ "derive_more 1.0.0",
  "futures",
  "pin-project",
- "reth-chainspec",
- "reth-codecs",
- "reth-ecies",
- "reth-eth-wire-types",
- "reth-metrics",
- "reth-network-peers",
- "reth-primitives",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-ecies 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-eth-wire-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "snap",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "reth-eth-wire"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "alloy-rlp",
+ "bytes",
+ "derive_more 1.0.0",
+ "futures",
+ "pin-project",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-ecies 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-eth-wire-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "snap",
  "thiserror",
  "tokio",
@@ -6189,69 +6382,91 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "alloy-chains",
  "alloy-genesis",
  "alloy-rlp",
  "bytes",
- "derive_more",
- "reth-chainspec",
- "reth-codecs-derive",
- "reth-primitives",
+ "derive_more 1.0.0",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-codecs-derive 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "thiserror",
+]
+
+[[package]]
+name = "reth-eth-wire-types"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "alloy-chains",
+ "alloy-genesis",
+ "alloy-rlp",
+ "bytes",
+ "derive_more 1.0.0",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-codecs-derive 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "thiserror",
 ]
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
- "reth-chainspec",
- "reth-consensus",
- "reth-consensus-common",
- "reth-primitives",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-consensus-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
  "tracing",
 ]
 
 [[package]]
-name = "reth-ethereum-engine"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+name = "reth-ethereum-consensus"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
- "futures",
- "pin-project",
- "reth-beacon-consensus",
- "reth-chainspec",
- "reth-db-api",
- "reth-engine-tree",
- "reth-ethereum-engine-primitives",
- "reth-evm-ethereum",
- "reth-network-p2p",
- "reth-payload-builder",
- "reth-payload-validator",
- "reth-provider",
- "reth-prune",
- "reth-stages-api",
- "reth-tasks",
- "thiserror",
- "tokio-stream",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-consensus-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "tracing",
 ]
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "alloy-rlp",
- "reth-chainspec",
- "reth-engine-primitives",
- "reth-evm-ethereum",
- "reth-payload-primitives",
- "reth-primitives",
- "reth-rpc-types",
- "reth-rpc-types-compat",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-evm-ethereum 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "revm-primitives",
+ "serde",
+ "sha2 0.10.8",
+]
+
+[[package]]
+name = "reth-ethereum-engine-primitives"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "alloy-rlp",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-evm-ethereum 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "revm-primitives",
  "serde",
  "sha2 0.10.8",
@@ -6259,8 +6474,25 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
+dependencies = [
+ "alloy-chains",
+ "alloy-primitives",
+ "alloy-rlp",
+ "auto_impl",
+ "crc",
+ "dyn-clone",
+ "once_cell",
+ "rustc-hash 2.0.0",
+ "serde",
+ "thiserror-no-std",
+]
+
+[[package]]
+name = "reth-ethereum-forks"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -6271,7 +6503,7 @@ dependencies = [
  "dyn-clone",
  "once_cell",
  "proptest",
- "proptest-derive 0.5.0",
+ "proptest-derive",
  "rustc-hash 2.0.0",
  "serde",
  "thiserror-no-std",
@@ -6279,169 +6511,330 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
- "reth-basic-payload-builder",
- "reth-errors",
- "reth-evm",
- "reth-evm-ethereum",
- "reth-execution-types",
- "reth-payload-builder",
- "reth-primitives",
- "reth-provider",
- "reth-revm",
- "reth-transaction-pool",
+ "reth-basic-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-evm-ethereum 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "revm",
+ "tracing",
+]
+
+[[package]]
+name = "reth-ethereum-payload-builder"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "reth-basic-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-evm-ethereum 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "revm",
  "tracing",
 ]
 
 [[package]]
 name = "reth-etl"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "rayon",
- "reth-db-api",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "tempfile",
+]
+
+[[package]]
+name = "reth-etl"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "rayon",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "tempfile",
 ]
 
 [[package]]
 name = "reth-evm"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
+dependencies = [
+ "alloy-eips",
+ "auto_impl",
+ "futures-util",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "revm",
+ "revm-primitives",
+]
+
+[[package]]
+name = "reth-evm"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-eips",
  "auto_impl",
  "futures-util",
  "parking_lot 0.12.3",
- "reth-chainspec",
- "reth-execution-errors",
- "reth-execution-types",
- "reth-primitives",
- "reth-prune-types",
- "reth-storage-errors",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "revm",
  "revm-primitives",
 ]
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "alloy-eips",
  "alloy-sol-types",
- "reth-chainspec",
- "reth-ethereum-consensus",
- "reth-ethereum-forks",
- "reth-evm",
- "reth-execution-types",
- "reth-primitives",
- "reth-prune-types",
- "reth-revm",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-ethereum-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "revm-primitives",
+]
+
+[[package]]
+name = "reth-evm-ethereum"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "alloy-eips",
+ "alloy-sol-types",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-ethereum-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "revm-primitives",
+]
+
+[[package]]
+name = "reth-evm-optimism"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
+dependencies = [
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-optimism-consensus",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "revm",
+ "revm-primitives",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "reth-execution-errors"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "derive_more 1.0.0",
+ "nybbles",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
  "revm-primitives",
 ]
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
- "reth-consensus",
- "reth-prune-types",
- "reth-storage-errors",
+ "alloy-rlp",
+ "derive_more 1.0.0",
+ "nybbles",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "revm-primitives",
- "thiserror-no-std",
 ]
 
 [[package]]
 name = "reth-execution-types"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
- "reth-execution-errors",
- "reth-primitives",
- "reth-trie",
+ "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
  "revm",
  "serde",
 ]
 
 [[package]]
+name = "reth-execution-types"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "revm",
+]
+
+[[package]]
 name = "reth-exex"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "eyre",
  "futures",
  "metrics",
- "reth-config",
- "reth-evm",
- "reth-exex-types",
- "reth-metrics",
- "reth-network",
- "reth-node-api",
- "reth-node-core",
- "reth-payload-builder",
- "reth-primitives",
- "reth-primitives-traits",
- "reth-provider",
- "reth-prune-types",
- "reth-revm",
- "reth-stages-api",
- "reth-tasks",
- "reth-tracing",
+ "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-exex-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-node-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-node-core 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-stages-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-tracing 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "reth-exex"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "eyre",
+ "futures",
+ "metrics",
+ "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-exex-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-node-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-node-core 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-stages-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-tracing 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "tokio",
  "tokio-util",
 ]
 
 [[package]]
 name = "reth-exex-test-utils"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "eyre",
  "futures-util",
  "rand 0.8.5",
- "reth-blockchain-tree",
- "reth-chainspec",
- "reth-config",
- "reth-consensus",
- "reth-db",
- "reth-db-common",
- "reth-evm",
- "reth-execution-types",
- "reth-exex",
- "reth-network",
- "reth-node-api",
- "reth-node-builder",
- "reth-node-core",
- "reth-node-ethereum",
- "reth-payload-builder",
- "reth-primitives",
- "reth-provider",
- "reth-tasks",
- "reth-transaction-pool",
+ "reth-blockchain-tree 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-db-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-exex 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-network 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-node-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-node-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-node-core 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-node-ethereum 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "thiserror",
  "tokio",
 ]
 
 [[package]]
 name = "reth-exex-types"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "alloy-primitives",
- "reth-provider",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
  "serde",
 ]
 
 [[package]]
+name = "reth-exex-types"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "alloy-primitives",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+]
+
+[[package]]
 name = "reth-fs-util"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "reth-fs-util"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "serde",
  "serde_json",
@@ -6450,8 +6843,29 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
+ "futures-util",
+ "interprocess",
+ "jsonrpsee",
+ "pin-project",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "reth-ipc"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6471,24 +6885,49 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "bitflags 2.6.0",
  "byteorder",
- "dashmap 6.0.1",
- "derive_more",
- "indexmap 2.2.6",
+ "dashmap",
+ "derive_more 1.0.0",
+ "indexmap 2.4.0",
  "parking_lot 0.12.3",
- "reth-mdbx-sys",
+ "reth-mdbx-sys 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "reth-libmdbx"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "bitflags 2.6.0",
+ "byteorder",
+ "dashmap",
+ "derive_more 1.0.0",
+ "indexmap 2.4.0",
+ "parking_lot 0.12.3",
+ "reth-mdbx-sys 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "thiserror",
  "tracing",
 ]
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
+dependencies = [
+ "bindgen",
+ "cc",
+]
+
+[[package]]
+name = "reth-mdbx-sys"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "bindgen",
  "cc",
@@ -6496,40 +6935,82 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "futures",
  "metrics",
- "reth-metrics-derive",
+ "reth-metrics-derive 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "reth-metrics"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "futures",
+ "metrics",
+ "reth-metrics-derive 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "tokio",
  "tokio-util",
 ]
 
 [[package]]
 name = "reth-metrics-derive"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
- "once_cell",
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.72",
+ "syn 2.0.76",
+]
+
+[[package]]
+name = "reth-metrics-derive"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.76",
 ]
 
 [[package]]
 name = "reth-net-banlist"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
+dependencies = [
+ "alloy-primitives",
+]
+
+[[package]]
+name = "reth-net-banlist"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "reth-net-nat"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
+dependencies = [
+ "futures-util",
+ "reqwest",
+ "serde_with",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "reth-net-nat"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "futures-util",
  "reqwest",
@@ -6540,46 +7021,92 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "alloy-rlp",
  "aquamarine",
  "auto_impl",
- "derive_more",
+ "derive_more 1.0.0",
  "discv5",
  "enr",
  "futures",
- "humantime-serde",
  "itertools 0.13.0",
  "metrics",
  "parking_lot 0.12.3",
  "pin-project",
  "rand 0.8.5",
- "reth-chainspec",
- "reth-consensus",
- "reth-discv4",
- "reth-discv5",
- "reth-dns-discovery",
- "reth-ecies",
- "reth-eth-wire",
- "reth-fs-util",
- "reth-metrics",
- "reth-net-banlist",
- "reth-network-api",
- "reth-network-p2p",
- "reth-network-peers",
- "reth-network-types",
- "reth-primitives",
- "reth-storage-api",
- "reth-tasks",
- "reth-tokio-util",
- "reth-transaction-pool",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-discv4 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-discv5 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-dns-discovery 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-ecies 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-eth-wire 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-net-banlist 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
  "rustc-hash 2.0.0",
  "schnellru",
  "secp256k1",
  "serde",
- "serde_json",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "reth-network"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "alloy-rlp",
+ "aquamarine",
+ "auto_impl",
+ "derive_more 1.0.0",
+ "discv5",
+ "enr",
+ "futures",
+ "itertools 0.13.0",
+ "metrics",
+ "parking_lot 0.12.3",
+ "pin-project",
+ "rand 0.8.5",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-discv4 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-discv5 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-dns-discovery 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-ecies 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-eth-wire 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-net-banlist 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-network-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "rustc-hash 2.0.0",
+ "schnellru",
+ "secp256k1",
+ "serde",
  "smallvec",
  "thiserror",
  "tokio",
@@ -6590,41 +7117,105 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-admin",
+ "auto_impl",
+ "derive_more 1.0.0",
  "enr",
- "reth-eth-wire",
- "reth-network-peers",
+ "futures",
+ "reth-eth-wire-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
  "serde",
  "thiserror",
  "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "reth-network-api"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types-admin",
+ "auto_impl",
+ "derive_more 1.0.0",
+ "enr",
+ "futures",
+ "reth-eth-wire-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-network-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "serde",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
 name = "reth-network-p2p"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "auto_impl",
+ "derive_more 1.0.0",
  "futures",
- "reth-consensus",
- "reth-eth-wire-types",
- "reth-network-api",
- "reth-network-peers",
- "reth-primitives",
- "reth-storage-errors",
- "thiserror",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-eth-wire-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "reth-network-p2p"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "auto_impl",
+ "derive_more 1.0.0",
+ "futures",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-eth-wire-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-network-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "reth-network-peers"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "enr",
+ "secp256k1",
+ "serde_with",
+ "thiserror",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "reth-network-peers"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6638,13 +7229,27 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "humantime-serde",
- "reth-net-banlist",
- "reth-network-api",
- "reth-network-peers",
+ "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-net-banlist 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "serde",
+ "serde_json",
+ "tracing",
+]
+
+[[package]]
+name = "reth-network-types"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "humantime-serde",
+ "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-net-banlist 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "serde",
  "serde_json",
  "tracing",
@@ -6652,17 +7257,36 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
  "cuckoofilter",
- "derive_more",
+ "derive_more 1.0.0",
  "lz4_flex",
  "memmap2",
  "ph",
- "reth-fs-util",
+ "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "serde",
+ "sucds",
+ "thiserror",
+ "tracing",
+ "zstd 0.13.2",
+]
+
+[[package]]
+name = "reth-nippy-jar"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "anyhow",
+ "bincode 1.3.3",
+ "cuckoofilter",
+ "derive_more 1.0.0",
+ "lz4_flex",
+ "memmap2",
+ "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "serde",
  "sucds",
  "thiserror",
@@ -6672,67 +7296,149 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
- "reth-db-api",
- "reth-engine-primitives",
- "reth-evm",
- "reth-network",
- "reth-payload-builder",
- "reth-payload-primitives",
- "reth-provider",
- "reth-tasks",
- "reth-transaction-pool",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-eth-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+]
+
+[[package]]
+name = "reth-node-api"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-eth-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
 ]
 
 [[package]]
 name = "reth-node-builder"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
+ "alloy-network",
  "aquamarine",
- "backon",
- "confy",
  "eyre",
  "fdlimit",
  "futures",
  "rayon",
- "reth-auto-seal-consensus",
- "reth-beacon-consensus",
- "reth-blockchain-tree",
- "reth-chainspec",
- "reth-cli-util",
- "reth-config",
- "reth-consensus",
- "reth-consensus-debug-client",
- "reth-db",
- "reth-db-api",
- "reth-db-common",
- "reth-downloaders",
- "reth-engine-util",
- "reth-evm",
- "reth-exex",
- "reth-network",
- "reth-network-p2p",
- "reth-node-api",
- "reth-node-core",
- "reth-node-events",
- "reth-payload-builder",
- "reth-primitives",
- "reth-provider",
- "reth-prune",
- "reth-rpc",
- "reth-rpc-builder",
- "reth-rpc-engine-api",
- "reth-rpc-eth-types",
- "reth-rpc-layer",
- "reth-rpc-types",
- "reth-stages",
- "reth-static-file",
- "reth-tasks",
- "reth-tracing",
- "reth-transaction-pool",
+ "reth-auto-seal-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-blockchain-tree 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-cli-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-consensus-debug-client 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-db-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-downloaders 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-engine-service 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-engine-tree 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-engine-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-exex 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-node-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-node-core 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-node-events 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-node-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-payload-validator 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-prune 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-engine-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-eth-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-layer 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-stages 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-static-file 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-tracing 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "secp256k1",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
+name = "reth-node-builder"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "alloy-network",
+ "aquamarine",
+ "eyre",
+ "fdlimit",
+ "futures",
+ "rayon",
+ "reth-auto-seal-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-blockchain-tree 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-cli-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-consensus-debug-client 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-db-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-downloaders 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-engine-service 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-engine-tree 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-engine-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-exex 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-network 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-node-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-node-core 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-node-events 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-node-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-payload-validator 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-prune 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-engine-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-eth-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-layer 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-stages 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-static-file 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-tracing 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "secp256k1",
  "tokio",
  "tokio-stream",
@@ -6741,58 +7447,214 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "alloy-genesis",
  "alloy-rpc-types-engine",
  "clap",
  "const_format",
- "derive_more",
+ "derive_more 1.0.0",
  "dirs-next",
  "eyre",
  "futures",
- "http 1.1.0",
  "humantime",
+ "rand 0.8.5",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-cli-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-consensus-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-discv4 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-discv5 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-net-nat 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-eth-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-eth-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-server-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-tracing 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "secp256k1",
+ "serde",
+ "serde_json",
+ "shellexpand",
+ "toml",
+ "tracing",
+ "vergen",
+]
+
+[[package]]
+name = "reth-node-core"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "alloy-genesis",
+ "alloy-rpc-types-engine",
+ "clap",
+ "const_format",
+ "derive_more 1.0.0",
+ "dirs-next",
+ "eyre",
+ "futures",
+ "humantime",
+ "rand 0.8.5",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-cli",
+ "reth-cli-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-consensus-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-discv4 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-discv5 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-net-nat 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-network 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-eth-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-eth-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-server-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-tracing 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "secp256k1",
+ "serde",
+ "serde_json",
+ "shellexpand",
+ "toml",
+ "tracing",
+ "vergen",
+]
+
+[[package]]
+name = "reth-node-ethereum"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
+dependencies = [
+ "eyre",
+ "reth-auto-seal-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-basic-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-ethereum-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-ethereum-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-evm-ethereum 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-node-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-node-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-tracing 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+]
+
+[[package]]
+name = "reth-node-ethereum"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "eyre",
+ "reth-auto-seal-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-basic-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-ethereum-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-ethereum-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-evm-ethereum 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-network 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-node-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-node-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-tracing 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+]
+
+[[package]]
+name = "reth-node-events"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
+dependencies = [
+ "alloy-rpc-types-engine",
+ "futures",
+ "humantime",
+ "pin-project",
+ "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-prune 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-stages 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-static-file 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "reth-node-events"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "alloy-rpc-types-engine",
+ "futures",
+ "humantime",
+ "pin-project",
+ "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-network 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-prune 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-stages 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-static-file 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "reth-node-metrics"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
+dependencies = [
+ "eyre",
+ "http",
  "jsonrpsee",
  "metrics",
  "metrics-exporter-prometheus",
  "metrics-process",
  "metrics-util",
- "once_cell",
  "procfs",
- "rand 0.8.5",
- "reth-chainspec",
- "reth-cli-util",
- "reth-config",
- "reth-consensus-common",
- "reth-db",
- "reth-db-api",
- "reth-discv4",
- "reth-discv5",
- "reth-fs-util",
- "reth-metrics",
- "reth-net-nat",
- "reth-network",
- "reth-network-p2p",
- "reth-network-peers",
- "reth-primitives",
- "reth-provider",
- "reth-prune-types",
- "reth-rpc-api",
- "reth-rpc-eth-api",
- "reth-rpc-eth-types",
- "reth-rpc-server-types",
- "reth-rpc-types",
- "reth-rpc-types-compat",
- "reth-stages-types",
- "reth-storage-errors",
- "reth-tasks",
- "reth-tracing",
- "reth-transaction-pool",
- "secp256k1",
- "serde_json",
- "shellexpand",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
  "tikv-jemalloc-ctl",
  "tokio",
  "tower",
@@ -6801,82 +7663,115 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-node-ethereum"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+name = "reth-node-metrics"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "eyre",
- "futures",
- "reth-auto-seal-consensus",
- "reth-basic-payload-builder",
- "reth-beacon-consensus",
- "reth-consensus",
- "reth-ethereum-engine",
- "reth-ethereum-engine-primitives",
- "reth-ethereum-payload-builder",
- "reth-evm-ethereum",
- "reth-exex",
- "reth-network",
- "reth-node-api",
- "reth-node-builder",
- "reth-node-core",
- "reth-node-events",
- "reth-payload-builder",
- "reth-provider",
- "reth-rpc",
- "reth-rpc-engine-api",
- "reth-rpc-types",
- "reth-tasks",
- "reth-tokio-util",
- "reth-tracing",
- "reth-transaction-pool",
+ "http",
+ "jsonrpsee",
+ "metrics",
+ "metrics-exporter-prometheus",
+ "metrics-process",
+ "metrics-util",
+ "procfs",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "tokio",
- "tokio-stream",
+ "tower",
+ "tracing",
+ "vergen",
 ]
 
 [[package]]
-name = "reth-node-events"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+name = "reth-optimism-consensus"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
- "alloy-rpc-types-engine",
- "futures",
- "humantime",
- "pin-project",
- "reth-beacon-consensus",
- "reth-db-api",
- "reth-network",
- "reth-network-api",
- "reth-primitives",
- "reth-primitives-traits",
- "reth-provider",
- "reth-prune",
- "reth-stages",
- "reth-static-file",
- "tokio",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-consensus-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
  "tracing",
 ]
 
 [[package]]
 name = "reth-optimism-primitives"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
+
+[[package]]
+name = "reth-optimism-rpc"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
+dependencies = [
+ "alloy-primitives",
+ "jsonrpsee-types",
+ "op-alloy-network",
+ "parking_lot 0.12.3",
+ "reqwest",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-evm-optimism",
+ "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-node-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-node-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-eth-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-eth-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-server-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "revm",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "reth-payload-builder"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "futures-util",
  "metrics",
- "reth-errors",
- "reth-ethereum-engine-primitives",
- "reth-metrics",
- "reth-payload-primitives",
- "reth-primitives",
- "reth-provider",
- "reth-rpc-types",
- "reth-transaction-pool",
+ "pin-project",
+ "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-ethereum-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
+name = "reth-payload-builder"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "futures-util",
+ "metrics",
+ "pin-project",
+ "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-ethereum-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -6885,14 +7780,31 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
- "reth-chainspec",
- "reth-errors",
- "reth-primitives",
- "reth-rpc-types",
- "reth-transaction-pool",
+ "reth-chain-state 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "serde",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "reth-payload-primitives"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "reth-chain-state 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "serde",
  "thiserror",
  "tokio",
@@ -6900,51 +7812,96 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
- "reth-chainspec",
- "reth-primitives",
- "reth-rpc-types",
- "reth-rpc-types-compat",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+]
+
+[[package]]
+name = "reth-payload-validator"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
 ]
 
 [[package]]
 name = "reth-primitives"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
+ "alloy-consensus",
  "alloy-eips",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types",
- "arbitrary",
+ "alloy-serde",
  "bytes",
  "c-kzg",
- "derive_more",
+ "derive_more 1.0.0",
+ "k256",
  "modular-bitfield",
  "once_cell",
- "proptest",
+ "op-alloy-rpc-types",
  "rayon",
- "reth-chainspec",
- "reth-codecs",
- "reth-ethereum-forks",
- "reth-primitives-traits",
- "reth-static-file-types",
- "reth-trie-common",
+ "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-static-file-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
  "revm-primitives",
  "secp256k1",
  "serde",
  "tempfile",
- "thiserror-no-std",
+ "thiserror",
+ "zstd 0.13.2",
+]
+
+[[package]]
+name = "reth-primitives"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-primitives",
+ "alloy-rlp",
+ "arbitrary",
+ "bytes",
+ "c-kzg",
+ "derive_more 1.0.0",
+ "k256",
+ "modular-bitfield",
+ "once_cell",
+ "proptest",
+ "rayon",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-static-file-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "revm-primitives",
+ "secp256k1",
+ "serde",
+ "tempfile",
+ "thiserror",
  "zstd 0.13.2",
 ]
 
 [[package]]
 name = "reth-primitives-traits"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6952,14 +7909,34 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-eth",
+ "byteorder",
+ "bytes",
+ "derive_more 1.0.0",
+ "modular-bitfield",
+ "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "revm-primitives",
+ "roaring",
+ "serde",
+]
+
+[[package]]
+name = "reth-primitives-traits"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-primitives",
+ "alloy-rlp",
  "arbitrary",
  "byteorder",
  "bytes",
- "derive_more",
+ "derive_more 1.0.0",
  "modular-bitfield",
  "proptest",
  "proptest-arbitrary-interop",
- "reth-codecs",
+ "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "revm-primitives",
  "roaring",
  "serde",
@@ -6967,37 +7944,75 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
- "alloy-rlp",
  "alloy-rpc-types-engine",
  "auto_impl",
- "dashmap 6.0.1",
+ "dashmap",
  "itertools 0.13.0",
  "metrics",
  "parking_lot 0.12.3",
  "rayon",
- "reth-blockchain-tree-api",
- "reth-chain-state",
- "reth-chainspec",
- "reth-codecs",
- "reth-db",
- "reth-db-api",
- "reth-errors",
- "reth-evm",
- "reth-execution-types",
- "reth-fs-util",
- "reth-metrics",
- "reth-network-p2p",
- "reth-nippy-jar",
- "reth-primitives",
- "reth-prune-types",
- "reth-stages-types",
- "reth-storage-api",
- "reth-storage-errors",
- "reth-trie",
- "reth-trie-db",
+ "reth-blockchain-tree-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-chain-state 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-nippy-jar 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-trie-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "revm",
+ "strum",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "reth-provider"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "alloy-rpc-types-engine",
+ "auto_impl",
+ "dashmap",
+ "itertools 0.13.0",
+ "metrics",
+ "once_cell",
+ "parking_lot 0.12.3",
+ "rayon",
+ "reth-blockchain-tree-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-chain-state 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-nippy-jar 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-trie-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "revm",
  "strum",
  "tokio",
@@ -7006,24 +8021,50 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "alloy-primitives",
  "itertools 0.13.0",
  "metrics",
  "rayon",
- "reth-chainspec",
- "reth-config",
- "reth-db",
- "reth-db-api",
- "reth-errors",
- "reth-exex-types",
- "reth-metrics",
- "reth-provider",
- "reth-prune-types",
- "reth-static-file-types",
- "reth-tokio-util",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-exex-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-static-file-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "rustc-hash 2.0.0",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "reth-prune"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "alloy-primitives",
+ "itertools 0.13.0",
+ "metrics",
+ "rayon",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-exex-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-static-file-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "rustc-hash 2.0.0",
  "thiserror",
  "tokio",
@@ -7032,48 +8073,76 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "alloy-primitives",
  "bytes",
- "derive_more",
+ "derive_more 1.0.0",
  "modular-bitfield",
- "reth-codecs",
+ "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "reth-prune-types"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "alloy-primitives",
+ "bytes",
+ "derive_more 1.0.0",
+ "modular-bitfield",
+ "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "serde",
  "thiserror",
 ]
 
 [[package]]
 name = "reth-revm"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
- "alloy-eips",
- "reth-chainspec",
- "reth-consensus-common",
- "reth-execution-errors",
- "reth-primitives",
- "reth-prune-types",
- "reth-storage-api",
- "reth-storage-errors",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-consensus-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
  "revm",
- "tracing",
+]
+
+[[package]]
+name = "reth-revm"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-consensus-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "revm",
 ]
 
 [[package]]
 name = "reth-rpc"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-genesis",
+ "alloy-network",
  "alloy-primitives",
  "alloy-rlp",
  "async-trait",
- "derive_more",
+ "derive_more 1.0.0",
  "futures",
- "http 1.1.0",
+ "http",
  "http-body",
  "hyper",
  "jsonrpsee",
@@ -7081,25 +8150,83 @@ dependencies = [
  "parking_lot 0.12.3",
  "pin-project",
  "rand 0.8.5",
- "reth-chainspec",
- "reth-consensus-common",
- "reth-errors",
- "reth-evm",
- "reth-network-api",
- "reth-network-peers",
- "reth-node-api",
- "reth-primitives",
- "reth-provider",
- "reth-revm",
- "reth-rpc-api",
- "reth-rpc-engine-api",
- "reth-rpc-eth-api",
- "reth-rpc-eth-types",
- "reth-rpc-server-types",
- "reth-rpc-types",
- "reth-rpc-types-compat",
- "reth-tasks",
- "reth-transaction-pool",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-consensus-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-node-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-engine-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-eth-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-eth-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-server-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "revm",
+ "revm-inspectors",
+ "revm-primitives",
+ "secp256k1",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "reth-rpc"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "alloy-dyn-abi",
+ "alloy-genesis",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-rlp",
+ "async-trait",
+ "derive_more 1.0.0",
+ "futures",
+ "http",
+ "http-body",
+ "hyper",
+ "jsonrpsee",
+ "jsonwebtoken",
+ "parking_lot 0.12.3",
+ "pin-project",
+ "rand 0.8.5",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-consensus-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-network-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-node-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-engine-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-eth-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-eth-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-server-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "revm",
  "revm-inspectors",
  "revm-primitives",
@@ -7116,41 +8243,91 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
+ "alloy-json-rpc",
  "jsonrpsee",
- "reth-engine-primitives",
- "reth-network-peers",
- "reth-primitives",
- "reth-rpc-eth-api",
- "reth-rpc-types",
+ "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-eth-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+]
+
+[[package]]
+name = "reth-rpc-api"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "alloy-json-rpc",
+ "jsonrpsee",
+ "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-eth-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
 ]
 
 [[package]]
 name = "reth-rpc-builder"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
- "http 1.1.0",
+ "http",
  "jsonrpsee",
  "metrics",
  "pin-project",
- "reth-engine-primitives",
- "reth-evm",
- "reth-ipc",
- "reth-metrics",
- "reth-network-api",
- "reth-node-core",
- "reth-provider",
- "reth-rpc",
- "reth-rpc-api",
- "reth-rpc-eth-api",
- "reth-rpc-eth-types",
- "reth-rpc-layer",
- "reth-rpc-server-types",
- "reth-tasks",
- "reth-transaction-pool",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-ipc 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-node-core 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-eth-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-eth-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-layer 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-server-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "serde",
+ "thiserror",
+ "tower",
+ "tower-http",
+ "tracing",
+]
+
+[[package]]
+name = "reth-rpc-builder"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "http",
+ "jsonrpsee",
+ "metrics",
+ "pin-project",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-ipc 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-node-core 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-eth-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-eth-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-layer 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-server-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "serde",
  "thiserror",
  "tower",
@@ -7160,26 +8337,54 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "async-trait",
  "jsonrpsee-core",
  "jsonrpsee-types",
  "metrics",
- "reth-beacon-consensus",
- "reth-chainspec",
- "reth-engine-primitives",
- "reth-evm",
- "reth-metrics",
- "reth-payload-builder",
- "reth-payload-primitives",
- "reth-primitives",
- "reth-rpc-api",
- "reth-rpc-types",
- "reth-rpc-types-compat",
- "reth-storage-api",
- "reth-tasks",
+ "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "serde",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "reth-rpc-engine-api"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "async-trait",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "metrics",
+ "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "serde",
  "thiserror",
  "tokio",
@@ -7188,29 +8393,71 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "alloy-dyn-abi",
+ "alloy-json-rpc",
+ "alloy-network",
  "async-trait",
  "auto_impl",
  "dyn-clone",
  "futures",
  "jsonrpsee",
+ "jsonrpsee-types",
  "parking_lot 0.12.3",
- "reth-chainspec",
- "reth-errors",
- "reth-evm",
- "reth-execution-types",
- "reth-primitives",
- "reth-provider",
- "reth-revm",
- "reth-rpc-eth-types",
- "reth-rpc-server-types",
- "reth-rpc-types",
- "reth-rpc-types-compat",
- "reth-tasks",
- "reth-transaction-pool",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-eth-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-server-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "revm",
+ "revm-inspectors",
+ "revm-primitives",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "reth-rpc-eth-api"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "alloy-dyn-abi",
+ "alloy-json-rpc",
+ "alloy-network",
+ "async-trait",
+ "auto_impl",
+ "dyn-clone",
+ "futures",
+ "jsonrpsee",
+ "jsonrpsee-types",
+ "parking_lot 0.12.3",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-eth-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-server-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "revm",
  "revm-inspectors",
  "revm-primitives",
@@ -7220,30 +8467,69 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "alloy-sol-types",
- "derive_more",
+ "derive_more 1.0.0",
  "futures",
  "jsonrpsee-core",
  "jsonrpsee-types",
  "metrics",
  "rand 0.8.5",
- "reth-chainspec",
- "reth-errors",
- "reth-evm",
- "reth-execution-types",
- "reth-metrics",
- "reth-primitives",
- "reth-provider",
- "reth-revm",
- "reth-rpc-server-types",
- "reth-rpc-types",
- "reth-rpc-types-compat",
- "reth-tasks",
- "reth-transaction-pool",
- "reth-trie",
+ "reth-chain-state 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-server-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "revm",
+ "revm-inspectors",
+ "revm-primitives",
+ "schnellru",
+ "serde",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
+name = "reth-rpc-eth-types"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "alloy-sol-types",
+ "derive_more 1.0.0",
+ "futures",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "metrics",
+ "rand 0.8.5",
+ "reth-chain-state 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-server-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "revm",
  "revm-inspectors",
  "revm-primitives",
@@ -7257,11 +8543,24 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "alloy-rpc-types-engine",
- "http 1.1.0",
+ "http",
+ "jsonrpsee-http-client",
+ "pin-project",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "reth-rpc-layer"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "alloy-rpc-types-engine",
+ "http",
  "jsonrpsee-http-client",
  "pin-project",
  "tower",
@@ -7270,24 +8569,40 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "alloy-primitives",
  "jsonrpsee-core",
  "jsonrpsee-types",
- "reth-errors",
- "reth-network-api",
- "reth-primitives",
- "reth-rpc-types",
+ "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "serde",
+ "strum",
+]
+
+[[package]]
+name = "reth-rpc-server-types"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "alloy-primitives",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "serde",
  "strum",
 ]
 
 [[package]]
 name = "reth-rpc-types"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
@@ -7300,49 +8615,117 @@ dependencies = [
  "alloy-rpc-types-txpool",
  "alloy-serde",
  "jsonrpsee-types",
+ "op-alloy-rpc-types",
+ "op-alloy-rpc-types-engine",
+]
+
+[[package]]
+name = "reth-rpc-types"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types",
+ "alloy-rpc-types-admin",
+ "alloy-rpc-types-anvil",
+ "alloy-rpc-types-beacon",
+ "alloy-rpc-types-engine",
+ "alloy-rpc-types-mev",
+ "alloy-rpc-types-trace",
+ "alloy-rpc-types-txpool",
+ "alloy-serde",
+ "jsonrpsee-types",
+ "op-alloy-rpc-types",
+ "op-alloy-rpc-types-engine",
 ]
 
 [[package]]
 name = "reth-rpc-types-compat"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "alloy-rlp",
  "alloy-rpc-types",
- "reth-primitives",
- "reth-rpc-types",
- "reth-trie-common",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+]
+
+[[package]]
+name = "reth-rpc-types-compat"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "alloy-rlp",
+ "alloy-rpc-types",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
 ]
 
 [[package]]
 name = "reth-stages"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "futures-util",
  "itertools 0.13.0",
  "num-traits",
  "rayon",
- "reth-codecs",
- "reth-config",
- "reth-consensus",
- "reth-db",
- "reth-db-api",
- "reth-etl",
- "reth-evm",
- "reth-execution-types",
- "reth-exex",
- "reth-network-p2p",
- "reth-primitives",
- "reth-primitives-traits",
- "reth-provider",
- "reth-prune",
- "reth-prune-types",
- "reth-revm",
- "reth-stages-api",
- "reth-storage-errors",
- "reth-trie",
- "reth-trie-db",
+ "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-etl 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-exex 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-prune 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-stages-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-trie-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "reth-stages"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "futures-util",
+ "itertools 0.13.0",
+ "num-traits",
+ "rayon",
+ "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-etl 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-exex 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-prune 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-stages-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-trie-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "thiserror",
  "tokio",
  "tracing",
@@ -7350,26 +8733,53 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "alloy-primitives",
  "aquamarine",
  "auto_impl",
  "futures-util",
  "metrics",
- "reth-consensus",
- "reth-db-api",
- "reth-errors",
- "reth-metrics",
- "reth-network-p2p",
- "reth-primitives-traits",
- "reth-provider",
- "reth-prune",
- "reth-stages-types",
- "reth-static-file",
- "reth-static-file-types",
- "reth-tokio-util",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-prune 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-static-file 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-static-file-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "reth-stages-api"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "alloy-primitives",
+ "aquamarine",
+ "auto_impl",
+ "futures-util",
+ "metrics",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-prune 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-static-file 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-static-file-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "thiserror",
  "tokio",
  "tracing",
@@ -7377,80 +8787,151 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "alloy-primitives",
  "bytes",
  "modular-bitfield",
- "reth-codecs",
- "reth-trie-common",
+ "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "serde",
+]
+
+[[package]]
+name = "reth-stages-types"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "alloy-primitives",
+ "bytes",
+ "modular-bitfield",
+ "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "serde",
 ]
 
 [[package]]
 name = "reth-static-file"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "alloy-primitives",
  "parking_lot 0.12.3",
  "rayon",
- "reth-db",
- "reth-db-api",
- "reth-nippy-jar",
- "reth-provider",
- "reth-prune-types",
- "reth-stages-types",
- "reth-static-file-types",
- "reth-storage-errors",
- "reth-tokio-util",
+ "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-nippy-jar 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-static-file-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "tracing",
+]
+
+[[package]]
+name = "reth-static-file"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "alloy-primitives",
+ "parking_lot 0.12.3",
+ "rayon",
+ "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-nippy-jar 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-static-file-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "tracing",
 ]
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "alloy-primitives",
  "clap",
- "derive_more",
+ "derive_more 1.0.0",
+ "serde",
+ "strum",
+]
+
+[[package]]
+name = "reth-static-file-types"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "alloy-primitives",
+ "derive_more 1.0.0",
  "serde",
  "strum",
 ]
 
 [[package]]
 name = "reth-storage-api"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "auto_impl",
- "reth-chainspec",
- "reth-db-api",
- "reth-execution-types",
- "reth-primitives",
- "reth-prune-types",
- "reth-stages-types",
- "reth-storage-errors",
- "reth-trie",
- "revm",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-db-models 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+]
+
+[[package]]
+name = "reth-storage-api"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "auto_impl",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-db-models 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
 ]
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
- "reth-fs-util",
- "reth-primitives",
- "thiserror-no-std",
+ "alloy-rlp",
+ "derive_more 1.0.0",
+ "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+]
+
+[[package]]
+name = "reth-storage-errors"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "alloy-rlp",
+ "derive_more 1.0.0",
+ "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
 ]
 
 [[package]]
 name = "reth-tasks"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -7458,7 +8939,25 @@ dependencies = [
  "metrics",
  "pin-project",
  "rayon",
- "reth-metrics",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "reth-tasks"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "auto_impl",
+ "dyn-clone",
+ "futures-util",
+ "metrics",
+ "pin-project",
+ "rayon",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "thiserror",
  "tokio",
  "tracing",
@@ -7467,19 +8966,30 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
+ "alloy-eips",
  "alloy-genesis",
  "rand 0.8.5",
- "reth-primitives",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "secp256k1",
 ]
 
 [[package]]
 name = "reth-tokio-util"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
+dependencies = [
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
+name = "reth-tokio-util"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -7488,8 +8998,23 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
+dependencies = [
+ "clap",
+ "eyre",
+ "rolling-file",
+ "tracing",
+ "tracing-appender",
+ "tracing-journald",
+ "tracing-logfmt",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "reth-tracing"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "clap",
  "eyre",
@@ -7503,8 +9028,40 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
+dependencies = [
+ "alloy-rlp",
+ "aquamarine",
+ "auto_impl",
+ "bitflags 2.6.0",
+ "futures-util",
+ "metrics",
+ "parking_lot 0.12.3",
+ "reth-chain-state 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-eth-wire-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "revm",
+ "rustc-hash 2.0.0",
+ "schnellru",
+ "serde",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
+name = "reth-transaction-pool"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-rlp",
  "aquamarine",
@@ -7515,14 +9072,15 @@ dependencies = [
  "parking_lot 0.12.3",
  "paste",
  "rand 0.8.5",
- "reth-chainspec",
- "reth-eth-wire-types",
- "reth-execution-types",
- "reth-fs-util",
- "reth-metrics",
- "reth-primitives",
- "reth-provider",
- "reth-tasks",
+ "reth-chain-state 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-eth-wire-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "revm",
  "rustc-hash 2.0.0",
  "schnellru",
@@ -7536,31 +9094,52 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "alloy-rlp",
  "auto_impl",
- "derive_more",
+ "derive_more 1.0.0",
  "itertools 0.13.0",
  "metrics",
  "rayon",
- "reth-db",
- "reth-db-api",
- "reth-execution-errors",
- "reth-metrics",
- "reth-primitives",
- "reth-stages-types",
- "reth-trie-common",
+ "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
  "revm",
  "serde",
  "tracing",
 ]
 
 [[package]]
+name = "reth-trie"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "alloy-rlp",
+ "auto_impl",
+ "derive_more 1.0.0",
+ "itertools 0.13.0",
+ "metrics",
+ "rayon",
+ "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "revm",
+ "tracing",
+ "triehash",
+]
+
+[[package]]
 name = "reth-trie-common"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7568,57 +9147,129 @@ dependencies = [
  "alloy-rlp",
  "alloy-trie",
  "bytes",
- "derive_more",
+ "derive_more 1.0.0",
  "itertools 0.13.0",
  "nybbles",
- "reth-codecs",
- "reth-primitives-traits",
+ "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "revm-primitives",
+ "serde",
+]
+
+[[package]]
+name = "reth-trie-common"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "alloy-consensus",
+ "alloy-genesis",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-trie",
+ "arbitrary",
+ "bytes",
+ "derive_more 1.0.0",
+ "hash-db",
+ "itertools 0.13.0",
+ "nybbles",
+ "plain_hasher",
+ "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "revm-primitives",
  "serde",
 ]
 
 [[package]]
 name = "reth-trie-db"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "alloy-rlp",
  "auto_impl",
- "derive_more",
+ "derive_more 1.0.0",
  "itertools 0.13.0",
  "metrics",
  "rayon",
- "reth-db",
- "reth-db-api",
- "reth-execution-errors",
- "reth-metrics",
- "reth-primitives",
- "reth-stages-types",
- "reth-trie",
- "reth-trie-common",
+ "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "revm",
+ "tracing",
+]
+
+[[package]]
+name = "reth-trie-db"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "alloy-rlp",
+ "auto_impl",
+ "derive_more 1.0.0",
+ "itertools 0.13.0",
+ "metrics",
+ "rayon",
+ "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "revm",
  "tracing",
 ]
 
 [[package]]
 name = "reth-trie-parallel"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#d107827b69092025dc3e35d53c50787c8b49810e"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "alloy-rlp",
- "derive_more",
+ "derive_more 1.0.0",
  "itertools 0.13.0",
  "metrics",
  "rayon",
- "reth-db",
- "reth-db-api",
- "reth-execution-errors",
- "reth-metrics",
- "reth-primitives",
- "reth-provider",
- "reth-tasks",
- "reth-trie",
- "reth-trie-db",
+ "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-trie-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "reth-trie-parallel"
+version = "1.0.6"
+source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+dependencies = [
+ "alloy-rlp",
+ "derive_more 1.0.0",
+ "itertools 0.13.0",
+ "metrics",
+ "rayon",
+ "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-trie-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
  "thiserror",
  "tokio",
  "tracing",
@@ -7626,9 +9277,9 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "12.1.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6cfb48bce8ca2113e157bdbddbd5eeb09daac1c903d79ec17085897c38c7c91"
+checksum = "69eae90188e48c81588fe1987b4bd35cd90d69b3602cb0c3a9ab12b882f18d91"
 dependencies = [
  "auto_impl",
  "cfg-if",
@@ -7641,16 +9292,14 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af2dc001e37ac3b061dc9087876aea91e28756c188a97cd99416d23a5562ca73"
+checksum = "48184032103bb23788e42e42c7c85207f5b0b8a248b09ea8f5233077f35ab56e"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
  "alloy-sol-types",
  "anstyle",
- "boa_engine",
- "boa_gc",
  "colorchoice",
  "revm",
  "serde_json",
@@ -7659,9 +9308,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "8.1.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b0daddea06fc6da5346acc39b32a357bbe3579e9e3d94117d9ae125cd596fc"
+checksum = "a7bad33a4f862ed8e2dc8bb5e7935852990da74f6db986732ef4f47f9021b2e4"
 dependencies = [
  "revm-primitives",
  "serde",
@@ -7669,9 +9318,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "9.2.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef55228211251d7b6c7707c3ee13bb70dea4d2fd81ec4034521e4fe31010b2ea"
+checksum = "24db0f8fb5bc636e18b4d36bdc4c402ea941be79cfbdb096469887b616959a46"
 dependencies = [
  "aurora-engine-modexp",
  "blst",
@@ -7688,9 +9337,9 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "7.1.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fc4311037ee093ec50ec734e1424fcb3e12d535c6cef683b75d1c064639630c"
+checksum = "c13132ed599b17fa9057fcfc1d37d2954921958f3b96173fc4f4cf52803b32c3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7699,13 +9348,10 @@ dependencies = [
  "bitvec",
  "c-kzg",
  "cfg-if",
- "derive_more",
  "dyn-clone",
  "enumn",
  "hashbrown 0.14.5",
  "hex",
- "kzg-rs",
- "once_cell",
  "serde",
 ]
 
@@ -7840,9 +9486,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.35.0"
+version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1790d1c4c0ca81211399e0e0af16333276f375209e71a37b67698a373db5b47a"
+checksum = "b082d80e3e3cc52b2ed634388d436fe1f4de6af5786cc2de9ba9737527bdf555"
 dependencies = [
  "arrayvec",
  "num-traits",
@@ -7883,18 +9529,18 @@ dependencies = [
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver 1.0.23",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "a85d50532239da68e9addb745ba38ff4612a242c1c7ceea689c4bc7c2f43c36f"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -7920,9 +9566,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.7.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88d6d420651b496bdd98684116959239430022a115c1240e6c3993be0b15fba"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
 dependencies = [
  "openssl-probe",
  "rustls-pemfile",
@@ -7933,9 +9579,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+checksum = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425"
 dependencies = [
  "base64 0.22.1",
  "rustls-pki-types",
@@ -7943,15 +9589,15 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e3beb939bcd33c269f4bf946cc829fcd336370267c4a927ac0399c84a3151a1"
+checksum = "afbb878bdfdf63a336a5e63561b1835e7a8c91524f51621db870169eac84b490"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
@@ -7970,15 +9616,15 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier-android"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84e217e7fdc8466b5b35d30f8c0a30febd29173df4a3a0c2115d306b9c4117ad"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.6"
+version = "0.102.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e"
+checksum = "84678086bd54edf2b415183ed7a94d0efb049f1b646a33e22a36f3794be6ae56"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -8004,27 +9650,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rw-stream-sink"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8c9026ff5d2f23da5e45bbc283f156383001bfb09c4e44256d02c1a685fe9a1"
-dependencies = [
- "futures",
- "pin-project",
- "static_assertions",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
-
-[[package]]
-name = "ryu-js"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad97d4ce1560a5e27cec89519dc8300d1aa6035b099821261c651486a19e44d5"
 
 [[package]]
 name = "same-file"
@@ -8160,9 +9789,9 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.204"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
 dependencies = [
  "serde_derive",
 ]
@@ -8178,32 +9807,33 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.204"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.120"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
+checksum = "8043c06d9f82bd7271361ed64f415fe5e12a77fdb52e573e7f06a516dea329ad"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
+checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
 dependencies = [
  "serde",
 ]
@@ -8230,7 +9860,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -8247,20 +9877,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap 2.2.6",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -8310,9 +9927,9 @@ dependencies = [
 
 [[package]]
 name = "sha3-asm"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9b57fd861253bff08bb1919e995f90ba8f4889de2726091c8876f3a4e823b40"
+checksum = "57d79b758b7cb2085612b11a235055e485605a5103faccdd633f35bd7aee69dd"
 dependencies = [
  "cc",
  "cfg-if",
@@ -8354,9 +9971,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-mio"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
+checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
 dependencies = [
  "libc",
  "mio 0.8.11",
@@ -8415,12 +10032,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "siphasher"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
-
-[[package]]
 name = "sketches-ddsketch"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8441,6 +10052,7 @@ version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 dependencies = [
+ "arbitrary",
  "serde",
 ]
 
@@ -8479,7 +10091,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures",
- "http 1.1.0",
+ "http",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -8503,26 +10115,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "sptr"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
-
-[[package]]
 name = "stability"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d904e7009df136af5297832a3ace3370cd14ff1546a232f4f185036c2736fcac"
 dependencies = [
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "starknet-crypto"
@@ -8552,7 +10152,7 @@ checksum = "bbc159a1934c7be9761c237333a57febe060ace2bc9e3b337a59a37af206d19f"
 dependencies = [
  "starknet-curve",
  "starknet-ff",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -8621,7 +10221,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -8666,9 +10266,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.72"
+version = "2.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+checksum = "578e081a14e0cefc3279b0472138c513f37b41a08d5a3cca9b6e4e8ceb6cd525"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8677,14 +10277,14 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "0.7.7"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c837dc8852cb7074e46b444afb81783140dab12c58867b49fb3898fbafedf7ea"
+checksum = "284c41c2919303438fcf8dede4036fd1e82d4fc0fbb2b279bd2a1442c909ca92"
 dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -8692,16 +10292,8 @@ name = "sync_wrapper"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
-
-[[package]]
-name = "synstructure"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.72",
+ "futures-core",
 ]
 
 [[package]]
@@ -8726,21 +10318,16 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.10.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "thin-vec"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a38c90d48152c236a3ab59271da4f4ae63d678c5d7ad6b7714d7cb9760be5e4b"
 
 [[package]]
 name = "thiserror"
@@ -8759,7 +10346,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -8840,7 +10427,6 @@ checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
- "js-sys",
  "libc",
  "num-conv",
  "num_threads",
@@ -8876,16 +10462,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinystr"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
-dependencies = [
- "displaydoc",
- "zerovec",
-]
-
-[[package]]
 name = "tinyvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8902,14 +10478,14 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.39.1"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d040ac2b29ab03b09d4129c2f5bbd012a3ac2f79d38ff506a4bf8dd34b0eac8a"
+checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio 1.0.1",
+ "mio 1.0.2",
  "parking_lot 0.12.3",
  "pin-project-lite",
  "signal-hook-registry",
@@ -8926,7 +10502,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -8985,47 +10561,36 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.15"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac2caab0bf757388c6c0ae23b3293fdb463fee59434529014f85e3263b995c28"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.16",
+ "toml_edit",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.6"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.21.1"
+version = "0.22.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
+checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
 dependencies = [
- "indexmap 2.2.6",
- "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "278f3d518e152219c994ce877758516bca5e118eaed6996192a774fb9fbf0788"
-dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.15",
+ "winnow",
 ]
 
 [[package]]
@@ -9061,7 +10626,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.1.0",
+ "http",
  "http-body",
  "http-body-util",
  "http-range-header",
@@ -9082,15 +10647,15 @@ dependencies = [
 
 [[package]]
 name = "tower-layer"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -9124,7 +10689,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -9171,9 +10736,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-logfmt"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22b8e455f6caa5212a102ec530bf86b8dc5a4c536299bffd84b238fed9119be7"
+checksum = "6b1f47d22deb79c3f59fcf2a1f00f60cbdc05462bf17d1cd356c1fefa3f444bd"
 dependencies = [
  "time",
  "tracing",
@@ -9210,6 +10775,16 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "triehash"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1631b201eb031b563d2e85ca18ec8092508e262a3196ce9bd10a67ec87b9f5c"
+dependencies = [
+ "hash-db",
+ "rlp",
 ]
 
 [[package]]
@@ -9273,7 +10848,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http 1.1.0",
+ "http",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -9302,7 +10877,6 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
 dependencies = [
- "arbitrary",
  "byteorder",
  "crunchy",
  "hex",
@@ -9370,37 +10944,25 @@ checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+checksum = "229730647fbc343e3a80e463c1db7f78f3855d3f3739bee0dda773c9a037c90a"
 
 [[package]]
 name = "universal-hash"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "generic-array",
+ "crypto-common",
  "subtle",
 ]
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "unsigned-varint"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6889a77d49f1f013504cec6bf97a2c730394adedaeb1deb5ea08949a50541105"
-
-[[package]]
-name = "unsigned-varint"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
 
 [[package]]
 name = "untrusted"
@@ -9424,18 +10986,6 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
-
-[[package]]
-name = "utf8_iter"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -9480,15 +11030,9 @@ dependencies = [
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"
@@ -9532,34 +11076,35 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
 dependencies = [
  "cfg-if",
+ "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
+checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -9569,9 +11114,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -9579,38 +11124,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "web-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9649,11 +11184,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9699,7 +11234,7 @@ checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-result",
+ "windows-result 0.1.2",
  "windows-targets 0.52.6",
 ]
 
@@ -9711,7 +11246,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -9722,7 +11257,18 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-strings",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -9731,6 +11277,25 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
  "windows-targets 0.52.6",
 ]
 
@@ -9748,6 +11313,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -9875,18 +11449,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.5.40"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
-version = "0.6.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "557404e450152cd6795bb558bca69e43c585055f4606e3bcae5894fc6dac9ba0"
+checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
 dependencies = [
  "memchr",
 ]
@@ -9902,28 +11467,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winreg"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
-
-[[package]]
-name = "writeable"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
-
-[[package]]
 name = "ws_stream_wasm"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9934,7 +11477,7 @@ dependencies = [
  "js-sys",
  "log",
  "pharos",
- "rustc_version 0.4.0",
+ "rustc_version 0.4.1",
  "send_wrapper 0.6.0",
  "thiserror",
  "wasm-bindgen",
@@ -9961,35 +11504,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "yoke"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
-dependencies = [
- "serde",
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.72",
- "synstructure",
-]
-
-[[package]]
 name = "zerocopy"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
+ "byteorder",
  "zerocopy-derive",
 ]
 
@@ -10001,28 +11521,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
-]
-
-[[package]]
-name = "zerofrom"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
-dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.72",
- "synstructure",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -10042,29 +11541,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -10073,7 +11550,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
 dependencies = [
- "aes 0.8.4",
+ "aes",
  "byteorder",
  "bzip2",
  "constant_time_eq",
@@ -10102,7 +11579,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
 dependencies = [
- "zstd-safe 7.2.0",
+ "zstd-safe 7.2.1",
 ]
 
 [[package]]
@@ -10117,18 +11594,18 @@ dependencies = [
 
 [[package]]
 name = "zstd-safe"
-version = "7.2.0"
+version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa556e971e7b568dc775c136fc9de8c779b1c2fc3a63defaafadffdbd3181afa"
+checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.12+zstd.1.5.6"
+version = "2.0.13+zstd.1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a4e40c320c3cb459d9a9ff6de98cff88f4751ee9275d140e2be94a2b74e4c13"
+checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3444,11 +3444,11 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "kakarot-node",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-cli-runner 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-cli-runner 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
  "reth-node-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-node-core 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-node-core 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
  "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
  "tracing",
  "tracing-subscriber",
@@ -5072,26 +5072,26 @@ dependencies = [
 [[package]]
 name = "reth-auto-seal-consensus"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "futures-util",
- "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-stages-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-stages-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -5123,21 +5123,21 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-rlp",
  "futures-core",
  "futures-util",
  "metrics",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "revm",
  "tokio",
  "tracing",
@@ -5180,30 +5180,30 @@ dependencies = [
 [[package]]
 name = "reth-beacon-consensus"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "futures",
  "itertools 0.13.0",
  "metrics",
- "reth-blockchain-tree-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-ethereum-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-payload-validator 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-prune 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-stages-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-static-file 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-blockchain-tree-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-ethereum-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-payload-validator 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-prune 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-stages-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-static-file 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "schnellru",
  "thiserror",
  "tokio",
@@ -5245,30 +5245,30 @@ dependencies = [
 [[package]]
 name = "reth-blockchain-tree"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "aquamarine",
  "linked_hash_set",
  "metrics",
  "parking_lot 0.12.3",
- "reth-blockchain-tree-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-network 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-stages-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-trie-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-trie-parallel 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-blockchain-tree-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-network 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-stages-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-trie-db 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-trie-parallel 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "tokio",
  "tracing",
 ]
@@ -5288,12 +5288,12 @@ dependencies = [
 [[package]]
 name = "reth-blockchain-tree-api"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "thiserror",
 ]
 
@@ -5322,7 +5322,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-signer",
  "alloy-signer-local",
@@ -5332,13 +5332,13 @@ dependencies = [
  "parking_lot 0.12.3",
  "pin-project",
  "rand 0.8.5",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "revm",
  "tokio",
  "tokio-stream",
@@ -5368,7 +5368,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-chains",
  "alloy-eips",
@@ -5378,21 +5378,21 @@ dependencies = [
  "auto_impl",
  "derive_more 1.0.0",
  "once_cell",
- "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "serde_json",
 ]
 
 [[package]]
 name = "reth-cli"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "clap",
  "eyre",
- "reth-cli-runner 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-cli-runner 1.0.6 (git+https://github.com/paradigmxyz/reth)",
 ]
 
 [[package]]
@@ -5462,9 +5462,9 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "tokio",
  "tracing",
 ]
@@ -5487,14 +5487,14 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "eyre",
  "libc",
  "rand 0.8.5",
- "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "secp256k1",
  "thiserror",
 ]
@@ -5518,7 +5518,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5527,7 +5527,7 @@ dependencies = [
  "alloy-trie",
  "bytes",
  "modular-bitfield",
- "reth-codecs-derive 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-codecs-derive 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "serde",
 ]
 
@@ -5545,7 +5545,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
@@ -5570,13 +5570,13 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "eyre",
  "humantime-serde",
- "reth-network-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-network-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "serde",
  "toml",
 ]
@@ -5594,11 +5594,11 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "auto_impl",
  "derive_more 1.0.0",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
 ]
 
 [[package]]
@@ -5614,11 +5614,11 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
 ]
 
 [[package]]
@@ -5647,7 +5647,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5656,12 +5656,12 @@ dependencies = [
  "eyre",
  "futures",
  "reqwest",
- "reth-node-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-node-core 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-tracing 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-node-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-node-core 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-builder 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-tracing 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "ringbuffer",
  "serde",
  "tokio",
@@ -5700,7 +5700,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",
@@ -5708,18 +5708,18 @@ dependencies = [
  "metrics",
  "page_size",
  "paste",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-libmdbx 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-nippy-jar 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-tracing 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-libmdbx 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-nippy-jar 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-tracing 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "rustc-hash 2.0.0",
  "serde",
  "strum",
@@ -5752,7 +5752,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -5761,14 +5761,14 @@ dependencies = [
  "modular-bitfield",
  "parity-scale-codec",
  "proptest",
- "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-db-models 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-db-models 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "serde",
 ]
 
@@ -5801,23 +5801,23 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-genesis",
  "boyer-moore-magiclen",
  "eyre",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-etl 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-trie-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-etl 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-trie-db 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "serde",
  "serde_json",
  "thiserror",
@@ -5839,14 +5839,14 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "arbitrary",
  "bytes",
  "modular-bitfield",
  "proptest",
- "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "serde",
 ]
 
@@ -5877,7 +5877,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -5885,10 +5885,10 @@ dependencies = [
  "enr",
  "generic-array",
  "parking_lot 0.12.3",
- "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-net-banlist 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-net-nat 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-net-banlist 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-net-nat 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "schnellru",
  "secp256k1",
  "serde",
@@ -5925,7 +5925,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -5936,10 +5936,10 @@ dependencies = [
  "itertools 0.13.0",
  "metrics",
  "rand 0.8.5",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "secp256k1",
  "thiserror",
  "tokio",
@@ -5971,16 +5971,16 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
  "enr",
  "linked_hash_set",
  "parking_lot 0.12.3",
- "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "schnellru",
  "secp256k1",
  "thiserror",
@@ -6020,7 +6020,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-rlp",
  "futures",
@@ -6029,14 +6029,14 @@ dependencies = [
  "metrics",
  "pin-project",
  "rayon",
- "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -6078,7 +6078,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -6094,7 +6094,7 @@ dependencies = [
  "hmac 0.12.1",
  "pin-project",
  "rand 0.8.5",
- "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "secp256k1",
  "sha2 0.10.8",
  "sha3",
@@ -6119,10 +6119,10 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "serde",
 ]
 
@@ -6153,24 +6153,24 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "futures",
  "pin-project",
- "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-engine-tree 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-payload-validator 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-prune 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-stages-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-engine-tree 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-payload-validator 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-prune 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-stages-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "thiserror",
 ]
 
@@ -6212,33 +6212,33 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "futures",
  "metrics",
- "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-blockchain-tree 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-blockchain-tree-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-chain-state 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-payload-validator 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-prune 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-stages-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-blockchain-tree 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-blockchain-tree-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-chain-state 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-payload-validator 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-prune 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-stages-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "thiserror",
  "tokio",
  "tracing",
@@ -6277,25 +6277,25 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "eyre",
  "futures",
  "itertools 0.13.0",
  "pin-project",
- "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-payload-validator 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-payload-validator 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "revm-primitives",
  "serde",
  "serde_json",
@@ -6320,13 +6320,13 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
- "reth-blockchain-tree-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-blockchain-tree-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "thiserror",
 ]
 
@@ -6358,20 +6358,20 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-rlp",
  "bytes",
  "derive_more 1.0.0",
  "futures",
  "pin-project",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-ecies 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-eth-wire-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-ecies 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-eth-wire-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "snap",
  "thiserror",
  "tokio",
@@ -6399,16 +6399,16 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-chains",
  "alloy-genesis",
  "alloy-rlp",
  "bytes",
  "derive_more 1.0.0",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-codecs-derive 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-codecs-derive 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "thiserror",
 ]
 
@@ -6427,12 +6427,12 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-consensus-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-consensus-common 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "tracing",
 ]
 
@@ -6457,16 +6457,16 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-rlp",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-evm-ethereum 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-evm-ethereum 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "revm-primitives",
  "serde",
  "sha2 0.10.8",
@@ -6492,7 +6492,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -6532,19 +6532,19 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
- "reth-basic-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-evm-ethereum 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-basic-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-evm-ethereum 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "revm",
  "tracing",
 ]
@@ -6562,10 +6562,10 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "rayon",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "tempfile",
 ]
 
@@ -6590,18 +6590,18 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-eips",
  "auto_impl",
  "futures-util",
  "parking_lot 0.12.3",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "revm",
  "revm-primitives",
 ]
@@ -6627,18 +6627,18 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-eips",
  "alloy-sol-types",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-ethereum-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-ethereum-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "revm-primitives",
 ]
 
@@ -6681,16 +6681,16 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "derive_more 1.0.0",
  "nybbles",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "revm-primitives",
 ]
 
@@ -6709,11 +6709,11 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
- "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "revm",
 ]
 
@@ -6747,26 +6747,26 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "eyre",
  "futures",
  "metrics",
- "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-exex-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-node-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-node-core 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-stages-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-tracing 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-exex-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-node-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-node-core 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-stages-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-tracing 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "tokio",
  "tokio-util",
 ]
@@ -6774,30 +6774,30 @@ dependencies = [
 [[package]]
 name = "reth-exex-test-utils"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "eyre",
  "futures-util",
  "rand 0.8.5",
- "reth-blockchain-tree 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-db-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-exex 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-network 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-node-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-node-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-node-core 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-node-ethereum 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-blockchain-tree 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-db-common 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-exex 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-network 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-node-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-node-builder 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-node-core 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-node-ethereum 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "thiserror",
  "tokio",
 ]
@@ -6815,10 +6815,10 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-primitives",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
 ]
 
 [[package]]
@@ -6834,7 +6834,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "serde",
  "serde_json",
@@ -6865,7 +6865,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6902,7 +6902,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "bitflags 2.6.0",
  "byteorder",
@@ -6910,7 +6910,7 @@ dependencies = [
  "derive_more 1.0.0",
  "indexmap 2.4.0",
  "parking_lot 0.12.3",
- "reth-mdbx-sys 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-mdbx-sys 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "thiserror",
  "tracing",
 ]
@@ -6927,7 +6927,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "bindgen",
  "cc",
@@ -6948,11 +6948,11 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "futures",
  "metrics",
- "reth-metrics-derive 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-metrics-derive 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "tokio",
  "tokio-util",
 ]
@@ -6971,7 +6971,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics-derive"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6990,7 +6990,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-primitives",
 ]
@@ -7010,7 +7010,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "futures-util",
  "reqwest",
@@ -7070,7 +7070,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-rlp",
  "aquamarine",
@@ -7084,25 +7084,25 @@ dependencies = [
  "parking_lot 0.12.3",
  "pin-project",
  "rand 0.8.5",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-discv4 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-discv5 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-dns-discovery 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-ecies 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-eth-wire 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-net-banlist 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-network-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-discv4 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-discv5 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-dns-discovery 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-ecies 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-eth-wire 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-net-banlist 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-network-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "rustc-hash 2.0.0",
  "schnellru",
  "secp256k1",
@@ -7141,7 +7141,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-admin",
@@ -7149,12 +7149,12 @@ dependencies = [
  "derive_more 1.0.0",
  "enr",
  "futures",
- "reth-eth-wire-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-network-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-eth-wire-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-network-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "serde",
  "thiserror",
  "tokio",
@@ -7182,17 +7182,17 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "auto_impl",
  "derive_more 1.0.0",
  "futures",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-eth-wire-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-network-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-eth-wire-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-network-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "tokio",
  "tracing",
 ]
@@ -7215,7 +7215,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7244,12 +7244,12 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "humantime-serde",
- "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-net-banlist 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-net-banlist 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "serde",
  "serde_json",
  "tracing",
@@ -7278,7 +7278,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -7286,7 +7286,7 @@ dependencies = [
  "derive_more 1.0.0",
  "lz4_flex",
  "memmap2",
- "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "serde",
  "sucds",
  "thiserror",
@@ -7315,19 +7315,19 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-eth-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-eth-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth)",
 ]
 
 [[package]]
@@ -7390,7 +7390,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-network",
  "aquamarine",
@@ -7398,47 +7398,47 @@ dependencies = [
  "fdlimit",
  "futures",
  "rayon",
- "reth-auto-seal-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-blockchain-tree 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-cli-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-consensus-debug-client 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-db-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-downloaders 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-engine-service 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-engine-tree 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-engine-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-exex 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-network 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-node-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-node-core 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-node-events 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-node-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-payload-validator 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-prune 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-engine-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-eth-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-layer 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-stages 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-static-file 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-tracing 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-auto-seal-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-blockchain-tree 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-cli-util 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-consensus-debug-client 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-db-common 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-downloaders 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-engine-service 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-engine-tree 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-engine-util 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-exex 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-network 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-node-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-node-core 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-node-events 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-node-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-payload-validator 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-prune 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-builder 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-engine-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-eth-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-layer 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-stages 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-static-file 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-tracing 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "secp256k1",
  "tokio",
  "tokio-stream",
@@ -7498,7 +7498,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-genesis",
  "alloy-rpc-types-engine",
@@ -7510,33 +7510,33 @@ dependencies = [
  "futures",
  "humantime",
  "rand 0.8.5",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "reth-cli",
- "reth-cli-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-consensus-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-discv4 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-discv5 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-net-nat 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-network 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-eth-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-eth-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-server-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-tracing 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-cli-util 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-consensus-common 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-discv4 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-discv5 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-net-nat 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-network 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-eth-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-eth-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-server-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-tracing 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "secp256k1",
  "serde",
  "serde_json",
@@ -7573,25 +7573,25 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "eyre",
- "reth-auto-seal-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-basic-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-ethereum-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-ethereum-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-evm-ethereum 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-network 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-node-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-node-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-tracing 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-auto-seal-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-basic-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-ethereum-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-ethereum-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-evm-ethereum 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-network 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-node-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-node-builder 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-tracing 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth)",
 ]
 
 [[package]]
@@ -7619,21 +7619,21 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-rpc-types-engine",
  "futures",
  "humantime",
  "pin-project",
- "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-network 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-prune 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-stages 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-static-file 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-network 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-prune 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-stages 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-static-file 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "tokio",
  "tracing",
 ]
@@ -7665,7 +7665,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "eyre",
  "http",
@@ -7675,10 +7675,10 @@ dependencies = [
  "metrics-process",
  "metrics-util",
  "procfs",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "tokio",
  "tower",
  "tracing",
@@ -7759,19 +7759,19 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "futures-util",
  "metrics",
  "pin-project",
- "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-ethereum-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-ethereum-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -7797,14 +7797,14 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
- "reth-chain-state 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-chain-state 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "serde",
  "thiserror",
  "tokio",
@@ -7824,12 +7824,12 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth)",
 ]
 
 [[package]]
@@ -7868,7 +7868,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7884,12 +7884,12 @@ dependencies = [
  "once_cell",
  "proptest",
  "rayon",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-static-file-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-static-file-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "revm-primitives",
  "secp256k1",
  "serde",
@@ -7922,7 +7922,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7936,7 +7936,7 @@ dependencies = [
  "modular-bitfield",
  "proptest",
  "proptest-arbitrary-interop",
- "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "revm-primitives",
  "roaring",
  "serde",
@@ -7983,7 +7983,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-rpc-types-engine",
  "auto_impl",
@@ -7993,26 +7993,26 @@ dependencies = [
  "once_cell",
  "parking_lot 0.12.3",
  "rayon",
- "reth-blockchain-tree-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-chain-state 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-nippy-jar 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-trie-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-blockchain-tree-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-chain-state 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-nippy-jar 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-trie-db 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "revm",
  "strum",
  "tokio",
@@ -8048,23 +8048,23 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-primitives",
  "itertools 0.13.0",
  "metrics",
  "rayon",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-exex-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-static-file-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-exex-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-static-file-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "rustc-hash 2.0.0",
  "thiserror",
  "tokio",
@@ -8088,13 +8088,13 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-primitives",
  "bytes",
  "derive_more 1.0.0",
  "modular-bitfield",
- "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "serde",
  "thiserror",
 ]
@@ -8117,15 +8117,15 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-consensus-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-consensus-common 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "revm",
 ]
 
@@ -8188,7 +8188,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-genesis",
@@ -8206,27 +8206,27 @@ dependencies = [
  "parking_lot 0.12.3",
  "pin-project",
  "rand 0.8.5",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-consensus-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-network-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-node-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-engine-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-eth-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-eth-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-server-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-consensus-common 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-network-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-node-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-engine-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-eth-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-eth-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-server-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "revm",
  "revm-inspectors",
  "revm-primitives",
@@ -8258,15 +8258,15 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-json-rpc",
  "jsonrpsee",
- "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-eth-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-eth-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
 ]
 
 [[package]]
@@ -8305,29 +8305,29 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "http",
  "jsonrpsee",
  "metrics",
  "pin-project",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-ipc 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-node-core 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-eth-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-eth-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-layer 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-server-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-ipc 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-node-core 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-eth-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-eth-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-layer 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-server-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "serde",
  "thiserror",
  "tower",
@@ -8366,25 +8366,25 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "async-trait",
  "jsonrpsee-core",
  "jsonrpsee-types",
  "metrics",
- "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "serde",
  "thiserror",
  "tokio",
@@ -8431,7 +8431,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-rpc",
@@ -8443,21 +8443,21 @@ dependencies = [
  "jsonrpsee",
  "jsonrpsee-types",
  "parking_lot 0.12.3",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-eth-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-server-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-eth-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-server-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "revm",
  "revm-inspectors",
  "revm-primitives",
@@ -8506,7 +8506,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-sol-types",
  "derive_more 1.0.0",
@@ -8515,21 +8515,21 @@ dependencies = [
  "jsonrpsee-types",
  "metrics",
  "rand 0.8.5",
- "reth-chain-state 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-server-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-chain-state 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-server-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "revm",
  "revm-inspectors",
  "revm-primitives",
@@ -8557,7 +8557,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -8586,15 +8586,15 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-primitives",
  "jsonrpsee-core",
  "jsonrpsee-types",
- "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "serde",
  "strum",
 ]
@@ -8622,7 +8622,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-types"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
@@ -8654,13 +8654,13 @@ dependencies = [
 [[package]]
 name = "reth-rpc-types-compat"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-rlp",
  "alloy-rpc-types",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth)",
 ]
 
 [[package]]
@@ -8700,32 +8700,32 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "futures-util",
  "itertools 0.13.0",
  "num-traits",
  "rayon",
- "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-etl 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-exex 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-prune 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-stages-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-trie-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-etl 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-exex 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-prune 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-stages-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-trie-db 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "thiserror",
  "tokio",
  "tracing",
@@ -8761,25 +8761,25 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-primitives",
  "aquamarine",
  "auto_impl",
  "futures-util",
  "metrics",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-prune 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-static-file 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-static-file-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-prune 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-static-file 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-static-file-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "thiserror",
  "tokio",
  "tracing",
@@ -8801,13 +8801,13 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-primitives",
  "bytes",
  "modular-bitfield",
- "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "serde",
 ]
 
@@ -8834,20 +8834,20 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-primitives",
  "parking_lot 0.12.3",
  "rayon",
- "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-nippy-jar 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-static-file-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-nippy-jar 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-static-file-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "tracing",
 ]
 
@@ -8866,7 +8866,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-primitives",
  "derive_more 1.0.0",
@@ -8893,17 +8893,17 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "auto_impl",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-db-models 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-db-models 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth)",
 ]
 
 [[package]]
@@ -8920,12 +8920,12 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-rlp",
  "derive_more 1.0.0",
- "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
 ]
 
 [[package]]
@@ -8949,7 +8949,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -8957,7 +8957,7 @@ dependencies = [
  "metrics",
  "pin-project",
  "rayon",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "thiserror",
  "tokio",
  "tracing",
@@ -8967,12 +8967,12 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
  "rand 0.8.5",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "secp256k1",
 ]
 
@@ -8989,7 +8989,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -9014,7 +9014,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "clap",
  "eyre",
@@ -9061,7 +9061,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-rlp",
  "aquamarine",
@@ -9072,15 +9072,15 @@ dependencies = [
  "parking_lot 0.12.3",
  "paste",
  "rand 0.8.5",
- "reth-chain-state 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-eth-wire-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-chain-state 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-eth-wire-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "revm",
  "rustc-hash 2.0.0",
  "schnellru",
@@ -9117,7 +9117,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-rlp",
  "auto_impl",
@@ -9125,12 +9125,12 @@ dependencies = [
  "itertools 0.13.0",
  "metrics",
  "rayon",
- "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "revm",
  "tracing",
  "triehash",
@@ -9159,7 +9159,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9173,8 +9173,8 @@ dependencies = [
  "itertools 0.13.0",
  "nybbles",
  "plain_hasher",
- "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "revm-primitives",
  "serde",
 ]
@@ -9206,7 +9206,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-rlp",
  "auto_impl",
@@ -9214,15 +9214,15 @@ dependencies = [
  "itertools 0.13.0",
  "metrics",
  "rayon",
- "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "revm",
  "tracing",
 ]
@@ -9254,22 +9254,22 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-rlp",
  "derive_more 1.0.0",
  "itertools 0.13.0",
  "metrics",
  "rayon",
- "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
- "reth-trie-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git)",
+ "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-trie-db 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "thiserror",
  "tokio",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3376,20 +3376,20 @@ dependencies = [
  "kakarot-pool",
  "once_cell",
  "reth",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-ethereum-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-exex 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-chainspec",
+ "reth-ethereum-engine-primitives",
+ "reth-execution-errors",
+ "reth-execution-types",
+ "reth-exex",
  "reth-exex-test-utils",
- "reth-node-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-node-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-node-ethereum 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-node-api",
+ "reth-node-builder",
+ "reth-node-ethereum",
+ "reth-primitives",
+ "reth-provider",
+ "reth-revm",
  "reth-testing-utils",
- "reth-tracing 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-tracing",
  "rusqlite",
  "serde",
  "serde_json",
@@ -3401,11 +3401,11 @@ name = "kakarot-node"
 version = "0.1.0"
 dependencies = [
  "kakarot-pool",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-ethereum-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-node-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-node-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-node-ethereum 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-chainspec",
+ "reth-ethereum-engine-primitives",
+ "reth-node-api",
+ "reth-node-builder",
+ "reth-node-ethereum",
  "serde",
 ]
 
@@ -3413,10 +3413,10 @@ dependencies = [
 name = "kakarot-pool"
 version = "0.1.0"
 dependencies = [
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-node-ethereum 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-chainspec",
+ "reth-node-ethereum",
+ "reth-primitives",
+ "reth-transaction-pool",
 ]
 
 [[package]]
@@ -3444,12 +3444,12 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "kakarot-node",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-cli-runner 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-node-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-node-core 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-chainspec",
+ "reth-cli-runner",
+ "reth-db",
+ "reth-node-builder",
+ "reth-node-core",
+ "reth-primitives",
  "tracing",
  "tracing-subscriber",
 ]
@@ -4976,61 +4976,61 @@ dependencies = [
  "itertools 0.13.0",
  "libc",
  "metrics-process",
- "reth-basic-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-blockchain-tree 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-basic-payload-builder",
+ "reth-beacon-consensus",
+ "reth-blockchain-tree",
+ "reth-chainspec",
  "reth-cli-commands",
- "reth-cli-runner 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-cli-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-consensus-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-db-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-downloaders 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-engine-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-ethereum-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-exex 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-node-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-node-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-node-core 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-node-ethereum 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-node-events 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-node-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-cli-runner",
+ "reth-cli-util",
+ "reth-config",
+ "reth-consensus",
+ "reth-consensus-common",
+ "reth-db",
+ "reth-db-api",
+ "reth-db-common",
+ "reth-downloaders",
+ "reth-engine-util",
+ "reth-errors",
+ "reth-ethereum-payload-builder",
+ "reth-evm",
+ "reth-execution-types",
+ "reth-exex",
+ "reth-fs-util",
+ "reth-network",
+ "reth-network-api",
+ "reth-network-p2p",
+ "reth-node-api",
+ "reth-node-builder",
+ "reth-node-core",
+ "reth-node-ethereum",
+ "reth-node-events",
+ "reth-node-metrics",
  "reth-optimism-primitives",
  "reth-optimism-rpc",
- "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-payload-validator 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-prune 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-eth-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-server-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-stages 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-stages-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-static-file 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-static-file-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-tracing 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-trie-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-payload-builder",
+ "reth-payload-primitives",
+ "reth-payload-validator",
+ "reth-primitives",
+ "reth-provider",
+ "reth-prune",
+ "reth-revm",
+ "reth-rpc",
+ "reth-rpc-api",
+ "reth-rpc-builder",
+ "reth-rpc-eth-types",
+ "reth-rpc-server-types",
+ "reth-rpc-types",
+ "reth-rpc-types-compat",
+ "reth-stages",
+ "reth-stages-api",
+ "reth-static-file",
+ "reth-static-file-types",
+ "reth-tasks",
+ "reth-tracing",
+ "reth-transaction-pool",
+ "reth-trie",
+ "reth-trie-db",
  "serde",
  "serde_json",
  "similar-asserts",
@@ -5047,51 +5047,23 @@ version = "1.0.6"
 source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "futures-util",
- "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-stages-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
-name = "reth-auto-seal-consensus"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "futures-util",
- "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-stages-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-beacon-consensus",
+ "reth-chainspec",
+ "reth-consensus",
+ "reth-engine-primitives",
+ "reth-evm",
+ "reth-execution-errors",
+ "reth-execution-types",
+ "reth-network-p2p",
+ "reth-network-peers",
+ "reth-primitives",
+ "reth-provider",
+ "reth-revm",
+ "reth-rpc-types",
+ "reth-stages-api",
+ "reth-tokio-util",
+ "reth-transaction-pool",
+ "reth-trie",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -5106,38 +5078,15 @@ dependencies = [
  "futures-core",
  "futures-util",
  "metrics",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "revm",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "reth-basic-payload-builder"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "alloy-rlp",
- "futures-core",
- "futures-util",
- "metrics",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-chainspec",
+ "reth-metrics",
+ "reth-payload-builder",
+ "reth-payload-primitives",
+ "reth-primitives",
+ "reth-provider",
+ "reth-revm",
+ "reth-tasks",
+ "reth-transaction-pool",
  "revm",
  "tokio",
  "tracing",
@@ -5151,59 +5100,25 @@ dependencies = [
  "futures",
  "itertools 0.13.0",
  "metrics",
- "reth-blockchain-tree-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-ethereum-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-payload-validator 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-prune 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-stages-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-static-file 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "schnellru",
- "thiserror",
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
-name = "reth-beacon-consensus"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "futures",
- "itertools 0.13.0",
- "metrics",
- "reth-blockchain-tree-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-ethereum-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-payload-validator 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-prune 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-stages-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-static-file 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-blockchain-tree-api",
+ "reth-chainspec",
+ "reth-db-api",
+ "reth-engine-primitives",
+ "reth-errors",
+ "reth-ethereum-consensus",
+ "reth-metrics",
+ "reth-network-p2p",
+ "reth-payload-builder",
+ "reth-payload-primitives",
+ "reth-payload-validator",
+ "reth-primitives",
+ "reth-provider",
+ "reth-prune",
+ "reth-rpc-types",
+ "reth-stages-api",
+ "reth-static-file",
+ "reth-tasks",
+ "reth-tokio-util",
  "schnellru",
  "thiserror",
  "tokio",
@@ -5220,55 +5135,24 @@ dependencies = [
  "linked_hash_set",
  "metrics",
  "parking_lot 0.12.3",
- "reth-blockchain-tree-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-stages-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-trie-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-trie-parallel 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "reth-blockchain-tree"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "aquamarine",
- "linked_hash_set",
- "metrics",
- "parking_lot 0.12.3",
- "reth-blockchain-tree-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-network 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-stages-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-trie-db 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-trie-parallel 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-blockchain-tree-api",
+ "reth-consensus",
+ "reth-db",
+ "reth-db-api",
+ "reth-evm",
+ "reth-execution-errors",
+ "reth-execution-types",
+ "reth-metrics",
+ "reth-network",
+ "reth-primitives",
+ "reth-provider",
+ "reth-prune-types",
+ "reth-revm",
+ "reth-stages-api",
+ "reth-storage-errors",
+ "reth-trie",
+ "reth-trie-db",
+ "reth-trie-parallel",
  "tokio",
  "tracing",
 ]
@@ -5278,22 +5162,10 @@ name = "reth-blockchain-tree-api"
 version = "1.0.6"
 source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "thiserror",
-]
-
-[[package]]
-name = "reth-blockchain-tree-api"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-consensus",
+ "reth-execution-errors",
+ "reth-primitives",
+ "reth-storage-errors",
  "thiserror",
 ]
 
@@ -5301,28 +5173,6 @@ dependencies = [
 name = "reth-chain-state"
 version = "1.0.6"
 source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
-dependencies = [
- "auto_impl",
- "derive_more 1.0.0",
- "metrics",
- "parking_lot 0.12.3",
- "pin-project",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
-name = "reth-chain-state"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-signer",
  "alloy-signer-local",
@@ -5332,13 +5182,13 @@ dependencies = [
  "parking_lot 0.12.3",
  "pin-project",
  "rand 0.8.5",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-chainspec",
+ "reth-errors",
+ "reth-execution-types",
+ "reth-metrics",
+ "reth-primitives",
+ "reth-storage-api",
+ "reth-trie",
  "revm",
  "tokio",
  "tokio-stream",
@@ -5358,41 +5208,11 @@ dependencies = [
  "auto_impl",
  "derive_more 1.0.0",
  "once_cell",
- "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-ethereum-forks",
+ "reth-network-peers",
+ "reth-primitives-traits",
+ "reth-trie-common",
  "serde_json",
-]
-
-[[package]]
-name = "reth-chainspec"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "alloy-chains",
- "alloy-eips",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-trie",
- "auto_impl",
- "derive_more 1.0.0",
- "once_cell",
- "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "serde_json",
-]
-
-[[package]]
-name = "reth-cli"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "clap",
- "eyre",
- "reth-cli-runner 1.0.6 (git+https://github.com/paradigmxyz/reth)",
 ]
 
 [[package]]
@@ -5411,36 +5231,36 @@ dependencies = [
  "human_bytes",
  "itertools 0.13.0",
  "ratatui",
- "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-cli-runner 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-cli-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-db-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-downloaders 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-ecies 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-eth-wire 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-exex 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-node-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-node-core 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-node-events 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-node-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-prune 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-stages 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-static-file 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-static-file-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-trie-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-beacon-consensus",
+ "reth-chainspec",
+ "reth-cli-runner",
+ "reth-cli-util",
+ "reth-config",
+ "reth-consensus",
+ "reth-db",
+ "reth-db-api",
+ "reth-db-common",
+ "reth-downloaders",
+ "reth-ecies",
+ "reth-eth-wire",
+ "reth-evm",
+ "reth-exex",
+ "reth-fs-util",
+ "reth-network",
+ "reth-network-p2p",
+ "reth-network-peers",
+ "reth-node-builder",
+ "reth-node-core",
+ "reth-node-events",
+ "reth-node-metrics",
+ "reth-primitives",
+ "reth-provider",
+ "reth-prune",
+ "reth-stages",
+ "reth-static-file",
+ "reth-static-file-types",
+ "reth-trie",
+ "reth-trie-db",
  "secp256k1",
  "serde",
  "serde_json",
@@ -5454,17 +5274,7 @@ name = "reth-cli-runner"
 version = "1.0.6"
 source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "reth-cli-runner"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-tasks",
  "tokio",
  "tracing",
 ]
@@ -5479,22 +5289,7 @@ dependencies = [
  "eyre",
  "libc",
  "rand 0.8.5",
- "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "secp256k1",
- "thiserror",
-]
-
-[[package]]
-name = "reth-cli-util"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "alloy-eips",
- "alloy-primitives",
- "eyre",
- "libc",
- "rand 0.8.5",
- "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-fs-util",
  "secp256k1",
  "thiserror",
 ]
@@ -5511,23 +5306,7 @@ dependencies = [
  "alloy-trie",
  "bytes",
  "modular-bitfield",
- "reth-codecs-derive 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "serde",
-]
-
-[[package]]
-name = "reth-codecs"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-trie",
- "bytes",
- "modular-bitfield",
- "reth-codecs-derive 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-codecs-derive",
  "serde",
 ]
 
@@ -5543,40 +5322,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-codecs-derive"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "convert_case 0.6.0",
- "proc-macro2",
- "quote",
- "syn 2.0.76",
-]
-
-[[package]]
 name = "reth-config"
 version = "1.0.6"
 source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "eyre",
  "humantime-serde",
- "reth-network-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "serde",
- "toml",
-]
-
-[[package]]
-name = "reth-config"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "eyre",
- "humantime-serde",
- "reth-network-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-network-types",
+ "reth-prune-types",
+ "reth-stages-types",
  "serde",
  "toml",
 ]
@@ -5588,17 +5342,7 @@ source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3ac
 dependencies = [
  "auto_impl",
  "derive_more 1.0.0",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
-]
-
-[[package]]
-name = "reth-consensus"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "auto_impl",
- "derive_more 1.0.0",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives",
 ]
 
 [[package]]
@@ -5606,19 +5350,9 @@ name = "reth-consensus-common"
 version = "1.0.6"
 source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
-]
-
-[[package]]
-name = "reth-consensus-common"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-chainspec",
+ "reth-consensus",
+ "reth-primitives",
 ]
 
 [[package]]
@@ -5633,35 +5367,12 @@ dependencies = [
  "eyre",
  "futures",
  "reqwest",
- "reth-node-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-node-core 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-tracing 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "ringbuffer",
- "serde",
- "tokio",
-]
-
-[[package]]
-name = "reth-consensus-debug-client"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-provider",
- "auto_impl",
- "eyre",
- "futures",
- "reqwest",
- "reth-node-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-node-core 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-builder 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-tracing 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-node-api",
+ "reth-node-core",
+ "reth-rpc-api",
+ "reth-rpc-builder",
+ "reth-rpc-types",
+ "reth-tracing",
  "ringbuffer",
  "serde",
  "tokio",
@@ -5678,48 +5389,18 @@ dependencies = [
  "metrics",
  "page_size",
  "paste",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-libmdbx 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-nippy-jar 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-tracing 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "rustc-hash 2.0.0",
- "serde",
- "strum",
- "sysinfo",
- "thiserror",
-]
-
-[[package]]
-name = "reth-db"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "bytes",
- "derive_more 1.0.0",
- "eyre",
- "metrics",
- "page_size",
- "paste",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-libmdbx 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-nippy-jar 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-tracing 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-db-api",
+ "reth-fs-util",
+ "reth-libmdbx",
+ "reth-metrics",
+ "reth-nippy-jar",
+ "reth-primitives",
+ "reth-primitives-traits",
+ "reth-prune-types",
+ "reth-stages-types",
+ "reth-storage-errors",
+ "reth-tracing",
+ "reth-trie-common",
  "rustc-hash 2.0.0",
  "serde",
  "strum",
@@ -5733,27 +5414,6 @@ name = "reth-db-api"
 version = "1.0.6"
 source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
- "bytes",
- "derive_more 1.0.0",
- "metrics",
- "modular-bitfield",
- "parity-scale-codec",
- "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-db-models 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "serde",
-]
-
-[[package]]
-name = "reth-db-api"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
  "arbitrary",
  "bytes",
  "derive_more 1.0.0",
@@ -5761,14 +5421,14 @@ dependencies = [
  "modular-bitfield",
  "parity-scale-codec",
  "proptest",
- "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-db-models 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-codecs",
+ "reth-db-models",
+ "reth-primitives",
+ "reth-primitives-traits",
+ "reth-prune-types",
+ "reth-stages-types",
+ "reth-storage-errors",
+ "reth-trie-common",
  "serde",
 ]
 
@@ -5780,44 +5440,18 @@ dependencies = [
  "alloy-genesis",
  "boyer-moore-magiclen",
  "eyre",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-etl 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-trie-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "serde",
- "serde_json",
- "thiserror",
- "tracing",
-]
-
-[[package]]
-name = "reth-db-common"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "alloy-genesis",
- "boyer-moore-magiclen",
- "eyre",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-etl 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-trie-db 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-chainspec",
+ "reth-codecs",
+ "reth-config",
+ "reth-db",
+ "reth-db-api",
+ "reth-etl",
+ "reth-fs-util",
+ "reth-primitives",
+ "reth-provider",
+ "reth-stages-types",
+ "reth-trie",
+ "reth-trie-db",
  "serde",
  "serde_json",
  "thiserror",
@@ -5829,24 +5463,12 @@ name = "reth-db-models"
 version = "1.0.6"
 source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
- "bytes",
- "modular-bitfield",
- "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "serde",
-]
-
-[[package]]
-name = "reth-db-models"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
  "arbitrary",
  "bytes",
  "modular-bitfield",
  "proptest",
- "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-codecs",
+ "reth-primitives",
  "serde",
 ]
 
@@ -5861,34 +5483,10 @@ dependencies = [
  "enr",
  "generic-array",
  "parking_lot 0.12.3",
- "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-net-banlist 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-net-nat 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "schnellru",
- "secp256k1",
- "serde",
- "thiserror",
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
-name = "reth-discv4"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "alloy-primitives",
- "alloy-rlp",
- "discv5",
- "enr",
- "generic-array",
- "parking_lot 0.12.3",
- "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-net-banlist 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-net-nat 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-ethereum-forks",
+ "reth-net-banlist",
+ "reth-net-nat",
+ "reth-network-peers",
  "schnellru",
  "secp256k1",
  "serde",
@@ -5912,34 +5510,10 @@ dependencies = [
  "itertools 0.13.0",
  "metrics",
  "rand 0.8.5",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "secp256k1",
- "thiserror",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "reth-discv5"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "alloy-primitives",
- "alloy-rlp",
- "derive_more 1.0.0",
- "discv5",
- "enr",
- "futures",
- "itertools 0.13.0",
- "metrics",
- "rand 0.8.5",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-chainspec",
+ "reth-ethereum-forks",
+ "reth-metrics",
+ "reth-network-peers",
  "secp256k1",
  "thiserror",
  "tokio",
@@ -5956,31 +5530,9 @@ dependencies = [
  "enr",
  "linked_hash_set",
  "parking_lot 0.12.3",
- "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "schnellru",
- "secp256k1",
- "thiserror",
- "tokio",
- "tokio-stream",
- "tracing",
- "trust-dns-resolver",
-]
-
-[[package]]
-name = "reth-dns-discovery"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "alloy-primitives",
- "data-encoding",
- "enr",
- "linked_hash_set",
- "parking_lot 0.12.3",
- "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-ethereum-forks",
+ "reth-network-peers",
+ "reth-tokio-util",
  "schnellru",
  "secp256k1",
  "thiserror",
@@ -6002,41 +5554,14 @@ dependencies = [
  "metrics",
  "pin-project",
  "rayon",
- "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "thiserror",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "reth-downloaders"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "alloy-rlp",
- "futures",
- "futures-util",
- "itertools 0.13.0",
- "metrics",
- "pin-project",
- "rayon",
- "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-config",
+ "reth-consensus",
+ "reth-metrics",
+ "reth-network-p2p",
+ "reth-network-peers",
+ "reth-primitives",
+ "reth-storage-api",
+ "reth-tasks",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -6063,38 +5588,7 @@ dependencies = [
  "hmac 0.12.1",
  "pin-project",
  "rand 0.8.5",
- "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "secp256k1",
- "sha2 0.10.8",
- "sha3",
- "thiserror",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "tracing",
- "typenum",
-]
-
-[[package]]
-name = "reth-ecies"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "aes",
- "alloy-primitives",
- "alloy-rlp",
- "block-padding",
- "byteorder",
- "cipher",
- "concat-kdf",
- "ctr",
- "digest 0.10.7",
- "futures",
- "generic-array",
- "hmac 0.12.1",
- "pin-project",
- "rand 0.8.5",
- "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-network-peers",
  "secp256k1",
  "sha2 0.10.8",
  "sha3",
@@ -6111,18 +5605,8 @@ name = "reth-engine-primitives"
 version = "1.0.6"
 source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "serde",
-]
-
-[[package]]
-name = "reth-engine-primitives"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-chainspec",
+ "reth-payload-primitives",
  "serde",
 ]
 
@@ -6133,44 +5617,20 @@ source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3ac
 dependencies = [
  "futures",
  "pin-project",
- "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-engine-tree 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-payload-validator 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-prune 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-stages-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "thiserror",
-]
-
-[[package]]
-name = "reth-engine-service"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "futures",
- "pin-project",
- "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-engine-tree 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-payload-validator 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-prune 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-stages-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-beacon-consensus",
+ "reth-chainspec",
+ "reth-consensus",
+ "reth-db-api",
+ "reth-engine-primitives",
+ "reth-engine-tree",
+ "reth-evm",
+ "reth-network-p2p",
+ "reth-payload-builder",
+ "reth-payload-validator",
+ "reth-provider",
+ "reth-prune",
+ "reth-stages-api",
+ "reth-tasks",
  "thiserror",
 ]
 
@@ -6181,64 +5641,29 @@ source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3ac
 dependencies = [
  "futures",
  "metrics",
- "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-blockchain-tree 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-blockchain-tree-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-chain-state 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-payload-validator 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-prune 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-stages-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "thiserror",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "reth-engine-tree"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "futures",
- "metrics",
- "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-blockchain-tree 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-blockchain-tree-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-chain-state 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-payload-validator 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-prune 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-stages-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-beacon-consensus",
+ "reth-blockchain-tree",
+ "reth-blockchain-tree-api",
+ "reth-chain-state",
+ "reth-consensus",
+ "reth-db",
+ "reth-db-api",
+ "reth-engine-primitives",
+ "reth-errors",
+ "reth-evm",
+ "reth-metrics",
+ "reth-network-p2p",
+ "reth-payload-builder",
+ "reth-payload-primitives",
+ "reth-payload-validator",
+ "reth-primitives",
+ "reth-provider",
+ "reth-prune",
+ "reth-revm",
+ "reth-rpc-types",
+ "reth-stages-api",
+ "reth-tasks",
+ "reth-trie",
  "thiserror",
  "tokio",
  "tracing",
@@ -6253,49 +5678,19 @@ dependencies = [
  "futures",
  "itertools 0.13.0",
  "pin-project",
- "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-payload-validator 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "revm-primitives",
- "serde",
- "serde_json",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "reth-engine-util"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "eyre",
- "futures",
- "itertools 0.13.0",
- "pin-project",
- "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-payload-validator 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-beacon-consensus",
+ "reth-engine-primitives",
+ "reth-errors",
+ "reth-ethereum-forks",
+ "reth-evm",
+ "reth-fs-util",
+ "reth-payload-validator",
+ "reth-primitives",
+ "reth-provider",
+ "reth-revm",
+ "reth-rpc-types",
+ "reth-rpc-types-compat",
+ "reth-trie",
  "revm-primitives",
  "serde",
  "serde_json",
@@ -6309,24 +5704,11 @@ name = "reth-errors"
 version = "1.0.6"
 source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
- "reth-blockchain-tree-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "thiserror",
-]
-
-[[package]]
-name = "reth-errors"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "reth-blockchain-tree-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-blockchain-tree-api",
+ "reth-consensus",
+ "reth-execution-errors",
+ "reth-fs-util",
+ "reth-storage-errors",
  "thiserror",
 ]
 
@@ -6340,38 +5722,13 @@ dependencies = [
  "derive_more 1.0.0",
  "futures",
  "pin-project",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-ecies 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-eth-wire-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "snap",
- "thiserror",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "reth-eth-wire"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "alloy-rlp",
- "bytes",
- "derive_more 1.0.0",
- "futures",
- "pin-project",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-ecies 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-eth-wire-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-chainspec",
+ "reth-codecs",
+ "reth-ecies",
+ "reth-eth-wire-types",
+ "reth-metrics",
+ "reth-network-peers",
+ "reth-primitives",
  "snap",
  "thiserror",
  "tokio",
@@ -6390,25 +5747,9 @@ dependencies = [
  "alloy-rlp",
  "bytes",
  "derive_more 1.0.0",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-codecs-derive 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "thiserror",
-]
-
-[[package]]
-name = "reth-eth-wire-types"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "alloy-chains",
- "alloy-genesis",
- "alloy-rlp",
- "bytes",
- "derive_more 1.0.0",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-codecs-derive 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-chainspec",
+ "reth-codecs-derive",
+ "reth-primitives",
  "thiserror",
 ]
 
@@ -6417,22 +5758,10 @@ name = "reth-ethereum-consensus"
 version = "1.0.6"
 source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-consensus-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "tracing",
-]
-
-[[package]]
-name = "reth-ethereum-consensus"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-consensus-common 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-chainspec",
+ "reth-consensus",
+ "reth-consensus-common",
+ "reth-primitives",
  "tracing",
 ]
 
@@ -6442,31 +5771,13 @@ version = "1.0.6"
 source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "alloy-rlp",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-evm-ethereum 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "revm-primitives",
- "serde",
- "sha2 0.10.8",
-]
-
-[[package]]
-name = "reth-ethereum-engine-primitives"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "alloy-rlp",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-evm-ethereum 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-chainspec",
+ "reth-engine-primitives",
+ "reth-evm-ethereum",
+ "reth-payload-primitives",
+ "reth-primitives",
+ "reth-rpc-types",
+ "reth-rpc-types-compat",
  "revm-primitives",
  "serde",
  "sha2 0.10.8",
@@ -6476,23 +5787,6 @@ dependencies = [
 name = "reth-ethereum-forks"
 version = "1.0.6"
 source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
-dependencies = [
- "alloy-chains",
- "alloy-primitives",
- "alloy-rlp",
- "auto_impl",
- "crc",
- "dyn-clone",
- "once_cell",
- "rustc-hash 2.0.0",
- "serde",
- "thiserror-no-std",
-]
-
-[[package]]
-name = "reth-ethereum-forks"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -6514,37 +5808,17 @@ name = "reth-ethereum-payload-builder"
 version = "1.0.6"
 source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
- "reth-basic-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-evm-ethereum 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "revm",
- "tracing",
-]
-
-[[package]]
-name = "reth-ethereum-payload-builder"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "reth-basic-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-evm-ethereum 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-basic-payload-builder",
+ "reth-errors",
+ "reth-evm",
+ "reth-evm-ethereum",
+ "reth-execution-types",
+ "reth-payload-builder",
+ "reth-primitives",
+ "reth-provider",
+ "reth-revm",
+ "reth-transaction-pool",
+ "reth-trie",
  "revm",
  "tracing",
 ]
@@ -6555,17 +5829,7 @@ version = "1.0.6"
 source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "rayon",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "tempfile",
-]
-
-[[package]]
-name = "reth-etl"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "rayon",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-db-api",
  "tempfile",
 ]
 
@@ -6573,35 +5837,17 @@ dependencies = [
 name = "reth-evm"
 version = "1.0.6"
 source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
-dependencies = [
- "alloy-eips",
- "auto_impl",
- "futures-util",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "revm",
- "revm-primitives",
-]
-
-[[package]]
-name = "reth-evm"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-eips",
  "auto_impl",
  "futures-util",
  "parking_lot 0.12.3",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-chainspec",
+ "reth-execution-errors",
+ "reth-execution-types",
+ "reth-primitives",
+ "reth-prune-types",
+ "reth-storage-errors",
  "revm",
  "revm-primitives",
 ]
@@ -6613,32 +5859,14 @@ source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3ac
 dependencies = [
  "alloy-eips",
  "alloy-sol-types",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-ethereum-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "revm-primitives",
-]
-
-[[package]]
-name = "reth-evm-ethereum"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "alloy-eips",
- "alloy-sol-types",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-ethereum-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-chainspec",
+ "reth-ethereum-consensus",
+ "reth-ethereum-forks",
+ "reth-evm",
+ "reth-execution-types",
+ "reth-primitives",
+ "reth-prune-types",
+ "reth-revm",
  "revm-primitives",
 ]
 
@@ -6647,15 +5875,15 @@ name = "reth-evm-optimism"
 version = "1.0.6"
 source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-chainspec",
+ "reth-ethereum-forks",
+ "reth-evm",
+ "reth-execution-errors",
+ "reth-execution-types",
  "reth-optimism-consensus",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-primitives",
+ "reth-prune-types",
+ "reth-revm",
  "revm",
  "revm-primitives",
  "thiserror",
@@ -6672,25 +5900,9 @@ dependencies = [
  "alloy-rlp",
  "derive_more 1.0.0",
  "nybbles",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "revm-primitives",
-]
-
-[[package]]
-name = "reth-execution-errors"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "derive_more 1.0.0",
- "nybbles",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-consensus",
+ "reth-prune-types",
+ "reth-storage-errors",
  "revm-primitives",
 ]
 
@@ -6699,25 +5911,14 @@ name = "reth-execution-types"
 version = "1.0.6"
 source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
- "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-execution-errors",
+ "reth-primitives",
+ "reth-trie",
  "revm",
  "serde",
 ]
 
 [[package]]
-name = "reth-execution-types"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "revm",
-]
-
-[[package]]
 name = "reth-exex"
 version = "1.0.6"
 source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
@@ -6725,48 +5926,21 @@ dependencies = [
  "eyre",
  "futures",
  "metrics",
- "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-exex-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-node-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-node-core 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-stages-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-tracing 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "tokio",
- "tokio-util",
-]
-
-[[package]]
-name = "reth-exex"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "eyre",
- "futures",
- "metrics",
- "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-exex-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-node-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-node-core 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-stages-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-tracing 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-config",
+ "reth-evm",
+ "reth-exex-types",
+ "reth-metrics",
+ "reth-node-api",
+ "reth-node-core",
+ "reth-payload-builder",
+ "reth-primitives",
+ "reth-primitives-traits",
+ "reth-provider",
+ "reth-prune-types",
+ "reth-revm",
+ "reth-stages-api",
+ "reth-tasks",
+ "reth-tracing",
  "tokio",
  "tokio-util",
 ]
@@ -6774,30 +5948,30 @@ dependencies = [
 [[package]]
 name = "reth-exex-test-utils"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "eyre",
  "futures-util",
  "rand 0.8.5",
- "reth-blockchain-tree 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-db-common 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-exex 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-network 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-node-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-node-builder 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-node-core 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-node-ethereum 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-blockchain-tree",
+ "reth-chainspec",
+ "reth-config",
+ "reth-consensus",
+ "reth-db",
+ "reth-db-common",
+ "reth-evm",
+ "reth-execution-types",
+ "reth-exex",
+ "reth-network",
+ "reth-node-api",
+ "reth-node-builder",
+ "reth-node-core",
+ "reth-node-ethereum",
+ "reth-payload-builder",
+ "reth-primitives",
+ "reth-provider",
+ "reth-tasks",
+ "reth-transaction-pool",
  "thiserror",
  "tokio",
 ]
@@ -6808,33 +5982,14 @@ version = "1.0.6"
 source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "alloy-primitives",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-provider",
  "serde",
-]
-
-[[package]]
-name = "reth-exex-types"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "alloy-primitives",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
 ]
 
 [[package]]
 name = "reth-fs-util"
 version = "1.0.6"
 source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
-dependencies = [
- "serde",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
-name = "reth-fs-util"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "serde",
  "serde_json",
@@ -6863,27 +6018,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-ipc"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "async-trait",
- "bytes",
- "futures",
- "futures-util",
- "interprocess",
- "jsonrpsee",
- "pin-project",
- "serde_json",
- "thiserror",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "tower",
- "tracing",
-]
-
-[[package]]
 name = "reth-libmdbx"
 version = "1.0.6"
 source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
@@ -6894,23 +6028,7 @@ dependencies = [
  "derive_more 1.0.0",
  "indexmap 2.4.0",
  "parking_lot 0.12.3",
- "reth-mdbx-sys 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "thiserror",
- "tracing",
-]
-
-[[package]]
-name = "reth-libmdbx"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "bitflags 2.6.0",
- "byteorder",
- "dashmap",
- "derive_more 1.0.0",
- "indexmap 2.4.0",
- "parking_lot 0.12.3",
- "reth-mdbx-sys 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-mdbx-sys",
  "thiserror",
  "tracing",
 ]
@@ -6925,34 +6043,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-mdbx-sys"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "bindgen",
- "cc",
-]
-
-[[package]]
 name = "reth-metrics"
 version = "1.0.6"
 source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "futures",
  "metrics",
- "reth-metrics-derive 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "tokio",
- "tokio-util",
-]
-
-[[package]]
-name = "reth-metrics"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "futures",
- "metrics",
- "reth-metrics-derive 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-metrics-derive",
  "tokio",
  "tokio-util",
 ]
@@ -6969,17 +6066,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-metrics-derive"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "proc-macro2",
- "quote",
- "regex",
- "syn 2.0.76",
-]
-
-[[package]]
 name = "reth-net-banlist"
 version = "1.0.6"
 source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
@@ -6988,29 +6074,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-net-banlist"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "alloy-primitives",
-]
-
-[[package]]
 name = "reth-net-nat"
 version = "1.0.6"
 source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
-dependencies = [
- "futures-util",
- "reqwest",
- "serde_with",
- "thiserror",
- "tokio",
-]
-
-[[package]]
-name = "reth-net-nat"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "futures-util",
  "reqwest",
@@ -7036,73 +6102,25 @@ dependencies = [
  "parking_lot 0.12.3",
  "pin-project",
  "rand 0.8.5",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-discv4 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-discv5 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-dns-discovery 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-ecies 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-eth-wire 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-net-banlist 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "rustc-hash 2.0.0",
- "schnellru",
- "secp256k1",
- "serde",
- "smallvec",
- "thiserror",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "reth-network"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "alloy-rlp",
- "aquamarine",
- "auto_impl",
- "derive_more 1.0.0",
- "discv5",
- "enr",
- "futures",
- "itertools 0.13.0",
- "metrics",
- "parking_lot 0.12.3",
- "pin-project",
- "rand 0.8.5",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-discv4 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-discv5 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-dns-discovery 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-ecies 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-eth-wire 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-net-banlist 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-network-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-chainspec",
+ "reth-consensus",
+ "reth-discv4",
+ "reth-discv5",
+ "reth-dns-discovery",
+ "reth-ecies",
+ "reth-eth-wire",
+ "reth-fs-util",
+ "reth-metrics",
+ "reth-net-banlist",
+ "reth-network-api",
+ "reth-network-p2p",
+ "reth-network-peers",
+ "reth-network-types",
+ "reth-primitives",
+ "reth-storage-api",
+ "reth-tasks",
+ "reth-tokio-util",
+ "reth-transaction-pool",
  "rustc-hash 2.0.0",
  "schnellru",
  "secp256k1",
@@ -7126,35 +6144,12 @@ dependencies = [
  "derive_more 1.0.0",
  "enr",
  "futures",
- "reth-eth-wire-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "serde",
- "thiserror",
- "tokio",
- "tokio-stream",
-]
-
-[[package]]
-name = "reth-network-api"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "alloy-primitives",
- "alloy-rpc-types-admin",
- "auto_impl",
- "derive_more 1.0.0",
- "enr",
- "futures",
- "reth-eth-wire-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-network-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-eth-wire-types",
+ "reth-ethereum-forks",
+ "reth-network-p2p",
+ "reth-network-peers",
+ "reth-network-types",
+ "reth-tokio-util",
  "serde",
  "thiserror",
  "tokio",
@@ -7169,30 +6164,12 @@ dependencies = [
  "auto_impl",
  "derive_more 1.0.0",
  "futures",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-eth-wire-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "reth-network-p2p"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "auto_impl",
- "derive_more 1.0.0",
- "futures",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-eth-wire-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-network-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-consensus",
+ "reth-eth-wire-types",
+ "reth-network-peers",
+ "reth-network-types",
+ "reth-primitives",
+ "reth-storage-errors",
  "tokio",
  "tracing",
 ]
@@ -7213,43 +6190,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-network-peers"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "alloy-primitives",
- "alloy-rlp",
- "enr",
- "secp256k1",
- "serde_with",
- "thiserror",
- "tokio",
- "url",
-]
-
-[[package]]
 name = "reth-network-types"
 version = "1.0.6"
 source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "humantime-serde",
- "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-net-banlist 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "serde",
- "serde_json",
- "tracing",
-]
-
-[[package]]
-name = "reth-network-types"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "humantime-serde",
- "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-net-banlist 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-ethereum-forks",
+ "reth-net-banlist",
+ "reth-network-peers",
  "serde",
  "serde_json",
  "tracing",
@@ -7267,26 +6215,7 @@ dependencies = [
  "lz4_flex",
  "memmap2",
  "ph",
- "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "serde",
- "sucds",
- "thiserror",
- "tracing",
- "zstd 0.13.2",
-]
-
-[[package]]
-name = "reth-nippy-jar"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "anyhow",
- "bincode 1.3.3",
- "cuckoofilter",
- "derive_more 1.0.0",
- "lz4_flex",
- "memmap2",
- "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-fs-util",
  "serde",
  "sucds",
  "thiserror",
@@ -7299,35 +6228,17 @@ name = "reth-node-api"
 version = "1.0.6"
 source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-eth-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
-]
-
-[[package]]
-name = "reth-node-api"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-eth-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-chainspec",
+ "reth-db-api",
+ "reth-engine-primitives",
+ "reth-evm",
+ "reth-network-api",
+ "reth-payload-builder",
+ "reth-payload-primitives",
+ "reth-provider",
+ "reth-rpc-eth-api",
+ "reth-tasks",
+ "reth-transaction-pool",
 ]
 
 [[package]]
@@ -7341,104 +6252,47 @@ dependencies = [
  "fdlimit",
  "futures",
  "rayon",
- "reth-auto-seal-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-blockchain-tree 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-cli-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-consensus-debug-client 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-db-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-downloaders 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-engine-service 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-engine-tree 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-engine-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-exex 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-node-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-node-core 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-node-events 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-node-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-payload-validator 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-prune 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-engine-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-eth-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-layer 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-stages 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-static-file 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-tracing 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "secp256k1",
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
-name = "reth-node-builder"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "alloy-network",
- "aquamarine",
- "eyre",
- "fdlimit",
- "futures",
- "rayon",
- "reth-auto-seal-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-blockchain-tree 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-cli-util 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-consensus-debug-client 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-db-common 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-downloaders 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-engine-service 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-engine-tree 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-engine-util 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-exex 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-network 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-node-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-node-core 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-node-events 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-node-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-payload-validator 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-prune 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-builder 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-engine-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-eth-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-layer 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-stages 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-static-file 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-tracing 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-auto-seal-consensus",
+ "reth-beacon-consensus",
+ "reth-blockchain-tree",
+ "reth-chainspec",
+ "reth-cli-util",
+ "reth-config",
+ "reth-consensus",
+ "reth-consensus-debug-client",
+ "reth-db",
+ "reth-db-api",
+ "reth-db-common",
+ "reth-downloaders",
+ "reth-engine-service",
+ "reth-engine-tree",
+ "reth-engine-util",
+ "reth-evm",
+ "reth-exex",
+ "reth-network",
+ "reth-network-api",
+ "reth-network-p2p",
+ "reth-node-api",
+ "reth-node-core",
+ "reth-node-events",
+ "reth-node-metrics",
+ "reth-payload-builder",
+ "reth-payload-validator",
+ "reth-primitives",
+ "reth-provider",
+ "reth-prune",
+ "reth-rpc",
+ "reth-rpc-builder",
+ "reth-rpc-engine-api",
+ "reth-rpc-eth-types",
+ "reth-rpc-layer",
+ "reth-rpc-types",
+ "reth-stages",
+ "reth-static-file",
+ "reth-tasks",
+ "reth-tokio-util",
+ "reth-tracing",
+ "reth-transaction-pool",
  "secp256k1",
  "tokio",
  "tokio-stream",
@@ -7460,83 +6314,32 @@ dependencies = [
  "futures",
  "humantime",
  "rand 0.8.5",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-cli-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-consensus-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-discv4 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-discv5 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-net-nat 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-eth-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-eth-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-server-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-tracing 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "secp256k1",
- "serde",
- "serde_json",
- "shellexpand",
- "toml",
- "tracing",
- "vergen",
-]
-
-[[package]]
-name = "reth-node-core"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "alloy-genesis",
- "alloy-rpc-types-engine",
- "clap",
- "const_format",
- "derive_more 1.0.0",
- "dirs-next",
- "eyre",
- "futures",
- "humantime",
- "rand 0.8.5",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-cli",
- "reth-cli-util 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-consensus-common 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-discv4 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-discv5 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-net-nat 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-network 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-eth-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-eth-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-server-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-tracing 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-chainspec",
+ "reth-cli-util",
+ "reth-config",
+ "reth-consensus-common",
+ "reth-db",
+ "reth-db-api",
+ "reth-discv4",
+ "reth-discv5",
+ "reth-fs-util",
+ "reth-net-nat",
+ "reth-network",
+ "reth-network-p2p",
+ "reth-network-peers",
+ "reth-primitives",
+ "reth-provider",
+ "reth-prune-types",
+ "reth-rpc-api",
+ "reth-rpc-eth-api",
+ "reth-rpc-eth-types",
+ "reth-rpc-server-types",
+ "reth-rpc-types",
+ "reth-rpc-types-compat",
+ "reth-stages-types",
+ "reth-storage-errors",
+ "reth-tracing",
+ "reth-transaction-pool",
  "secp256k1",
  "serde",
  "serde_json",
@@ -7552,46 +6355,22 @@ version = "1.0.6"
 source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "eyre",
- "reth-auto-seal-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-basic-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-ethereum-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-ethereum-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-evm-ethereum 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-node-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-node-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-tracing 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
-]
-
-[[package]]
-name = "reth-node-ethereum"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "eyre",
- "reth-auto-seal-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-basic-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-ethereum-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-ethereum-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-evm-ethereum 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-network 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-node-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-node-builder 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-tracing 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-auto-seal-consensus",
+ "reth-basic-payload-builder",
+ "reth-beacon-consensus",
+ "reth-chainspec",
+ "reth-consensus",
+ "reth-ethereum-engine-primitives",
+ "reth-ethereum-payload-builder",
+ "reth-evm-ethereum",
+ "reth-network",
+ "reth-node-api",
+ "reth-node-builder",
+ "reth-payload-builder",
+ "reth-provider",
+ "reth-rpc",
+ "reth-tracing",
+ "reth-transaction-pool",
 ]
 
 [[package]]
@@ -7603,37 +6382,15 @@ dependencies = [
  "futures",
  "humantime",
  "pin-project",
- "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-prune 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-stages 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-static-file 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "reth-node-events"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "alloy-rpc-types-engine",
- "futures",
- "humantime",
- "pin-project",
- "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-network 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-prune 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-stages 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-static-file 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-beacon-consensus",
+ "reth-network",
+ "reth-network-api",
+ "reth-primitives",
+ "reth-primitives-traits",
+ "reth-provider",
+ "reth-prune",
+ "reth-stages",
+ "reth-static-file",
  "tokio",
  "tracing",
 ]
@@ -7651,34 +6408,11 @@ dependencies = [
  "metrics-process",
  "metrics-util",
  "procfs",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-db-api",
+ "reth-metrics",
+ "reth-provider",
+ "reth-tasks",
  "tikv-jemalloc-ctl",
- "tokio",
- "tower",
- "tracing",
- "vergen",
-]
-
-[[package]]
-name = "reth-node-metrics"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "eyre",
- "http",
- "jsonrpsee",
- "metrics",
- "metrics-exporter-prometheus",
- "metrics-process",
- "metrics-util",
- "procfs",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
  "tokio",
  "tower",
  "tracing",
@@ -7690,10 +6424,10 @@ name = "reth-optimism-consensus"
 version = "1.0.6"
 source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-consensus-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-chainspec",
+ "reth-consensus",
+ "reth-consensus-common",
+ "reth-primitives",
  "tracing",
 ]
 
@@ -7712,21 +6446,21 @@ dependencies = [
  "op-alloy-network",
  "parking_lot 0.12.3",
  "reqwest",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-chainspec",
+ "reth-evm",
  "reth-evm-optimism",
- "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-node-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-node-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-eth-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-eth-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-server-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-network-api",
+ "reth-node-api",
+ "reth-node-builder",
+ "reth-primitives",
+ "reth-provider",
+ "reth-rpc",
+ "reth-rpc-eth-api",
+ "reth-rpc-eth-types",
+ "reth-rpc-server-types",
+ "reth-rpc-types",
+ "reth-tasks",
+ "reth-transaction-pool",
  "revm",
  "serde_json",
  "thiserror",
@@ -7742,36 +6476,14 @@ dependencies = [
  "futures-util",
  "metrics",
  "pin-project",
- "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-ethereum-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "thiserror",
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
-name = "reth-payload-builder"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "futures-util",
- "metrics",
- "pin-project",
- "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-ethereum-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-errors",
+ "reth-ethereum-engine-primitives",
+ "reth-metrics",
+ "reth-payload-primitives",
+ "reth-primitives",
+ "reth-provider",
+ "reth-rpc-types",
+ "reth-transaction-pool",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -7783,28 +6495,12 @@ name = "reth-payload-primitives"
 version = "1.0.6"
 source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
- "reth-chain-state 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "serde",
- "thiserror",
- "tokio",
-]
-
-[[package]]
-name = "reth-payload-primitives"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "reth-chain-state 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-chain-state",
+ "reth-chainspec",
+ "reth-errors",
+ "reth-primitives",
+ "reth-rpc-types",
+ "reth-transaction-pool",
  "serde",
  "thiserror",
  "tokio",
@@ -7815,21 +6511,10 @@ name = "reth-payload-validator"
 version = "1.0.6"
 source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
-]
-
-[[package]]
-name = "reth-payload-validator"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-chainspec",
+ "reth-primitives",
+ "reth-rpc-types",
+ "reth-rpc-types-compat",
 ]
 
 [[package]]
@@ -7844,37 +6529,6 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types",
  "alloy-serde",
- "bytes",
- "c-kzg",
- "derive_more 1.0.0",
- "k256",
- "modular-bitfield",
- "once_cell",
- "op-alloy-rpc-types",
- "rayon",
- "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-static-file-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "revm-primitives",
- "secp256k1",
- "serde",
- "tempfile",
- "thiserror",
- "zstd 0.13.2",
-]
-
-[[package]]
-name = "reth-primitives"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-rlp",
  "arbitrary",
  "bytes",
  "c-kzg",
@@ -7882,14 +6536,15 @@ dependencies = [
  "k256",
  "modular-bitfield",
  "once_cell",
+ "op-alloy-rpc-types",
  "proptest",
  "rayon",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-ethereum-forks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-static-file-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-chainspec",
+ "reth-codecs",
+ "reth-ethereum-forks",
+ "reth-primitives-traits",
+ "reth-static-file-types",
+ "reth-trie-common",
  "revm-primitives",
  "secp256k1",
  "serde",
@@ -7909,26 +6564,6 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-eth",
- "byteorder",
- "bytes",
- "derive_more 1.0.0",
- "modular-bitfield",
- "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "revm-primitives",
- "roaring",
- "serde",
-]
-
-[[package]]
-name = "reth-primitives-traits"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-rlp",
  "arbitrary",
  "byteorder",
  "bytes",
@@ -7936,7 +6571,7 @@ dependencies = [
  "modular-bitfield",
  "proptest",
  "proptest-arbitrary-interop",
- "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-codecs",
  "revm-primitives",
  "roaring",
  "serde",
@@ -7946,44 +6581,6 @@ dependencies = [
 name = "reth-provider"
 version = "1.0.6"
 source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
-dependencies = [
- "alloy-rpc-types-engine",
- "auto_impl",
- "dashmap",
- "itertools 0.13.0",
- "metrics",
- "parking_lot 0.12.3",
- "rayon",
- "reth-blockchain-tree-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-chain-state 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-nippy-jar 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-trie-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "revm",
- "strum",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "reth-provider"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-rpc-types-engine",
  "auto_impl",
@@ -7993,26 +6590,26 @@ dependencies = [
  "once_cell",
  "parking_lot 0.12.3",
  "rayon",
- "reth-blockchain-tree-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-chain-state 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-nippy-jar 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-trie-db 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-blockchain-tree-api",
+ "reth-chain-state",
+ "reth-chainspec",
+ "reth-codecs",
+ "reth-db",
+ "reth-db-api",
+ "reth-errors",
+ "reth-evm",
+ "reth-execution-types",
+ "reth-fs-util",
+ "reth-metrics",
+ "reth-network-p2p",
+ "reth-nippy-jar",
+ "reth-primitives",
+ "reth-prune-types",
+ "reth-stages-types",
+ "reth-storage-api",
+ "reth-storage-errors",
+ "reth-trie",
+ "reth-trie-db",
  "revm",
  "strum",
  "tokio",
@@ -8028,43 +6625,17 @@ dependencies = [
  "itertools 0.13.0",
  "metrics",
  "rayon",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-exex-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-static-file-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "rustc-hash 2.0.0",
- "thiserror",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "reth-prune"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "alloy-primitives",
- "itertools 0.13.0",
- "metrics",
- "rayon",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-exex-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-static-file-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-chainspec",
+ "reth-config",
+ "reth-db",
+ "reth-db-api",
+ "reth-errors",
+ "reth-exex-types",
+ "reth-metrics",
+ "reth-provider",
+ "reth-prune-types",
+ "reth-static-file-types",
+ "reth-tokio-util",
  "rustc-hash 2.0.0",
  "thiserror",
  "tokio",
@@ -8080,21 +6651,7 @@ dependencies = [
  "bytes",
  "derive_more 1.0.0",
  "modular-bitfield",
- "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "reth-prune-types"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "alloy-primitives",
- "bytes",
- "derive_more 1.0.0",
- "modular-bitfield",
- "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-codecs",
  "serde",
  "thiserror",
 ]
@@ -8104,28 +6661,13 @@ name = "reth-revm"
 version = "1.0.6"
 source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-consensus-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "revm",
-]
-
-[[package]]
-name = "reth-revm"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-consensus-common 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-chainspec",
+ "reth-consensus-common",
+ "reth-execution-errors",
+ "reth-primitives",
+ "reth-prune-types",
+ "reth-storage-api",
+ "reth-storage-errors",
  "revm",
 ]
 
@@ -8150,83 +6692,27 @@ dependencies = [
  "parking_lot 0.12.3",
  "pin-project",
  "rand 0.8.5",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-consensus-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-node-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-engine-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-eth-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-eth-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-server-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "revm",
- "revm-inspectors",
- "revm-primitives",
- "secp256k1",
- "serde",
- "serde_json",
- "thiserror",
- "tokio",
- "tokio-stream",
- "tower",
- "tracing",
- "tracing-futures",
-]
-
-[[package]]
-name = "reth-rpc"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "alloy-dyn-abi",
- "alloy-genesis",
- "alloy-network",
- "alloy-primitives",
- "alloy-rlp",
- "async-trait",
- "derive_more 1.0.0",
- "futures",
- "http",
- "http-body",
- "hyper",
- "jsonrpsee",
- "jsonwebtoken",
- "parking_lot 0.12.3",
- "pin-project",
- "rand 0.8.5",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-consensus-common 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-network-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-node-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-engine-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-eth-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-eth-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-server-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-chainspec",
+ "reth-consensus-common",
+ "reth-errors",
+ "reth-evm",
+ "reth-network-api",
+ "reth-network-peers",
+ "reth-network-types",
+ "reth-node-api",
+ "reth-primitives",
+ "reth-provider",
+ "reth-revm",
+ "reth-rpc-api",
+ "reth-rpc-engine-api",
+ "reth-rpc-eth-api",
+ "reth-rpc-eth-types",
+ "reth-rpc-server-types",
+ "reth-rpc-types",
+ "reth-rpc-types-compat",
+ "reth-tasks",
+ "reth-transaction-pool",
+ "reth-trie",
  "revm",
  "revm-inspectors",
  "revm-primitives",
@@ -8248,25 +6734,11 @@ source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3ac
 dependencies = [
  "alloy-json-rpc",
  "jsonrpsee",
- "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-eth-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
-]
-
-[[package]]
-name = "reth-rpc-api"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "alloy-json-rpc",
- "jsonrpsee",
- "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-network-peers 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-eth-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-engine-primitives",
+ "reth-network-peers",
+ "reth-primitives",
+ "reth-rpc-eth-api",
+ "reth-rpc-types",
 ]
 
 [[package]]
@@ -8278,56 +6750,23 @@ dependencies = [
  "jsonrpsee",
  "metrics",
  "pin-project",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-ipc 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-node-core 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-eth-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-eth-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-layer 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-server-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "serde",
- "thiserror",
- "tower",
- "tower-http",
- "tracing",
-]
-
-[[package]]
-name = "reth-rpc-builder"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "http",
- "jsonrpsee",
- "metrics",
- "pin-project",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-ipc 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-node-core 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-eth-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-eth-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-layer 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-server-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-chainspec",
+ "reth-engine-primitives",
+ "reth-evm",
+ "reth-ipc",
+ "reth-metrics",
+ "reth-network-api",
+ "reth-node-core",
+ "reth-provider",
+ "reth-rpc",
+ "reth-rpc-api",
+ "reth-rpc-eth-api",
+ "reth-rpc-eth-types",
+ "reth-rpc-layer",
+ "reth-rpc-server-types",
+ "reth-rpc-types",
+ "reth-tasks",
+ "reth-transaction-pool",
  "serde",
  "thiserror",
  "tower",
@@ -8344,47 +6783,19 @@ dependencies = [
  "jsonrpsee-core",
  "jsonrpsee-types",
  "metrics",
- "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "serde",
- "thiserror",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "reth-rpc-engine-api"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "async-trait",
- "jsonrpsee-core",
- "jsonrpsee-types",
- "metrics",
- "reth-beacon-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-engine-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-payload-builder 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-payload-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-beacon-consensus",
+ "reth-chainspec",
+ "reth-engine-primitives",
+ "reth-evm",
+ "reth-metrics",
+ "reth-payload-builder",
+ "reth-payload-primitives",
+ "reth-primitives",
+ "reth-rpc-api",
+ "reth-rpc-types",
+ "reth-rpc-types-compat",
+ "reth-storage-api",
+ "reth-tasks",
  "serde",
  "thiserror",
  "tokio",
@@ -8406,58 +6817,21 @@ dependencies = [
  "jsonrpsee",
  "jsonrpsee-types",
  "parking_lot 0.12.3",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-eth-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-server-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "revm",
- "revm-inspectors",
- "revm-primitives",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "reth-rpc-eth-api"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "alloy-dyn-abi",
- "alloy-json-rpc",
- "alloy-network",
- "async-trait",
- "auto_impl",
- "dyn-clone",
- "futures",
- "jsonrpsee",
- "jsonrpsee-types",
- "parking_lot 0.12.3",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-eth-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-server-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-chainspec",
+ "reth-errors",
+ "reth-evm",
+ "reth-execution-types",
+ "reth-network-api",
+ "reth-primitives",
+ "reth-provider",
+ "reth-revm",
+ "reth-rpc-eth-types",
+ "reth-rpc-server-types",
+ "reth-rpc-types",
+ "reth-rpc-types-compat",
+ "reth-tasks",
+ "reth-transaction-pool",
+ "reth-trie",
  "revm",
  "revm-inspectors",
  "revm-primitives",
@@ -8477,59 +6851,21 @@ dependencies = [
  "jsonrpsee-types",
  "metrics",
  "rand 0.8.5",
- "reth-chain-state 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-server-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "revm",
- "revm-inspectors",
- "revm-primitives",
- "schnellru",
- "serde",
- "thiserror",
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
-name = "reth-rpc-eth-types"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "alloy-sol-types",
- "derive_more 1.0.0",
- "futures",
- "jsonrpsee-core",
- "jsonrpsee-types",
- "metrics",
- "rand 0.8.5",
- "reth-chain-state 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-server-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-types-compat 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-transaction-pool 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-chain-state",
+ "reth-chainspec",
+ "reth-errors",
+ "reth-evm",
+ "reth-execution-types",
+ "reth-metrics",
+ "reth-primitives",
+ "reth-revm",
+ "reth-rpc-server-types",
+ "reth-rpc-types",
+ "reth-rpc-types-compat",
+ "reth-storage-api",
+ "reth-tasks",
+ "reth-transaction-pool",
+ "reth-trie",
  "revm",
  "revm-inspectors",
  "revm-primitives",
@@ -8555,19 +6891,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-rpc-layer"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "alloy-rpc-types-engine",
- "http",
- "jsonrpsee-http-client",
- "pin-project",
- "tower",
- "tracing",
-]
-
-[[package]]
 name = "reth-rpc-server-types"
 version = "1.0.6"
 source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
@@ -8575,26 +6898,10 @@ dependencies = [
  "alloy-primitives",
  "jsonrpsee-core",
  "jsonrpsee-types",
- "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "serde",
- "strum",
-]
-
-[[package]]
-name = "reth-rpc-server-types"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "alloy-primitives",
- "jsonrpsee-core",
- "jsonrpsee-types",
- "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-network-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-errors",
+ "reth-network-api",
+ "reth-primitives",
+ "reth-rpc-types",
  "serde",
  "strum",
 ]
@@ -8620,47 +6927,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-rpc-types"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "alloy-primitives",
- "alloy-rpc-types",
- "alloy-rpc-types-admin",
- "alloy-rpc-types-anvil",
- "alloy-rpc-types-beacon",
- "alloy-rpc-types-engine",
- "alloy-rpc-types-mev",
- "alloy-rpc-types-trace",
- "alloy-rpc-types-txpool",
- "alloy-serde",
- "jsonrpsee-types",
- "op-alloy-rpc-types",
- "op-alloy-rpc-types-engine",
-]
-
-[[package]]
 name = "reth-rpc-types-compat"
 version = "1.0.6"
 source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "alloy-rlp",
  "alloy-rpc-types",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
-]
-
-[[package]]
-name = "reth-rpc-types-compat"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "alloy-rlp",
- "alloy-rpc-types",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-rpc-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives",
+ "reth-rpc-types",
+ "reth-trie-common",
 ]
 
 [[package]]
@@ -8672,60 +6947,26 @@ dependencies = [
  "itertools 0.13.0",
  "num-traits",
  "rayon",
- "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-etl 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-exex 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-prune 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-stages-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-trie-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "thiserror",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "reth-stages"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "futures-util",
- "itertools 0.13.0",
- "num-traits",
- "rayon",
- "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-config 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-etl 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-evm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-exex 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-prune 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-revm 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-stages-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-trie-db 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-codecs",
+ "reth-config",
+ "reth-consensus",
+ "reth-db",
+ "reth-db-api",
+ "reth-etl",
+ "reth-evm",
+ "reth-execution-types",
+ "reth-exex",
+ "reth-network-p2p",
+ "reth-primitives",
+ "reth-primitives-traits",
+ "reth-provider",
+ "reth-prune",
+ "reth-prune-types",
+ "reth-revm",
+ "reth-stages-api",
+ "reth-storage-errors",
+ "reth-trie",
+ "reth-trie-db",
  "thiserror",
  "tokio",
  "tracing",
@@ -8741,45 +6982,18 @@ dependencies = [
  "auto_impl",
  "futures-util",
  "metrics",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-prune 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-static-file 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-static-file-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "thiserror",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "reth-stages-api"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "alloy-primitives",
- "aquamarine",
- "auto_impl",
- "futures-util",
- "metrics",
- "reth-consensus 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-network-p2p 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-prune 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-static-file 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-static-file-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-consensus",
+ "reth-db-api",
+ "reth-errors",
+ "reth-metrics",
+ "reth-network-p2p",
+ "reth-primitives-traits",
+ "reth-provider",
+ "reth-prune",
+ "reth-stages-types",
+ "reth-static-file",
+ "reth-static-file-types",
+ "reth-tokio-util",
  "thiserror",
  "tokio",
  "tracing",
@@ -8793,21 +7007,8 @@ dependencies = [
  "alloy-primitives",
  "bytes",
  "modular-bitfield",
- "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "serde",
-]
-
-[[package]]
-name = "reth-stages-types"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "alloy-primitives",
- "bytes",
- "modular-bitfield",
- "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-codecs",
+ "reth-trie-common",
  "serde",
 ]
 
@@ -8819,35 +7020,15 @@ dependencies = [
  "alloy-primitives",
  "parking_lot 0.12.3",
  "rayon",
- "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-nippy-jar 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-static-file-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "tracing",
-]
-
-[[package]]
-name = "reth-static-file"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "alloy-primitives",
- "parking_lot 0.12.3",
- "rayon",
- "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-nippy-jar 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-static-file-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-tokio-util 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-db",
+ "reth-db-api",
+ "reth-nippy-jar",
+ "reth-provider",
+ "reth-prune-types",
+ "reth-stages-types",
+ "reth-static-file-types",
+ "reth-storage-errors",
+ "reth-tokio-util",
  "tracing",
 ]
 
@@ -8864,46 +7045,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-static-file-types"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "alloy-primitives",
- "derive_more 1.0.0",
- "serde",
- "strum",
-]
-
-[[package]]
 name = "reth-storage-api"
 version = "1.0.6"
 source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "auto_impl",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-db-models 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
-]
-
-[[package]]
-name = "reth-storage-api"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "auto_impl",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-db-models 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-prune-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-chainspec",
+ "reth-db-models",
+ "reth-execution-types",
+ "reth-primitives",
+ "reth-prune-types",
+ "reth-stages-types",
+ "reth-storage-errors",
+ "reth-trie",
 ]
 
 [[package]]
@@ -8913,19 +7067,8 @@ source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3ac
 dependencies = [
  "alloy-rlp",
  "derive_more 1.0.0",
- "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
-]
-
-[[package]]
-name = "reth-storage-errors"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "alloy-rlp",
- "derive_more 1.0.0",
- "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-fs-util",
+ "reth-primitives",
 ]
 
 [[package]]
@@ -8939,25 +7082,7 @@ dependencies = [
  "metrics",
  "pin-project",
  "rayon",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "thiserror",
- "tokio",
- "tracing",
- "tracing-futures",
-]
-
-[[package]]
-name = "reth-tasks"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "auto_impl",
- "dyn-clone",
- "futures-util",
- "metrics",
- "pin-project",
- "rayon",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-metrics",
  "thiserror",
  "tokio",
  "tracing",
@@ -8967,12 +7092,12 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
  "rand 0.8.5",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-primitives",
  "secp256k1",
 ]
 
@@ -8987,16 +7112,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-tokio-util"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
 name = "reth-tracing"
 version = "1.0.6"
 source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
@@ -9012,56 +7127,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-tracing"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "clap",
- "eyre",
- "rolling-file",
- "tracing",
- "tracing-appender",
- "tracing-journald",
- "tracing-logfmt",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "reth-transaction-pool"
 version = "1.0.6"
 source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
-dependencies = [
- "alloy-rlp",
- "aquamarine",
- "auto_impl",
- "bitflags 2.6.0",
- "futures-util",
- "metrics",
- "parking_lot 0.12.3",
- "reth-chain-state 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-eth-wire-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "revm",
- "rustc-hash 2.0.0",
- "schnellru",
- "serde",
- "smallvec",
- "thiserror",
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
-name = "reth-transaction-pool"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
 dependencies = [
  "alloy-rlp",
  "aquamarine",
@@ -9072,15 +7140,15 @@ dependencies = [
  "parking_lot 0.12.3",
  "paste",
  "rand 0.8.5",
- "reth-chain-state 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-chainspec 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-eth-wire-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-execution-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-fs-util 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-storage-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-chain-state",
+ "reth-chainspec",
+ "reth-eth-wire-types",
+ "reth-execution-types",
+ "reth-fs-util",
+ "reth-metrics",
+ "reth-primitives",
+ "reth-storage-api",
+ "reth-tasks",
  "revm",
  "rustc-hash 2.0.0",
  "schnellru",
@@ -9103,35 +7171,14 @@ dependencies = [
  "itertools 0.13.0",
  "metrics",
  "rayon",
- "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
+ "reth-execution-errors",
+ "reth-metrics",
+ "reth-primitives",
+ "reth-stages-types",
+ "reth-storage-errors",
+ "reth-trie-common",
  "revm",
  "serde",
- "tracing",
-]
-
-[[package]]
-name = "reth-trie"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "alloy-rlp",
- "auto_impl",
- "derive_more 1.0.0",
- "itertools 0.13.0",
- "metrics",
- "rayon",
- "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "revm",
  "tracing",
  "triehash",
 ]
@@ -9146,26 +7193,6 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-trie",
- "bytes",
- "derive_more 1.0.0",
- "itertools 0.13.0",
- "nybbles",
- "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "revm-primitives",
- "serde",
-]
-
-[[package]]
-name = "reth-trie-common"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "alloy-consensus",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-trie",
  "arbitrary",
  "bytes",
  "derive_more 1.0.0",
@@ -9173,8 +7200,8 @@ dependencies = [
  "itertools 0.13.0",
  "nybbles",
  "plain_hasher",
- "reth-codecs 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives-traits 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-codecs",
+ "reth-primitives-traits",
  "revm-primitives",
  "serde",
 ]
@@ -9190,39 +7217,15 @@ dependencies = [
  "itertools 0.13.0",
  "metrics",
  "rayon",
- "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "revm",
- "tracing",
-]
-
-[[package]]
-name = "reth-trie-db"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "alloy-rlp",
- "auto_impl",
- "derive_more 1.0.0",
- "itertools 0.13.0",
- "metrics",
- "rayon",
- "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-stages-types 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-storage-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-trie-common 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-db",
+ "reth-db-api",
+ "reth-execution-errors",
+ "reth-metrics",
+ "reth-primitives",
+ "reth-stages-types",
+ "reth-storage-errors",
+ "reth-trie",
+ "reth-trie-common",
  "revm",
  "tracing",
 ]
@@ -9237,39 +7240,15 @@ dependencies = [
  "itertools 0.13.0",
  "metrics",
  "rayon",
- "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "reth-trie-db 1.0.6 (git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6)",
- "thiserror",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "reth-trie-parallel"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth#e18a46d0a59f776464c0c6905c5e7ef371bc06e3"
-dependencies = [
- "alloy-rlp",
- "derive_more 1.0.0",
- "itertools 0.13.0",
- "metrics",
- "rayon",
- "reth-db 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-db-api 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-execution-errors 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-metrics 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-primitives 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-provider 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-tasks 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-trie 1.0.6 (git+https://github.com/paradigmxyz/reth)",
- "reth-trie-db 1.0.6 (git+https://github.com/paradigmxyz/reth)",
+ "reth-db",
+ "reth-db-api",
+ "reth-execution-errors",
+ "reth-metrics",
+ "reth-primitives",
+ "reth-provider",
+ "reth-tasks",
+ "reth-trie",
+ "reth-trie-db",
  "thiserror",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,12 +52,11 @@ reth-revm = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.0.6" }
 reth-execution-errors = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.0.6" }
 reth-provider = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.0.6" }
 reth = { git = "https://github.com/paradigmxyz/reth", tag = "v1.0.6" }
+reth-exex-test-utils = { git = "https://github.com/paradigmxyz/reth", tag = "v1.0.6" }
+reth-testing-utils = { git = "https://github.com/paradigmxyz/reth", tag = "v1.0.6" }
 
 serde = { version = "1.0", default-features = false }
 eyre = "0.6"
 once_cell = "1"
 serde_json = "1"
 tokio = { version = "1.0", features = ["full"] }
-
-reth-exex-test-utils = { git = "https://github.com/paradigmxyz/reth" }
-reth-testing-utils = { git = "https://github.com/paradigmxyz/reth" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,20 +38,20 @@ kakarot-pool = { path = "crates/pool" }
 kakarot-exex = { path = "crates/exex" }
 
 # Reth
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth.git" }
-reth-primitives = { git = "https://github.com/paradigmxyz/reth.git" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth.git" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth.git" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth.git" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth.git" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth.git" }
-reth-exex = { git = "https://github.com/paradigmxyz/reth", features = ["serde"] }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth.git" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth.git" }
-reth-revm = { git = "https://github.com/paradigmxyz/reth.git" }
-reth-execution-errors = { git = "https://github.com/paradigmxyz/reth.git" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth.git" }
-reth = { git = "https://github.com/paradigmxyz/reth" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.0.6" }
+reth-primitives = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.0.6" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.0.6" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.0.6" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.0.6" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.0.6" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.0.6" }
+reth-exex = { git = "https://github.com/paradigmxyz/reth", tag = "v1.0.6", features = ["serde"] }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.0.6" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.0.6" }
+reth-revm = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.0.6" }
+reth-execution-errors = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.0.6" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.0.6" }
+reth = { git = "https://github.com/paradigmxyz/reth", tag = "v1.0.6" }
 
 serde = { version = "1.0", default-features = false }
 eyre = "0.6"

--- a/bin/keth/Cargo.toml
+++ b/bin/keth/Cargo.toml
@@ -15,11 +15,11 @@ exclude.workspace = true
 kakarot-node.workspace = true
 
 # Reth
-reth-db = { git = "https://github.com/paradigmxyz/reth.git" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth.git" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth.git" }
+reth-db = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.0.6" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.0.6" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.0.6" }
 reth-node-builder.workspace = true
-reth-node-core = { git = "https://github.com/paradigmxyz/reth.git" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.0.6" }
 reth-primitives.workspace = true
 
 # Tracing

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -1,5 +1,6 @@
 use crate::execution::KakarotExecutorBuilder;
 use kakarot_pool::KakarotPoolBuilder;
+use reth_chainspec::ChainSpec;
 use reth_ethereum_engine_primitives::{
     EthBuiltPayload, EthPayloadAttributes, EthPayloadBuilderAttributes,
 };
@@ -63,6 +64,7 @@ impl KakarotNode {
 impl NodeTypes for KakarotNode {
     type Primitives = ();
     type Engine = EthEngineTypes;
+    type ChainSpec = ChainSpec;
 }
 
 impl<N> Node<N> for KakarotNode


### PR DESCRIPTION
In order to avoid moving the `Cargo.lock` at each compilation, we chose to use a fixed version of reth. 

Latest is `1.0.6`.

Related https://github.com/paradigmxyz/reth/releases/tag/v1.0.6