### PR TITLE
rm `no_eip4844` in tx pool

### DIFF
--- a/crates/exex/src/db.rs
+++ b/crates/exex/src/db.rs
@@ -124,7 +124,7 @@ impl Database {
         let block = self.connection().query_row::<String, _, _>(
             "SELECT data FROM block WHERE number = ?",
             (number.to_string(),),
-            // Retrieves the first column of the result row as a string.
+            // Retrieves the first column of the result row as a string
             |row| row.get(0),
         );
 

--- a/crates/exex/src/db.rs
+++ b/crates/exex/src/db.rs
@@ -124,7 +124,7 @@ impl Database {
         let block = self.connection().query_row::<String, _, _>(
             "SELECT data FROM block WHERE number = ?",
             (number.to_string(),),
-            // Retrieves the first column of the result row as a string
+            // Retrieves the first column of the result row as a string.
             |row| row.get(0),
         );
 

--- a/crates/pool/src/validate/mod.rs
+++ b/crates/pool/src/validate/mod.rs
@@ -18,7 +18,7 @@ impl KakarotTransactionValidatorBuilder {
         Self(EthTransactionValidatorBuilder::new(chain_spec))
     }
 
-    /// Build the [`EthTransactionValidator`]. Force `no_eip4844`.
+    /// Build the [`EthTransactionValidator`].
     pub fn build<Client, S>(
         self,
         client: Client,
@@ -27,7 +27,7 @@ impl KakarotTransactionValidatorBuilder {
     where
         S: BlobStore,
     {
-        let validator = self.0.no_eip4844().build(client, store);
+        let validator = self.0.build(client, store);
         KakarotEthTransactionValidator { inner: validator }
     }
 }


### PR DESCRIPTION
We want to be generic at a node level and enforce specific rules at ExEx level.