### PR TITLE
fix: felt_to_bytes_little loop stop condition

### DIFF
--- a/cairo/src/utils/bytes.cairo
+++ b/cairo/src/utils/bytes.cairo
@@ -99,6 +99,7 @@ func felt_to_bytes_little{range_check_ptr}(dst: felt*, value: felt) -> felt {
     let lower_bound = [ap - 1];
     let upper_bound = pow256_address[bytes_len];
     with_attr error_message("bytes_len is not the minimal possible") {
+        assert_le_felt(bytes_len, 31);
         assert_le_felt(lower_bound, initial_value);
         assert_le_felt(initial_value, upper_bound - 1);
     }

--- a/cairo/tests/src/utils/test_bytes.py
+++ b/cairo/tests/src/utils/test_bytes.py
@@ -71,6 +71,19 @@ class TestBytes:
             ):
                 cairo_run("test__felt_to_bytes_little", n=n)
 
+        def test_should_raise_when_bytes_len_is_greater_than_31(
+            self, cairo_program, cairo_run
+        ):
+            with (
+                patch_hint(
+                    cairo_program,
+                    "memory[ids.output] = res = (int(ids.value) % PRIME) % ids.base\nassert res < ids.bound, f'split_int(): Limb {res} is out of range.'",
+                    "memory[ids.output] = 2 if ids.bytes_len < 3 else (int(ids.value) % PRIME) % ids.base\nprint(f'[DEBUG] Byte value: {memory[ids.output]}')",
+                ),
+                cairo_error(message="bytes_len is not the minimal possible"),
+            ):
+                cairo_run("test__felt_to_bytes_little", n=3)
+
     class TestFeltToBytes:
         @given(n=integers(min_value=0, max_value=2**248 - 1))
         def test_should_return_bytes(self, cairo_run, n):


### PR DESCRIPTION
Closes https://github.com/kkrt-labs/keth/issues/145
Add a missing constraint to ensure `bytes_len` cannot be greater to `31` in `felt_to_bytes_little`

Note to reviewer: this is a fix imported from C4 mitigation, ensure the fix was correctly ported by looking at the corresponding issue and PR.
