### PR TITLE
run cairo-vm in proof mode and store AIR inputs

### DIFF
--- a/cairo_programs/compile_cairo.py
+++ b/cairo_programs/compile_cairo.py
@@ -20,6 +20,7 @@ def compile_cairo(file_name):
         str(input_path),
         "--output",
         str(output_path),
+        "--proof_mode",
         "--no_debug_info",
         "--cairo_path",
         "cairo_programs",

--- a/cairo_programs/fibonacci.json
+++ b/cairo_programs/fibonacci.json
@@ -1,260 +1,260 @@
 {
-    "attributes": [],
-    "builtins": [],
-    "compiler_version": "0.12.0",
-    "data": [
-        "0x40780017fff7fff",
-        "0x0",
-        "0x1104800180018000",
-        "0x4",
-        "0x10780017fff7fff",
-        "0x0",
-        "0x480680017fff8000",
-        "0x1",
-        "0x480680017fff8000",
-        "0x1",
-        "0x480680017fff8000",
-        "0xa",
-        "0x1104800180018000",
-        "0x5",
-        "0x400680017fff7fff",
-        "0x90",
-        "0x208b7fff7fff7ffe",
-        "0x20780017fff7ffd",
-        "0x5",
-        "0x480a7ffc7fff8000",
-        "0x480a7ffc7fff8000",
-        "0x208b7fff7fff7ffe",
-        "0x482a7ffc7ffb8000",
-        "0x480a7ffc7fff8000",
-        "0x48127ffe7fff8000",
-        "0x482680017ffd8000",
-        "0x800000000000011000000000000000000000000000000000000000000000000",
-        "0x1104800180018000",
-        "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffff7",
-        "0x208b7fff7fff7ffe"
-    ],
-    "debug_info": null,
-    "hints": {},
-    "identifiers": {
-        "__main__.__end__": {
-            "pc": 4,
-            "type": "label"
-        },
-        "__main__.__start__": {
-            "pc": 0,
-            "type": "label"
-        },
-        "__main__.fib": {
-            "decorators": [],
-            "pc": 17,
-            "type": "function"
-        },
-        "__main__.fib.Args": {
-            "full_name": "__main__.fib.Args",
-            "members": {
-                "first_element": {
-                    "cairo_type": "felt",
-                    "offset": 0
-                },
-                "n": {
-                    "cairo_type": "felt",
-                    "offset": 2
-                },
-                "second_element": {
-                    "cairo_type": "felt",
-                    "offset": 1
-                }
-            },
-            "size": 3,
-            "type": "struct"
-        },
-        "__main__.fib.ImplicitArgs": {
-            "full_name": "__main__.fib.ImplicitArgs",
-            "members": {},
-            "size": 0,
-            "type": "struct"
-        },
-        "__main__.fib.Return": {
-            "cairo_type": "(res: felt)",
-            "type": "type_definition"
-        },
-        "__main__.fib.SIZEOF_LOCALS": {
-            "type": "const",
-            "value": 0
-        },
-        "__main__.fib.fib_body": {
-            "pc": 22,
-            "type": "label"
-        },
-        "__main__.fib.first_element": {
-            "cairo_type": "felt",
-            "full_name": "__main__.fib.first_element",
-            "references": [
-                {
-                    "ap_tracking_data": {
-                        "group": 4,
-                        "offset": 0
-                    },
-                    "pc": 17,
-                    "value": "[cast(fp + (-5), felt*)]"
-                }
-            ],
-            "type": "reference"
-        },
-        "__main__.fib.n": {
-            "cairo_type": "felt",
-            "full_name": "__main__.fib.n",
-            "references": [
-                {
-                    "ap_tracking_data": {
-                        "group": 4,
-                        "offset": 0
-                    },
-                    "pc": 17,
-                    "value": "[cast(fp + (-3), felt*)]"
-                }
-            ],
-            "type": "reference"
-        },
-        "__main__.fib.result": {
-            "cairo_type": "felt",
-            "full_name": "__main__.fib.result",
-            "references": [
-                {
-                    "ap_tracking_data": {
-                        "group": 4,
-                        "offset": 1
-                    },
-                    "pc": 20,
-                    "value": "[cast(ap + (-1), felt*)]"
-                }
-            ],
-            "type": "reference"
-        },
-        "__main__.fib.second_element": {
-            "cairo_type": "felt",
-            "full_name": "__main__.fib.second_element",
-            "references": [
-                {
-                    "ap_tracking_data": {
-                        "group": 4,
-                        "offset": 0
-                    },
-                    "pc": 17,
-                    "value": "[cast(fp + (-4), felt*)]"
-                }
-            ],
-            "type": "reference"
-        },
-        "__main__.fib.y": {
-            "cairo_type": "felt",
-            "full_name": "__main__.fib.y",
-            "references": [
-                {
-                    "ap_tracking_data": {
-                        "group": 4,
-                        "offset": 1
-                    },
-                    "pc": 23,
-                    "value": "[cast(ap + (-1), felt*)]"
-                }
-            ],
-            "type": "reference"
-        },
-        "__main__.main": {
-            "decorators": [],
-            "pc": 6,
-            "type": "function"
-        },
-        "__main__.main.Args": {
-            "full_name": "__main__.main.Args",
-            "members": {},
-            "size": 0,
-            "type": "struct"
-        },
-        "__main__.main.ImplicitArgs": {
-            "full_name": "__main__.main.ImplicitArgs",
-            "members": {},
-            "size": 0,
-            "type": "struct"
-        },
-        "__main__.main.Return": {
-            "cairo_type": "()",
-            "type": "type_definition"
-        },
-        "__main__.main.SIZEOF_LOCALS": {
-            "type": "const",
-            "value": 0
-        },
-        "__main__.main.result": {
-            "cairo_type": "felt",
-            "full_name": "__main__.main.result",
-            "references": [
-                {
-                    "ap_tracking_data": {
-                        "group": 3,
-                        "offset": 0
-                    },
-                    "pc": 14,
-                    "value": "[cast(ap + (-1), felt*)]"
-                }
-            ],
-            "type": "reference"
-        }
+  "attributes": [],
+  "builtins": [],
+  "compiler_version": "0.12.0",
+  "data": [
+    "0x40780017fff7fff",
+    "0x0",
+    "0x1104800180018000",
+    "0x4",
+    "0x10780017fff7fff",
+    "0x0",
+    "0x480680017fff8000",
+    "0x1",
+    "0x480680017fff8000",
+    "0x1",
+    "0x480680017fff8000",
+    "0xa",
+    "0x1104800180018000",
+    "0x5",
+    "0x400680017fff7fff",
+    "0x90",
+    "0x208b7fff7fff7ffe",
+    "0x20780017fff7ffd",
+    "0x5",
+    "0x480a7ffc7fff8000",
+    "0x480a7ffc7fff8000",
+    "0x208b7fff7fff7ffe",
+    "0x482a7ffc7ffb8000",
+    "0x480a7ffc7fff8000",
+    "0x48127ffe7fff8000",
+    "0x482680017ffd8000",
+    "0x800000000000011000000000000000000000000000000000000000000000000",
+    "0x1104800180018000",
+    "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffff7",
+    "0x208b7fff7fff7ffe"
+  ],
+  "debug_info": null,
+  "hints": {},
+  "identifiers": {
+    "__main__.__end__": {
+      "pc": 4,
+      "type": "label"
     },
-    "main_scope": "__main__",
-    "prime": "0x800000000000011000000000000000000000000000000000000000000000001",
-    "reference_manager": {
-        "references": [
-            {
-                "ap_tracking_data": {
-                    "group": 3,
-                    "offset": 0
-                },
-                "pc": 14,
-                "value": "[cast(ap + (-1), felt*)]"
-            },
-            {
-                "ap_tracking_data": {
-                    "group": 4,
-                    "offset": 0
-                },
-                "pc": 17,
-                "value": "[cast(fp + (-5), felt*)]"
-            },
-            {
-                "ap_tracking_data": {
-                    "group": 4,
-                    "offset": 0
-                },
-                "pc": 17,
-                "value": "[cast(fp + (-4), felt*)]"
-            },
-            {
-                "ap_tracking_data": {
-                    "group": 4,
-                    "offset": 0
-                },
-                "pc": 17,
-                "value": "[cast(fp + (-3), felt*)]"
-            },
-            {
-                "ap_tracking_data": {
-                    "group": 4,
-                    "offset": 1
-                },
-                "pc": 20,
-                "value": "[cast(ap + (-1), felt*)]"
-            },
-            {
-                "ap_tracking_data": {
-                    "group": 4,
-                    "offset": 1
-                },
-                "pc": 23,
-                "value": "[cast(ap + (-1), felt*)]"
-            }
-        ]
+    "__main__.__start__": {
+      "pc": 0,
+      "type": "label"
+    },
+    "__main__.fib": {
+      "decorators": [],
+      "pc": 17,
+      "type": "function"
+    },
+    "__main__.fib.Args": {
+      "full_name": "__main__.fib.Args",
+      "members": {
+        "first_element": {
+          "cairo_type": "felt",
+          "offset": 0
+        },
+        "n": {
+          "cairo_type": "felt",
+          "offset": 2
+        },
+        "second_element": {
+          "cairo_type": "felt",
+          "offset": 1
+        }
+      },
+      "size": 3,
+      "type": "struct"
+    },
+    "__main__.fib.ImplicitArgs": {
+      "full_name": "__main__.fib.ImplicitArgs",
+      "members": {},
+      "size": 0,
+      "type": "struct"
+    },
+    "__main__.fib.Return": {
+      "cairo_type": "(res: felt)",
+      "type": "type_definition"
+    },
+    "__main__.fib.SIZEOF_LOCALS": {
+      "type": "const",
+      "value": 0
+    },
+    "__main__.fib.fib_body": {
+      "pc": 22,
+      "type": "label"
+    },
+    "__main__.fib.first_element": {
+      "cairo_type": "felt",
+      "full_name": "__main__.fib.first_element",
+      "references": [
+        {
+          "ap_tracking_data": {
+            "group": 4,
+            "offset": 0
+          },
+          "pc": 17,
+          "value": "[cast(fp + (-5), felt*)]"
+        }
+      ],
+      "type": "reference"
+    },
+    "__main__.fib.n": {
+      "cairo_type": "felt",
+      "full_name": "__main__.fib.n",
+      "references": [
+        {
+          "ap_tracking_data": {
+            "group": 4,
+            "offset": 0
+          },
+          "pc": 17,
+          "value": "[cast(fp + (-3), felt*)]"
+        }
+      ],
+      "type": "reference"
+    },
+    "__main__.fib.result": {
+      "cairo_type": "felt",
+      "full_name": "__main__.fib.result",
+      "references": [
+        {
+          "ap_tracking_data": {
+            "group": 4,
+            "offset": 1
+          },
+          "pc": 20,
+          "value": "[cast(ap + (-1), felt*)]"
+        }
+      ],
+      "type": "reference"
+    },
+    "__main__.fib.second_element": {
+      "cairo_type": "felt",
+      "full_name": "__main__.fib.second_element",
+      "references": [
+        {
+          "ap_tracking_data": {
+            "group": 4,
+            "offset": 0
+          },
+          "pc": 17,
+          "value": "[cast(fp + (-4), felt*)]"
+        }
+      ],
+      "type": "reference"
+    },
+    "__main__.fib.y": {
+      "cairo_type": "felt",
+      "full_name": "__main__.fib.y",
+      "references": [
+        {
+          "ap_tracking_data": {
+            "group": 4,
+            "offset": 1
+          },
+          "pc": 23,
+          "value": "[cast(ap + (-1), felt*)]"
+        }
+      ],
+      "type": "reference"
+    },
+    "__main__.main": {
+      "decorators": [],
+      "pc": 6,
+      "type": "function"
+    },
+    "__main__.main.Args": {
+      "full_name": "__main__.main.Args",
+      "members": {},
+      "size": 0,
+      "type": "struct"
+    },
+    "__main__.main.ImplicitArgs": {
+      "full_name": "__main__.main.ImplicitArgs",
+      "members": {},
+      "size": 0,
+      "type": "struct"
+    },
+    "__main__.main.Return": {
+      "cairo_type": "()",
+      "type": "type_definition"
+    },
+    "__main__.main.SIZEOF_LOCALS": {
+      "type": "const",
+      "value": 0
+    },
+    "__main__.main.result": {
+      "cairo_type": "felt",
+      "full_name": "__main__.main.result",
+      "references": [
+        {
+          "ap_tracking_data": {
+            "group": 3,
+            "offset": 0
+          },
+          "pc": 14,
+          "value": "[cast(ap + (-1), felt*)]"
+        }
+      ],
+      "type": "reference"
     }
+  },
+  "main_scope": "__main__",
+  "prime": "0x800000000000011000000000000000000000000000000000000000000000001",
+  "reference_manager": {
+    "references": [
+      {
+        "ap_tracking_data": {
+          "group": 3,
+          "offset": 0
+        },
+        "pc": 14,
+        "value": "[cast(ap + (-1), felt*)]"
+      },
+      {
+        "ap_tracking_data": {
+          "group": 4,
+          "offset": 0
+        },
+        "pc": 17,
+        "value": "[cast(fp + (-5), felt*)]"
+      },
+      {
+        "ap_tracking_data": {
+          "group": 4,
+          "offset": 0
+        },
+        "pc": 17,
+        "value": "[cast(fp + (-4), felt*)]"
+      },
+      {
+        "ap_tracking_data": {
+          "group": 4,
+          "offset": 0
+        },
+        "pc": 17,
+        "value": "[cast(fp + (-3), felt*)]"
+      },
+      {
+        "ap_tracking_data": {
+          "group": 4,
+          "offset": 1
+        },
+        "pc": 20,
+        "value": "[cast(ap + (-1), felt*)]"
+      },
+      {
+        "ap_tracking_data": {
+          "group": 4,
+          "offset": 1
+        },
+        "pc": 23,
+        "value": "[cast(ap + (-1), felt*)]"
+      }
+    ]
+  }
 }

--- a/cairo_programs/fibonacci.json
+++ b/cairo_programs/fibonacci.json
@@ -1,246 +1,260 @@
 {
-  "attributes": [],
-  "builtins": [],
-  "compiler_version": "0.13.2",
-  "data": [
-    "0x480680017fff8000",
-    "0x1",
-    "0x480680017fff8000",
-    "0x1",
-    "0x480680017fff8000",
-    "0xa",
-    "0x1104800180018000",
-    "0x5",
-    "0x400680017fff7fff",
-    "0x90",
-    "0x208b7fff7fff7ffe",
-    "0x20780017fff7ffd",
-    "0x5",
-    "0x480a7ffc7fff8000",
-    "0x480a7ffc7fff8000",
-    "0x208b7fff7fff7ffe",
-    "0x482a7ffc7ffb8000",
-    "0x480a7ffc7fff8000",
-    "0x48127ffe7fff8000",
-    "0x482680017ffd8000",
-    "0x800000000000011000000000000000000000000000000000000000000000000",
-    "0x1104800180018000",
-    "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffff7",
-    "0x208b7fff7fff7ffe"
-  ],
-  "debug_info": null,
-  "hints": {},
-  "identifiers": {
-    "__main__.fib": {
-      "decorators": [],
-      "pc": 11,
-      "type": "function"
-    },
-    "__main__.fib.Args": {
-      "full_name": "__main__.fib.Args",
-      "members": {
-        "first_element": {
-          "cairo_type": "felt",
-          "offset": 0
+    "attributes": [],
+    "builtins": [],
+    "compiler_version": "0.12.0",
+    "data": [
+        "0x40780017fff7fff",
+        "0x0",
+        "0x1104800180018000",
+        "0x4",
+        "0x10780017fff7fff",
+        "0x0",
+        "0x480680017fff8000",
+        "0x1",
+        "0x480680017fff8000",
+        "0x1",
+        "0x480680017fff8000",
+        "0xa",
+        "0x1104800180018000",
+        "0x5",
+        "0x400680017fff7fff",
+        "0x90",
+        "0x208b7fff7fff7ffe",
+        "0x20780017fff7ffd",
+        "0x5",
+        "0x480a7ffc7fff8000",
+        "0x480a7ffc7fff8000",
+        "0x208b7fff7fff7ffe",
+        "0x482a7ffc7ffb8000",
+        "0x480a7ffc7fff8000",
+        "0x48127ffe7fff8000",
+        "0x482680017ffd8000",
+        "0x800000000000011000000000000000000000000000000000000000000000000",
+        "0x1104800180018000",
+        "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffff7",
+        "0x208b7fff7fff7ffe"
+    ],
+    "debug_info": null,
+    "hints": {},
+    "identifiers": {
+        "__main__.__end__": {
+            "pc": 4,
+            "type": "label"
         },
-        "n": {
-          "cairo_type": "felt",
-          "offset": 2
+        "__main__.__start__": {
+            "pc": 0,
+            "type": "label"
         },
-        "second_element": {
-          "cairo_type": "felt",
-          "offset": 1
+        "__main__.fib": {
+            "decorators": [],
+            "pc": 17,
+            "type": "function"
+        },
+        "__main__.fib.Args": {
+            "full_name": "__main__.fib.Args",
+            "members": {
+                "first_element": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                },
+                "n": {
+                    "cairo_type": "felt",
+                    "offset": 2
+                },
+                "second_element": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 3,
+            "type": "struct"
+        },
+        "__main__.fib.ImplicitArgs": {
+            "full_name": "__main__.fib.ImplicitArgs",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "__main__.fib.Return": {
+            "cairo_type": "(res: felt)",
+            "type": "type_definition"
+        },
+        "__main__.fib.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "__main__.fib.fib_body": {
+            "pc": 22,
+            "type": "label"
+        },
+        "__main__.fib.first_element": {
+            "cairo_type": "felt",
+            "full_name": "__main__.fib.first_element",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 0
+                    },
+                    "pc": 17,
+                    "value": "[cast(fp + (-5), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.fib.n": {
+            "cairo_type": "felt",
+            "full_name": "__main__.fib.n",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 0
+                    },
+                    "pc": 17,
+                    "value": "[cast(fp + (-3), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.fib.result": {
+            "cairo_type": "felt",
+            "full_name": "__main__.fib.result",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 1
+                    },
+                    "pc": 20,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.fib.second_element": {
+            "cairo_type": "felt",
+            "full_name": "__main__.fib.second_element",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 0
+                    },
+                    "pc": 17,
+                    "value": "[cast(fp + (-4), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.fib.y": {
+            "cairo_type": "felt",
+            "full_name": "__main__.fib.y",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 1
+                    },
+                    "pc": 23,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main": {
+            "decorators": [],
+            "pc": 6,
+            "type": "function"
+        },
+        "__main__.main.Args": {
+            "full_name": "__main__.main.Args",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "__main__.main.ImplicitArgs": {
+            "full_name": "__main__.main.ImplicitArgs",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "__main__.main.Return": {
+            "cairo_type": "()",
+            "type": "type_definition"
+        },
+        "__main__.main.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "__main__.main.result": {
+            "cairo_type": "felt",
+            "full_name": "__main__.main.result",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 3,
+                        "offset": 0
+                    },
+                    "pc": 14,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
         }
-      },
-      "size": 3,
-      "type": "struct"
     },
-    "__main__.fib.ImplicitArgs": {
-      "full_name": "__main__.fib.ImplicitArgs",
-      "members": {},
-      "size": 0,
-      "type": "struct"
-    },
-    "__main__.fib.Return": {
-      "cairo_type": "(res: felt)",
-      "type": "type_definition"
-    },
-    "__main__.fib.SIZEOF_LOCALS": {
-      "type": "const",
-      "value": 0
-    },
-    "__main__.fib.fib_body": {
-      "pc": 16,
-      "type": "label"
-    },
-    "__main__.fib.first_element": {
-      "cairo_type": "felt",
-      "full_name": "__main__.fib.first_element",
-      "references": [
-        {
-          "ap_tracking_data": {
-            "group": 2,
-            "offset": 0
-          },
-          "pc": 11,
-          "value": "[cast(fp + (-5), felt*)]"
-        }
-      ],
-      "type": "reference"
-    },
-    "__main__.fib.n": {
-      "cairo_type": "felt",
-      "full_name": "__main__.fib.n",
-      "references": [
-        {
-          "ap_tracking_data": {
-            "group": 2,
-            "offset": 0
-          },
-          "pc": 11,
-          "value": "[cast(fp + (-3), felt*)]"
-        }
-      ],
-      "type": "reference"
-    },
-    "__main__.fib.result": {
-      "cairo_type": "felt",
-      "full_name": "__main__.fib.result",
-      "references": [
-        {
-          "ap_tracking_data": {
-            "group": 2,
-            "offset": 1
-          },
-          "pc": 14,
-          "value": "[cast(ap + (-1), felt*)]"
-        }
-      ],
-      "type": "reference"
-    },
-    "__main__.fib.second_element": {
-      "cairo_type": "felt",
-      "full_name": "__main__.fib.second_element",
-      "references": [
-        {
-          "ap_tracking_data": {
-            "group": 2,
-            "offset": 0
-          },
-          "pc": 11,
-          "value": "[cast(fp + (-4), felt*)]"
-        }
-      ],
-      "type": "reference"
-    },
-    "__main__.fib.y": {
-      "cairo_type": "felt",
-      "full_name": "__main__.fib.y",
-      "references": [
-        {
-          "ap_tracking_data": {
-            "group": 2,
-            "offset": 1
-          },
-          "pc": 17,
-          "value": "[cast(ap + (-1), felt*)]"
-        }
-      ],
-      "type": "reference"
-    },
-    "__main__.main": {
-      "decorators": [],
-      "pc": 0,
-      "type": "function"
-    },
-    "__main__.main.Args": {
-      "full_name": "__main__.main.Args",
-      "members": {},
-      "size": 0,
-      "type": "struct"
-    },
-    "__main__.main.ImplicitArgs": {
-      "full_name": "__main__.main.ImplicitArgs",
-      "members": {},
-      "size": 0,
-      "type": "struct"
-    },
-    "__main__.main.Return": {
-      "cairo_type": "()",
-      "type": "type_definition"
-    },
-    "__main__.main.SIZEOF_LOCALS": {
-      "type": "const",
-      "value": 0
-    },
-    "__main__.main.result": {
-      "cairo_type": "felt",
-      "full_name": "__main__.main.result",
-      "references": [
-        {
-          "ap_tracking_data": {
-            "group": 1,
-            "offset": 0
-          },
-          "pc": 8,
-          "value": "[cast(ap + (-1), felt*)]"
-        }
-      ],
-      "type": "reference"
+    "main_scope": "__main__",
+    "prime": "0x800000000000011000000000000000000000000000000000000000000000001",
+    "reference_manager": {
+        "references": [
+            {
+                "ap_tracking_data": {
+                    "group": 3,
+                    "offset": 0
+                },
+                "pc": 14,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 0
+                },
+                "pc": 17,
+                "value": "[cast(fp + (-5), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 0
+                },
+                "pc": 17,
+                "value": "[cast(fp + (-4), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 0
+                },
+                "pc": 17,
+                "value": "[cast(fp + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 1
+                },
+                "pc": 20,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 1
+                },
+                "pc": 23,
+                "value": "[cast(ap + (-1), felt*)]"
+            }
+        ]
     }
-  },
-  "main_scope": "__main__",
-  "prime": "0x800000000000011000000000000000000000000000000000000000000000001",
-  "reference_manager": {
-    "references": [
-      {
-        "ap_tracking_data": {
-          "group": 1,
-          "offset": 0
-        },
-        "pc": 8,
-        "value": "[cast(ap + (-1), felt*)]"
-      },
-      {
-        "ap_tracking_data": {
-          "group": 2,
-          "offset": 0
-        },
-        "pc": 11,
-        "value": "[cast(fp + (-5), felt*)]"
-      },
-      {
-        "ap_tracking_data": {
-          "group": 2,
-          "offset": 0
-        },
-        "pc": 11,
-        "value": "[cast(fp + (-4), felt*)]"
-      },
-      {
-        "ap_tracking_data": {
-          "group": 2,
-          "offset": 0
-        },
-        "pc": 11,
-        "value": "[cast(fp + (-3), felt*)]"
-      },
-      {
-        "ap_tracking_data": {
-          "group": 2,
-          "offset": 1
-        },
-        "pc": 14,
-        "value": "[cast(ap + (-1), felt*)]"
-      },
-      {
-        "ap_tracking_data": {
-          "group": 2,
-          "offset": 1
-        },
-        "pc": 17,
-        "value": "[cast(ap + (-1), felt*)]"
-      }
-    ]
-  }
 }

