### PR TITLE
Implement and diff-test validate_header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,9 +97,9 @@ checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "alloy-chains"
-version = "0.1.37"
+version = "0.1.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54e2fbc026948a0f638bf6a94fc0ce6e44652280fed40bb0dd970e3357bc5f2"
+checksum = "156bfc5dcd52ef9a5f33381701fa03310317e14c65093a9430d3e3557b08dcd3"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -128,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f95d76a38cae906fd394a5afb0736aaceee5432efe76addfd71048e623e208af"
+checksum = "e6228abfc751a29cde117b0879b805a3e0b3b641358f063272c83ca459a56886"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -204,9 +204,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c66eec1acdd96b39b995b8f5ee5239bc0c871d62c527ae1ac9fd1d7fecd455"
+checksum = "d46eb5871592c216d39192499c95a99f7175cb94104f88c307e6dc960676d9f1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -264,9 +264,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb848c43f6b06ae3de2e4a67496cbbabd78ae87db0f1248934f15d76192c6a"
+checksum = "38f35429a652765189c1c5092870d8360ee7b7769b09b06d89ebaefd34676446"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -577,9 +577,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "661c516eb1fa3294cc7f2fb8955b3b609d639c282ac81a4eedb14d3046db503a"
+checksum = "3b2395336745358cc47207442127c47c63801a7065ecc0aa928da844f8bb5576"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -591,9 +591,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecbabb8fc3d75a0c2cea5215be22e7a267e3efde835b0f2a8922f5e3f5d47683"
+checksum = "9ed5047c9a241df94327879c2b0729155b58b941eae7805a7ada2e19436e6b39"
 dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
