### PR TITLE
fix: decode legacy chain id overflow

### DIFF
--- a/cairo/src/utils/transaction.cairo
+++ b/cairo/src/utils/transaction.cairo
@@ -68,6 +68,7 @@ namespace Transaction {
 
         // pre eip-155 txs have 6 fields, post eip-155 txs have 9 fields
         if (items_len == 6) {
+            tempvar range_check_ptr = range_check_ptr;
             tempvar is_some = 0;
             tempvar chain_id = 0;
         } else {
@@ -75,11 +76,15 @@ namespace Transaction {
             assert items[6].is_list = FALSE;
             assert items[7].is_list = FALSE;
             assert items[8].is_list = FALSE;
+
+            assert_nn(31 - items[6].data_len);
             let chain_id = Helpers.bytes_to_felt(items[6].data_len, items[6].data);
 
+            tempvar range_check_ptr = range_check_ptr;
             tempvar is_some = 1;
             tempvar chain_id = chain_id;
         }
+        let range_check_ptr = [ap - 3];
         let is_some = [ap - 2];
         let chain_id = [ap - 1];
 

--- a/cairo/tests/src/utils/test_transaction.py
+++ b/cairo/tests/src/utils/test_transaction.py
@@ -28,6 +28,20 @@ class TestTransaction:
             with cairo_error():
                 cairo_run("test__decode", data=list(encode(list(transaction.values()))))
 
+        def test_should_raise_if_chain_id_overflow_legacy_transaction(self, cairo_run):
+            transaction = {
+                "nonce": 0,
+                "gasPrice": 234567897654321,
+                "gas": 2_000_000,
+                "to": "0xF0109fC8DF283027b6285cc889F5aA624EaC1F55",
+                "value": 1_000_000_000,
+                "data": b"",
+                "chainId": 2**252,
+            }
+            with cairo_error(message="assert_nn(31 - items[6].data_len);"):
+                encoded_unsigned_tx = rlp_encode_signed_data(transaction)
+                cairo_run("test__decode", data=list(encoded_unsigned_tx))
+
         @given(value=st.integers(min_value=2**248))
         @pytest.mark.parametrize("transaction", TRANSACTIONS)
         @pytest.mark.parametrize(

--- a/cairo/tests/utils/errors.py
+++ b/cairo/tests/utils/errors.py
@@ -13,6 +13,6 @@ def cairo_error(message=None):
             return
         error = re.search(r"Error message: (.*)", str(e.value))
         error = error.group(1) if error else str(e.value)
-        assert message == error, f"Expected {message}, got {error}"
+        assert message in error, f"Expected {message}, got {error}"
     finally:
         pass


### PR DESCRIPTION
Closes #148
Adds missing constraint in `decode_legacy_tx` to ensure there is no overflow for `chain_id`

Note to reviewer: this is a fix imported from C4 mitigation, ensure the fix was correctly ported by looking at the corresponding issue and PR.