--- a/cairo_programs/transaction_hash.json
+++ b/cairo_programs/transaction_hash.json
@@ -1,54 +1,73 @@
 {
-  "attributes": [],
-  "builtins": [],
-  "compiler_version": "0.13.2",
-  "data": ["0x208b7fff7fff7ffe"],
-  "debug_info": null,
-  "hints": {
-    "0": [
-      {
-        "accessible_scopes": ["__main__", "__main__.main"],
-        "code": "print_latest_block_transactions",
-        "flow_tracking_data": {
-          "ap_tracking": {
-            "group": 0,
-            "offset": 0
-          },
-          "reference_ids": {}
+    "attributes": [],
+    "builtins": [],
+    "compiler_version": "0.12.0",
+    "data": [
+        "0x40780017fff7fff",
+        "0x0",
+        "0x1104800180018000",
+        "0x4",
+        "0x10780017fff7fff",
+        "0x0",
+        "0x208b7fff7fff7ffe"
+    ],
+    "debug_info": null,
+    "hints": {
+        "6": [
+            {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "code": "print_latest_block_transactions",
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "reference_ids": {}
+                }
+            }
+        ]
+    },
+    "identifiers": {
+        "__main__.__end__": {
+            "pc": 4,
+            "type": "label"
+        },
+        "__main__.__start__": {
+            "pc": 0,
+            "type": "label"
+        },
+        "__main__.main": {
+            "decorators": [],
+            "pc": 6,
+            "type": "function"
+        },
+        "__main__.main.Args": {
+            "full_name": "__main__.main.Args",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "__main__.main.ImplicitArgs": {
+            "full_name": "__main__.main.ImplicitArgs",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "__main__.main.Return": {
+            "cairo_type": "()",
+            "type": "type_definition"
+        },
+        "__main__.main.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
         }
-      }
-    ]
-  },
-  "identifiers": {
-    "__main__.main": {
-      "decorators": [],
-      "pc": 0,
-      "type": "function"
     },
-    "__main__.main.Args": {
-      "full_name": "__main__.main.Args",
-      "members": {},
-      "size": 0,
-      "type": "struct"
-    },
-    "__main__.main.ImplicitArgs": {
-      "full_name": "__main__.main.ImplicitArgs",
-      "members": {},
-      "size": 0,
-      "type": "struct"
-    },
-    "__main__.main.Return": {
-      "cairo_type": "()",
-      "type": "type_definition"
-    },
-    "__main__.main.SIZEOF_LOCALS": {
-      "type": "const",
-      "value": 0
+    "main_scope": "__main__",
+    "prime": "0x800000000000011000000000000000000000000000000000000000000000001",
+    "reference_manager": {
+        "references": []
     }
-  },
-  "main_scope": "__main__",
-  "prime": "0x800000000000011000000000000000000000000000000000000000000000001",
-  "reference_manager": {
-    "references": []
-  }
 }

--- a/cairo_programs/transaction_hash.json
+++ b/cairo_programs/transaction_hash.json
@@ -1,73 +1,70 @@
 {
-    "attributes": [],
-    "builtins": [],
-    "compiler_version": "0.12.0",
-    "data": [
-        "0x40780017fff7fff",
-        "0x0",
-        "0x1104800180018000",
-        "0x4",
-        "0x10780017fff7fff",
-        "0x0",
-        "0x208b7fff7fff7ffe"
-    ],
-    "debug_info": null,
-    "hints": {
-        "6": [
-            {
-                "accessible_scopes": [
-                    "__main__",
-                    "__main__.main"
-                ],
-                "code": "print_latest_block_transactions",
-                "flow_tracking_data": {
-                    "ap_tracking": {
-                        "group": 2,
-                        "offset": 0
-                    },
-                    "reference_ids": {}
-                }
-            }
-        ]
-    },
-    "identifiers": {
-        "__main__.__end__": {
-            "pc": 4,
-            "type": "label"
-        },
-        "__main__.__start__": {
-            "pc": 0,
-            "type": "label"
-        },
-        "__main__.main": {
-            "decorators": [],
-            "pc": 6,
-            "type": "function"
-        },
-        "__main__.main.Args": {
-            "full_name": "__main__.main.Args",
-            "members": {},
-            "size": 0,
-            "type": "struct"
-        },
-        "__main__.main.ImplicitArgs": {
-            "full_name": "__main__.main.ImplicitArgs",
-            "members": {},
-            "size": 0,
-            "type": "struct"
-        },
-        "__main__.main.Return": {
-            "cairo_type": "()",
-            "type": "type_definition"
-        },
-        "__main__.main.SIZEOF_LOCALS": {
-            "type": "const",
-            "value": 0
+  "attributes": [],
+  "builtins": [],
+  "compiler_version": "0.12.0",
+  "data": [
+    "0x40780017fff7fff",
+    "0x0",
+    "0x1104800180018000",
+    "0x4",
+    "0x10780017fff7fff",
+    "0x0",
+    "0x208b7fff7fff7ffe"
+  ],
+  "debug_info": null,
+  "hints": {
+    "6": [
+      {
+        "accessible_scopes": ["__main__", "__main__.main"],
+        "code": "print_latest_block_transactions",
+        "flow_tracking_data": {
+          "ap_tracking": {
+            "group": 2,
+            "offset": 0
+          },
+          "reference_ids": {}
         }
+      }
+    ]
+  },
+  "identifiers": {
+    "__main__.__end__": {
+      "pc": 4,
+      "type": "label"
     },
-    "main_scope": "__main__",
-    "prime": "0x800000000000011000000000000000000000000000000000000000000000001",
-    "reference_manager": {
-        "references": []
+    "__main__.__start__": {
+      "pc": 0,
+      "type": "label"
+    },
+    "__main__.main": {
+      "decorators": [],
+      "pc": 6,
+      "type": "function"
+    },
+    "__main__.main.Args": {
+      "full_name": "__main__.main.Args",
+      "members": {},
+      "size": 0,
+      "type": "struct"
+    },
+    "__main__.main.ImplicitArgs": {
+      "full_name": "__main__.main.ImplicitArgs",
+      "members": {},
+      "size": 0,
+      "type": "struct"
+    },
+    "__main__.main.Return": {
+      "cairo_type": "()",
+      "type": "type_definition"
+    },
+    "__main__.main.SIZEOF_LOCALS": {
+      "type": "const",
+      "value": 0
     }
+  },
+  "main_scope": "__main__",
+  "prime": "0x800000000000011000000000000000000000000000000000000000000000001",
+  "reference_manager": {
+    "references": []
+  }
 }


### PR DESCRIPTION
In the scope of this PR:
- Compile the Cairo programs in proof mode
- Run the Cairo VM in proof mode
- Store in the db the air private and public input with the aim of using them to run the prover (see https://github.com/dipdup-io/stone-packaging/tree/master)