@@ -609,9 +609,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16517f2af03064485150d89746b8ffdcdbc9b6eeb3d536fb66efd7c2846fbc75"
+checksum = "5dee02a81f529c415082235129f0df8b8e60aa1601b9c9298ffe54d75f57210b"
 dependencies = [
  "const-hex",
  "dunce",
@@ -624,9 +624,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c07ebb0c1674ff8cbb08378d7c2e0e27919d2a2dae07ad3bca26174deda8d389"
+checksum = "f631f0bd9a9d79619b27c91b6b1ab2c4ef4e606a65192369a1ee05d40dcf81cc"
 dependencies = [
  "serde",
  "winnow",
@@ -634,9 +634,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e448d879903624863f608c552d10efb0e0905ddbee98b0049412799911eb062"
+checksum = "c2841af22d99e2c0f82a78fe107b6481be3dd20b89bfb067290092794734343a"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -953,9 +953,9 @@ checksum = "155a5a185e42c6b77ac7b88a15143d930a9e9727a5b7b77eed417404ab15c247"
 
 [[package]]
 name = "async-compression"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "998282f8f49ccd6116b0ed8a4de0fbd3151697920e7c7533416d6e25e76434a7"
+checksum = "103db485efc3e41214fe4fda9f3dbeae2eb9082f48fd236e6095627a9422066e"
 dependencies = [
  "brotli",
  "flate2",
@@ -1421,9 +1421,9 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
 name = "bytemuck"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bbb0ad554ad961ddc5da507a12a29b14e4ae5bda06b19f575a3e6079d2e2ae"
+checksum = "8334215b81e418a0a7bdb8ef0849474f40bb10c8b71f1c4ed315cff49f32494d"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -1569,9 +1569,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.28"
+version = "1.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e80e3b6a3ab07840e1cae9b0666a63970dc28e8ed5ffbcdacbfc760c281bfc1"
+checksum = "b16803a61b81d9eabb7eae2588776c4c1e584b738ede45fdbb4c972cec1e9945"
 dependencies = [
  "jobserver",
  "libc",
@@ -3016,9 +3016,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
+checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -3411,9 +3411,9 @@ checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
 name = "iri-string"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44bd7eced44cfe2cebc674adb2a7124a754a4b5269288d22e9f39f8fada3562d"
+checksum = "dc0f0a572e8ffe56e2ff4f769f32ffe919282c3916799f8b68688b6030063bea"
 dependencies = [
  "memchr",
  "serde",
@@ -3489,9 +3489,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.24.6"
+version = "0.24.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02f01f48e04e0d7da72280ab787c9943695699c9b32b99158ece105e8ad0afea"
+checksum = "c5c71d8c1a731cc4227c2f698d377e7848ca12c8a48866fc5e6951c43a4db843"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
@@ -3507,9 +3507,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-client-transport"
-version = "0.24.6"
+version = "0.24.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d80eccbd47a7b9f1e67663fd846928e941cb49c65236e297dd11c9ea3c5e3387"
+checksum = "548125b159ba1314104f5bb5f38519e03a41862786aa3925cf349aae9cdd546e"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -3532,9 +3532,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-core"
-version = "0.24.6"
+version = "0.24.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c2709a32915d816a6e8f625bf72cf74523ebe5d8829f895d6b041b1d3137818"
+checksum = "f2882f6f8acb9fdaec7cefc4fd607119a9bd709831df7d7672a1d3b644628280"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3559,9 +3559,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-http-client"
-version = "0.24.6"
+version = "0.24.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc54db939002b030e794fbfc9d5a925aa2854889c5a2f0352b0bffa54681707e"
+checksum = "b3638bc4617f96675973253b3a45006933bde93c2fd8a6170b33c777cc389e5b"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3584,9 +3584,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-proc-macros"
-version = "0.24.6"
+version = "0.24.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a9a4b2eaba8cc928f49c4ccf4fcfa65b690a73997682da99ed08f3393b51f07"
+checksum = "c06c01ae0007548e73412c08e2285ffe5d723195bf268bce67b1b77c3bb2a14d"
 dependencies = [
  "heck",
  "proc-macro-crate",
@@ -3597,9 +3597,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-server"
-version = "0.24.6"
+version = "0.24.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e30110d0f2d7866c8cc6c86483bdab2eb9f4d2f0e20db55518b2bca84651ba8e"
+checksum = "82ad8ddc14be1d4290cd68046e7d1d37acd408efed6d3ca08aefcc3ad6da069c"
 dependencies = [
  "futures-util",
  "http",
@@ -3624,9 +3624,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-types"
-version = "0.24.6"
+version = "0.24.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ca331cd7b3fe95b33432825c2d4c9f5a43963e207fdc01ae67f9fd80ab0930f"
+checksum = "a178c60086f24cc35bb82f57c651d0d25d99c4742b4d335de04e97fa1f08a8a1"
 dependencies = [
  "http",
  "serde",
@@ -3636,9 +3636,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-wasm-client"
-version = "0.24.6"
+version = "0.24.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c603d97578071dc44d79d3cfaf0775437638fd5adc33c6b622dfe4fa2ec812d"
+checksum = "1a01cd500915d24ab28ca17527e23901ef1be6d659a2322451e1045532516c25"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
@@ -3647,9 +3647,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-ws-client"
-version = "0.24.6"
+version = "0.24.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755ca3da1c67671f1fae01cd1a47f41dfb2233a8f19a643e587ab0a663942044"
+checksum = "0fe322e0896d0955a3ebdd5bf813571c53fea29edd713bc315b76620b327e86d"
 dependencies = [
  "http",
  "jsonrpsee-client-transport",
@@ -4126,16 +4126,16 @@ dependencies = [
 
 [[package]]
 name = "metrics-process"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48e9ed6b48279656a738d38d832440bd59c349cd178a21ff46276a4a86f15f60"
+checksum = "e69e6ced169644e186e060ddc15f3923fdf06862c811a867bb1e5e7c7824f4d0"
 dependencies = [
  "libc",
  "libproc",
  "mach2",
  "metrics",
  "once_cell",
- "procfs",
+ "procfs 0.17.0",
  "rlimit",
  "windows 0.58.0",
 ]
@@ -4739,9 +4739,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.13"
+version = "2.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdbef9d1d47087a895abd220ed25eb4ad973a5e26f6a4367b038c25e28dfc2d9"
+checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
 dependencies = [
  "memchr",
  "thiserror",
@@ -4974,9 +4974,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.87"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
+checksum = "7c3a7fc5db1e57d5a779a352c8cdb57b29aa4c40cc69c3a68a7fedc815fbf2f9"
 dependencies = [
  "unicode-ident",
 ]
@@ -4992,7 +4992,19 @@ dependencies = [
  "flate2",
  "hex",
  "lazy_static",
- "procfs-core",
+ "procfs-core 0.16.0",
+ "rustix",
+]
+
+[[package]]
+name = "procfs"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
+dependencies = [
+ "bitflags 2.6.0",
+ "hex",
+ "procfs-core 0.17.0",
  "rustix",
 ]
 
@@ -5004,6 +5016,16 @@ checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
 dependencies = [
  "bitflags 2.6.0",
  "chrono",
+ "hex",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
+dependencies = [
+ "bitflags 2.6.0",
  "hex",
 ]
 
@@ -6900,7 +6922,7 @@ dependencies = [
  "metrics-exporter-prometheus",
  "metrics-process",
  "metrics-util",
- "procfs",
+ "procfs 0.16.0",
  "reth-db-api",
  "reth-metrics",
  "reth-provider",
@@ -8058,9 +8080,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.14"
+version = "0.23.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "415d9944693cb90382053259f89fbb077ea730ad7273047ec63b19bc9b160ba8"
+checksum = "5fbb44d7acc4e873d613422379f69f237a1b141928c02f6bc6ccfddddc2d7993"
 dependencies = [
  "log",
  "once_cell",
@@ -8095,9 +8117,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e696e35370c65c9c541198af4543ccd580cf17fc25d8e05c5a242b202488c55"
+checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
 
 [[package]]
 name = "rustls-platform-verifier"
@@ -8139,9 +8161,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
 
 [[package]]
 name = "rusty-fork"
@@ -8788,9 +8810,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20e7b52ad118b2153644eea95c6fc740b6c1555b2344fdab763fc9de4075f665"
+checksum = "ebfc1bfd06acc78f16d8fd3ef846bc222ee7002468d10a7dce8d703d6eab89a3"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -9571,9 +9593,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
 dependencies = [
  "getrandom",
 ]

--- a/cairo/programs/fork.cairo
+++ b/cairo/programs/fork.cairo
@@ -1,0 +1,203 @@
+// See https://github.com/ethereum/execution-specs/blob/master/src/ethereum/cancun/fork.py
+
+from starkware.cairo.common.uint256 import Uint256
+from starkware.cairo.common.math import unsigned_div_rem, split_felt
+from starkware.cairo.common.math_cmp import is_nn
+from starkware.cairo.common.bool import FALSE
+
+from src.model import model
+
+using Uint128 = felt;
+
+const ELASTICITY_MULTIPLIER = 2;
+const GAS_LIMIT_ADJUSTMENT_FACTOR = 1024;
+const GAS_LIMIT_MINIMUM = 5000;
+const BASE_FEE_MAX_CHANGE_DENOMINATOR = 8;
+const EMPTY_OMMER_HASH_LOW = 0xd312451b948a7413f0a142fd40d49347;
+const EMPTY_OMMER_HASH_HIGH = 0x1dcc4de8dec75d7aab85b567b6ccd41a;
+
+// @notice See https://github.com/ethereum/execution-specs/blob/master/src/ethereum/cancun/fork.py#L1118-L1154
+// @dev We use the Uint128 alias to strenghten the fact that these felts should have been range_checked before
+func check_gas_limit{range_check_ptr}(gas_limit: Uint128, parent_gas_limit: Uint128) {
+    let (max_adjustment_delta, _) = unsigned_div_rem(parent_gas_limit, GAS_LIMIT_ADJUSTMENT_FACTOR);
+
+    with_attr error_message("InvalidBlock") {
+        assert [range_check_ptr] = parent_gas_limit + max_adjustment_delta - gas_limit - 1;
+        assert [range_check_ptr + 1] = gas_limit - (parent_gas_limit - max_adjustment_delta) - 1;
+        assert [range_check_ptr + 2] = gas_limit - GAS_LIMIT_MINIMUM;
+        let range_check_ptr = range_check_ptr + 3;
+    }
+
+    return ();
+}
+
+// @notice See https://github.com/ethereum/execution-specs/blob/master/src/ethereum/cancun/fork.py#L226-L285
+// @dev We use the Uint128 alias to strenghten the fact that these felts should have been range_checked before
+func calculate_base_fee_per_gas{range_check_ptr}(
+    block_gas_limit: Uint128,
+    parent_gas_limit: Uint128,
+    parent_gas_used: Uint128,
+    parent_base_fee_per_gas: Uint128,
+) -> Uint128 {
+    let (parent_gas_target, _) = unsigned_div_rem(parent_gas_limit, ELASTICITY_MULTIPLIER);
+
+    check_gas_limit(block_gas_limit, parent_gas_limit);
+
+    if (parent_gas_used == parent_gas_target) {
+        return parent_base_fee_per_gas;
+    }
+
+    let is_parent_gas_used_greater_than_parent_gas_target = is_nn(
+        parent_gas_used - parent_gas_target - 1
+    );
+    if (is_parent_gas_used_greater_than_parent_gas_target != FALSE) {
+        let gas_used_delta = parent_gas_used - parent_gas_target;
+        let parent_fee_gas_delta = parent_base_fee_per_gas * gas_used_delta;
+        let (target_fee_gas_delta, _) = unsigned_div_rem(parent_fee_gas_delta, parent_gas_target);
+        let (base_fee_per_gas_delta, _) = unsigned_div_rem(
+            target_fee_gas_delta, BASE_FEE_MAX_CHANGE_DENOMINATOR
+        );
+        if (base_fee_per_gas_delta == 0) {
+            return 1;
+        }
+        return base_fee_per_gas_delta;
+    }
+
+    let gas_used_delta = parent_gas_target - parent_gas_used;
+    let parent_fee_gas_delta = parent_base_fee_per_gas * gas_used_delta;
+    let (target_fee_gas_delta, _) = unsigned_div_rem(parent_fee_gas_delta, parent_gas_target);
+    let (base_fee_per_gas_delta, _) = unsigned_div_rem(
+        target_fee_gas_delta, BASE_FEE_MAX_CHANGE_DENOMINATOR
+    );
+
+    return parent_base_fee_per_gas - base_fee_per_gas_delta;
+}
+
+// @notice See https://github.com/ethereum/execution-specs/blob/master/src/ethereum/cancun/fork.py#L288-L332
+// @dev Initial range checks for all values because header is filled with a hint
+func validate_header{range_check_ptr}(header: model.BlockHeader, parent_header: model.BlockHeader) {
+    // parent_hash
+    assert [range_check_ptr] = header.parent_hash.low;
+    let range_check_ptr = range_check_ptr + 1;
+    assert [range_check_ptr] = header.parent_hash.high;
+    let range_check_ptr = range_check_ptr + 1;
+    // ommers_hash
+    assert [range_check_ptr] = header.ommers_hash.low;
+    let range_check_ptr = range_check_ptr + 1;
+    assert [range_check_ptr] = header.ommers_hash.high;
+    let range_check_ptr = range_check_ptr + 1;
+    // coinbase
+    let (coinbase_high, coinbase_low) = split_felt(header.coinbase);
+    assert [range_check_ptr] = coinbase_low;
+    let range_check_ptr = range_check_ptr + 1;
+    assert [range_check_ptr] = coinbase_high;
+    let range_check_ptr = range_check_ptr + 1;
+    assert [range_check_ptr] = 2 ** 32 - coinbase_high - 1;
+    let range_check_ptr = range_check_ptr + 1;
+    // state_root
+    assert [range_check_ptr] = header.state_root.low;
+    let range_check_ptr = range_check_ptr + 1;
+    assert [range_check_ptr] = header.state_root.high;
+    let range_check_ptr = range_check_ptr + 1;
+    // transactions_root
+    assert [range_check_ptr] = header.transactions_root.low;
+    let range_check_ptr = range_check_ptr + 1;
+    assert [range_check_ptr] = header.transactions_root.high;
+    let range_check_ptr = range_check_ptr + 1;
+    // receipt_root
+    assert [range_check_ptr] = header.receipt_root.low;
+    let range_check_ptr = range_check_ptr + 1;
+    assert [range_check_ptr] = header.receipt_root.high;
+    let range_check_ptr = range_check_ptr + 1;
+    // withdrawals_root
+    assert header.withdrawals_root.is_some * (1 - header.withdrawals_root.is_some) = 0;
+    let withdrawals_root = cast(header.withdrawals_root.value, Uint256*);
+    assert [range_check_ptr] = withdrawals_root.low;
+    let range_check_ptr = range_check_ptr + 1;
+    assert [range_check_ptr] = withdrawals_root.high;
+    let range_check_ptr = range_check_ptr + 1;
+    // difficulty
+    assert [range_check_ptr] = header.difficulty.low;
+    let range_check_ptr = range_check_ptr + 1;
+    assert [range_check_ptr] = header.difficulty.high;
+    let range_check_ptr = range_check_ptr + 1;
+    // number
+    assert [range_check_ptr] = header.number;
+    let range_check_ptr = range_check_ptr + 1;
+    // gas_limit
+    assert [range_check_ptr] = header.gas_limit;
+    let range_check_ptr = range_check_ptr + 1;
+    // gas_used
+    assert [range_check_ptr] = header.gas_used;
+    let range_check_ptr = range_check_ptr + 1;
+    // timestamp
+    assert [range_check_ptr] = header.timestamp;
+    let range_check_ptr = range_check_ptr + 1;
+    // mix_hash
+    assert [range_check_ptr] = header.mix_hash.low;
+    let range_check_ptr = range_check_ptr + 1;
+    assert [range_check_ptr] = header.mix_hash.high;
+    let range_check_ptr = range_check_ptr + 1;
+    // nonce
+    assert [range_check_ptr] = header.nonce;
+    let range_check_ptr = range_check_ptr + 1;
+    // base_fee_per_gas
+    assert header.base_fee_per_gas.is_some * (1 - header.base_fee_per_gas.is_some) = 0;
+    assert [range_check_ptr] = header.base_fee_per_gas.value;
+    let range_check_ptr = range_check_ptr + 1;
+    // blob_gas_used
+    assert header.blob_gas_used.is_some * (1 - header.blob_gas_used.is_some) = 0;
+    assert [range_check_ptr] = header.blob_gas_used.value;
+    let range_check_ptr = range_check_ptr + 1;
+    // excess_blob_gas
+    assert header.excess_blob_gas.is_some * (1 - header.excess_blob_gas.is_some) = 0;
+    assert [range_check_ptr] = header.excess_blob_gas.value;
+    let range_check_ptr = range_check_ptr + 1;
+    // parent_beacon_block_root
+    assert header.parent_beacon_block_root.is_some * (
+        1 - header.parent_beacon_block_root.is_some
+    ) = 0;
+    let parent_beacon_block_root = cast(header.parent_beacon_block_root.value, Uint256*);
+    assert [range_check_ptr] = parent_beacon_block_root.low;
+    let range_check_ptr = range_check_ptr + 1;
+    assert [range_check_ptr] = parent_beacon_block_root.high;
+    let range_check_ptr = range_check_ptr + 1;
+    // requests_root
+    assert header.requests_root.is_some * (1 - header.requests_root.is_some) = 0;
+    let requests_root = cast(header.requests_root.value, Uint256*);
+    assert [range_check_ptr] = requests_root.low;
+    let range_check_ptr = range_check_ptr + 1;
+    assert [range_check_ptr] = requests_root.high;
+    let range_check_ptr = range_check_ptr + 1;
+    // extra_data_len
+    assert [range_check_ptr] = header.extra_data_len;
+    let range_check_ptr = range_check_ptr + 1;
+
+    with_attr error_message("InvalidBlock") {
+        assert [range_check_ptr] = header.gas_limit - header.gas_used;
+        let range_check_ptr = range_check_ptr + 1;
+        let expected_base_fee_per_gas = calculate_base_fee_per_gas(
+            header.gas_limit,
+            parent_header.gas_limit,
+            parent_header.gas_used,
+            parent_header.base_fee_per_gas.value,
+        );
+
+        assert expected_base_fee_per_gas = header.base_fee_per_gas.value;
+        assert [range_check_ptr] = header.timestamp - parent_header.timestamp - 1;
+        assert [range_check_ptr + 1] = header.number - parent_header.number - 1;
+        assert [range_check_ptr + 2] = 32 - header.extra_data_len;
+        let range_check_ptr = range_check_ptr + 3;
+        assert header.difficulty.low = 0;
+        assert header.difficulty.high = 0;
+        assert header.nonce = 0;
+        assert header.ommers_hash.low = EMPTY_OMMER_HASH_LOW;
+        assert header.ommers_hash.high = EMPTY_OMMER_HASH_HIGH;
+    }
+
+    // TODO: Implement block header hash check
+    // block_parent_hash = keccak256(rlp.encode(parent_header))
+    // if header.parent_hash != block_parent_hash:
+    //     raise InvalidBlock
+    return ();
+}

--- a/cairo/programs/fork.cairo
+++ b/cairo/programs/fork.cairo
@@ -59,9 +59,9 @@ func calculate_base_fee_per_gas{range_check_ptr}(
             target_fee_gas_delta, BASE_FEE_MAX_CHANGE_DENOMINATOR
         );
         if (base_fee_per_gas_delta == 0) {
-            return 1;
+            return parent_base_fee_per_gas + 1;
         }
-        return base_fee_per_gas_delta;
+        return parent_base_fee_per_gas + base_fee_per_gas_delta;
     }
 
     let gas_used_delta = parent_gas_target - parent_gas_used;

--- a/cairo/tests/fixtures/data.py
+++ b/cairo/tests/fixtures/data.py
@@ -1,6 +1,36 @@
 import pytest
+from hypothesis import strategies as st
 
 from tests.utils.models import Account, Block, State
+
+block_header_strategy = st.fixed_dictionaries(
+    {
+        "parent_hash": st.binary(min_size=32, max_size=32),
+        "ommers_hash": st.just(
+            bytes.fromhex(
+                "1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+            )
+        ),
+        "coinbase": st.binary(min_size=20, max_size=20),
+        "state_root": st.binary(min_size=32, max_size=32),
+        "transactions_root": st.binary(min_size=32, max_size=32),
+        "receipt_root": st.binary(min_size=32, max_size=32),
+        "bloom": st.binary(min_size=256, max_size=256),
+        "difficulty": st.just(0x00),
+        "number": st.integers(min_value=0, max_value=2**64 - 1),
+        "gas_limit": st.integers(min_value=0, max_value=2**64 - 1),
+        "gas_used": st.integers(min_value=0, max_value=2**64 - 1),
+        "timestamp": st.integers(min_value=0, max_value=2**64 - 1),
+        "extra_data": st.binary(max_size=32),
+        "prev_randao": st.binary(min_size=32, max_size=32),
+        "nonce": st.just("0x0000000000000000"),
+        "base_fee_per_gas": st.integers(min_value=0, max_value=2**128 - 1),
+        "withdrawals_root": st.binary(min_size=32, max_size=32),
+        "blob_gas_used": st.integers(min_value=0, max_value=2**64 - 1),
+        "excess_blob_gas": st.integers(min_value=0, max_value=2**64 - 1),
+        "parent_beacon_block_root": st.binary(min_size=32, max_size=32),
+    }
+)
 
 
 @pytest.fixture

--- a/cairo/tests/fixtures/data.py
+++ b/cairo/tests/fixtures/data.py
@@ -24,7 +24,7 @@ block_header_strategy = st.fixed_dictionaries(
         "extra_data": st.binary(max_size=32),
         "prev_randao": st.binary(min_size=32, max_size=32),
         "nonce": st.just("0x0000000000000000"),
-        "base_fee_per_gas": st.integers(min_value=0, max_value=2**128 - 1),
+        "base_fee_per_gas": st.integers(min_value=0, max_value=2**64 - 1),
         "withdrawals_root": st.binary(min_size=32, max_size=32),
         "blob_gas_used": st.integers(min_value=0, max_value=2**64 - 1),
         "excess_blob_gas": st.integers(min_value=0, max_value=2**64 - 1),

--- a/cairo/tests/programs/test_fork.cairo
+++ b/cairo/tests/programs/test_fork.cairo
@@ -1,0 +1,48 @@
+from programs.fork import check_gas_limit, calculate_base_fee_per_gas, validate_header, Uint128
+from src.model import model
+
+func test_check_gas_limit{range_check_ptr}() {
+    tempvar gas_limit: Uint128;
+    tempvar parent_gas_limit: Uint128;
+    %{
+        ids.gas_limit = program_input["gas_limit"]
+        ids.parent_gas_limit = program_input["parent_gas_limit"]
+    %}
+    check_gas_limit(gas_limit, parent_gas_limit);
+
+    return ();
+}
+
+func test_calculate_base_fee_per_gas{range_check_ptr}() -> Uint128 {
+    tempvar block_gas_limit: Uint128;
+    tempvar parent_gas_limit: Uint128;
+    tempvar parent_gas_used: Uint128;
+    tempvar parent_base_fee_per_gas: Uint128;
+    %{
+        ids.block_gas_limit = program_input["block_gas_limit"]
+        ids.parent_gas_limit = program_input["parent_gas_limit"]
+        ids.parent_gas_used = program_input["parent_gas_used"]
+        ids.parent_base_fee_per_gas = program_input["parent_base_fee_per_gas"]
+    %}
+    return calculate_base_fee_per_gas(
+        block_gas_limit, parent_gas_limit, parent_gas_used, parent_base_fee_per_gas
+    );
+}
+
+func test_validate_header{range_check_ptr}() {
+    alloc_locals;
+    local header: model.BlockHeader*;
+    local parent_header: model.BlockHeader*;
+    %{
+        if '__dict_manager' not in globals():
+            from starkware.cairo.common.dict import DictManager
+            __dict_manager = DictManager()
+
+        from tests.utils.hints import gen_arg
+
+        ids.header = gen_arg(__dict_manager, segments, program_input["header"])
+        ids.parent_header = gen_arg(__dict_manager, segments, program_input["parent_header"])
+    %}
+    validate_header([header], [parent_header]);
+    return ();
+}

--- a/cairo/tests/programs/test_fork.py
+++ b/cairo/tests/programs/test_fork.py
@@ -5,7 +5,7 @@ from ethereum.cancun.fork import (
     validate_header,
 )
 from ethereum.exceptions import InvalidBlock
-from hypothesis import given
+from hypothesis import given, reproduce_failure
 from hypothesis.strategies import integers
 
 from tests.fixtures.data import block_header_strategy
@@ -35,10 +35,10 @@ class TestFork:
             )
 
     @given(
-        integers(min_value=0, max_value=2**128 - 1),
-        integers(min_value=0, max_value=2**128 - 1),
-        integers(min_value=0, max_value=2**128 - 1),
-        integers(min_value=0, max_value=2**128 - 1),
+        integers(min_value=0, max_value=2**64 - 1),
+        integers(min_value=0, max_value=2**64 - 1),
+        integers(min_value=0, max_value=2**64 - 1),
+        integers(min_value=0, max_value=2**64 - 1),
     )
     def test_calculate_base_fee_per_gas(
         self,

--- a/cairo/tests/programs/test_fork.py
+++ b/cairo/tests/programs/test_fork.py
@@ -5,7 +5,7 @@ from ethereum.cancun.fork import (
     validate_header,
 )
 from ethereum.exceptions import InvalidBlock
-from hypothesis import given, reproduce_failure
+from hypothesis import given
 from hypothesis.strategies import integers
 
 from tests.fixtures.data import block_header_strategy

--- a/cairo/tests/programs/test_fork.py
+++ b/cairo/tests/programs/test_fork.py
@@ -1,0 +1,99 @@
+from ethereum.cancun.blocks import Header
+from ethereum.cancun.fork import (
+    calculate_base_fee_per_gas,
+    check_gas_limit,
+    validate_header,
+)
+from ethereum.exceptions import InvalidBlock
+from hypothesis import given
+from hypothesis.strategies import integers
+
+from tests.fixtures.data import block_header_strategy
+from tests.utils.errors import cairo_error
+from tests.utils.models import BlockHeader
+
+
+class TestFork:
+    @given(
+        integers(min_value=0, max_value=2**128 - 1),
+        integers(min_value=0, max_value=2**128 - 1),
+    )
+    def test_check_gas_limit(self, cairo_run, gas_limit, parent_gas_limit):
+        error = check_gas_limit(gas_limit, parent_gas_limit)
+        if not error:
+            with cairo_error("InvalidBlock"):
+                cairo_run(
+                    "test_check_gas_limit",
+                    gas_limit=gas_limit,
+                    parent_gas_limit=parent_gas_limit,
+                )
+        else:
+            cairo_run(
+                "test_check_gas_limit",
+                gas_limit=gas_limit,
+                parent_gas_limit=parent_gas_limit,
+            )
+
+    @given(
+        integers(min_value=0, max_value=2**128 - 1),
+        integers(min_value=0, max_value=2**128 - 1),
+        integers(min_value=0, max_value=2**128 - 1),
+        integers(min_value=0, max_value=2**128 - 1),
+    )
+    def test_calculate_base_fee_per_gas(
+        self,
+        cairo_run,
+        block_gas_limit,
+        parent_gas_limit,
+        parent_gas_used,
+        parent_base_fee_per_gas,
+    ):
+        try:
+            expected = calculate_base_fee_per_gas(
+                block_gas_limit,
+                parent_gas_limit,
+                parent_gas_used,
+                parent_base_fee_per_gas,
+            )
+        except InvalidBlock:
+            expected = None
+
+        if expected is not None:
+            assert expected == cairo_run(
+                "test_calculate_base_fee_per_gas",
+                block_gas_limit=block_gas_limit,
+                parent_gas_limit=parent_gas_limit,
+                parent_gas_used=parent_gas_used,
+                parent_base_fee_per_gas=parent_base_fee_per_gas,
+            )
+        else:
+            with cairo_error("InvalidBlock"):
+                cairo_run(
+                    "test_calculate_base_fee_per_gas",
+                    block_gas_limit=block_gas_limit,
+                    parent_gas_limit=parent_gas_limit,
+                    parent_gas_used=parent_gas_used,
+                    parent_base_fee_per_gas=parent_base_fee_per_gas,
+                )
+
+    @given(header=block_header_strategy, parent_header=block_header_strategy)
+    def test_validate_header(self, cairo_run, header, parent_header):
+        error = None
+        try:
+            validate_header(Header(**header), Header(**parent_header))
+        except InvalidBlock as e:
+            error = e
+
+        if error is not None:
+            with cairo_error("InvalidBlock"):
+                cairo_run(
+                    "test_validate_header",
+                    header=BlockHeader.model_validate(header),
+                    parent_header=BlockHeader.model_validate(parent_header),
+                )
+        else:
+            cairo_run(
+                "test_validate_header",
+                header=BlockHeader.model_validate(header),
+                parent_header=BlockHeader.model_validate(parent_header),
+            )

--- a/cairo/tests/utils/models.py
+++ b/cairo/tests/utils/models.py
@@ -68,6 +68,7 @@ class BlockHeader(BaseModelIterValuesOnly):
             "withdrawals_root",
             "difficulty",
             "mix_hash",
+            "prev_randao",
         ]:
             if key not in values:
                 key = to_camel(key)
@@ -125,7 +126,7 @@ class BlockHeader(BaseModelIterValuesOnly):
             raise ValueError("Bloom cannot be empty")
         if len(bloom) != 256:
             raise ValueError("Bloom must be 256 bytes")
-        return tuple(int(chunk) for chunk in wrap(bloom.hex(), 32))
+        return tuple(int(chunk, 16) for chunk in wrap(bloom.hex(), 32))
 
     parent_hash_low: int
     parent_hash_high: int
@@ -179,8 +180,16 @@ class BlockHeader(BaseModelIterValuesOnly):
     gas_limit: int
     gas_used: int
     timestamp: int
-    mix_hash_low: int
-    mix_hash_high: int
+    mix_hash_low: int = Field(
+        validation_alias=AliasChoices(
+            "mix_hash", "mixHash", "prev_randao", "prevRandao"
+        )
+    )
+    mix_hash_high: int = Field(
+        validation_alias=AliasChoices(
+            "mixHashHigh", "prev_randao_high", "prevRandaoHigh"
+        )
+    )
     nonce: int
     base_fee_per_gas_is_some: bool
     base_fee_per_gas_value: int

--- a/cairo/tests/utils/parsers.py
+++ b/cairo/tests/utils/parsers.py
@@ -1,13 +1,18 @@
+import re
 from typing import Optional, Union
+
+hex_pattern = re.compile(r"^(0x)?[0-9a-fA-F]+$")
 
 
 def to_int(v: Optional[Union[str, int]]) -> Optional[int]:
     if v is None:
         return v
     if isinstance(v, str):
-        if v.startswith("0x"):
+        if hex_pattern.match(v):
             return int(v, 16)
         return int(v)
+    if isinstance(v, bytes):
+        return int.from_bytes(v, "big")
     return v
 
 


### PR DESCRIPTION
### Why

In order to make sure that keth closely follows the ethereum spec, we need to make sure that the fork rules are correctly implemented.

One of the best way to do this is to work with diff testing.

### What

Refactor the codebase to be closer to the execution spec and diff test every function.

### How

Create a file structure that mimics the one in the execution specs and implement the required functions in order.

This PR starts with the `validate_header` function.
