### PR TITLE
fix: underconstrained initialize_jumpdests

### DIFF
--- a/cairo/src/utils/utils.cairo
+++ b/cairo/src/utils/utils.cairo
@@ -877,6 +877,11 @@ namespace Helpers {
         let valid_jumpdests = cast([ap - 2], DictAccess*);
         let i = [ap - 1];
 
+        with_attr error_message("Reading out of bounds bytecode") {
+            assert [range_check_ptr] = bytecode_len - 1 - i;
+        }
+        let range_check_ptr = range_check_ptr + 1;
+
         tempvar opcode = [bytecode + i];
         let is_opcode_ge_0x5f = Helpers.is_le_unchecked(0x5f, opcode);
         let is_opcode_le_0x7f = Helpers.is_le_unchecked(opcode, 0x7f);

--- a/cairo/tests/src/utils/test_utils.cairo
+++ b/cairo/tests/src/utils/test_utils.cairo
@@ -9,6 +9,7 @@ from starkware.cairo.common.default_dict import default_dict_new
 
 from src.utils.utils import Helpers
 from src.constants import Constants
+from tests.utils.dict import dict_keys
 
 func test__bytes_to_uint256{range_check_ptr}() -> Uint256 {
     alloc_locals;
@@ -104,6 +105,28 @@ func test__try_parse_destination_from_bytes{range_check_ptr}(output_ptr: felt*) 
     // Then
     assert [output_ptr] = maybe_address.is_some;
     assert [output_ptr + 1] = maybe_address.value;
+
+    return ();
+}
+
+func test__initialize_jumpdests{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    output_ptr: felt*
+) {
+    alloc_locals;
+
+    tempvar bytecode_len;
+    let (bytecode) = alloc();
+
+    %{
+        ids.bytecode_len = len(program_input["bytecode"])
+        segments.write_arg(ids.bytecode, program_input["bytecode"])
+    %}
+
+    let (valid_jumpdests_start, valid_jumpdests) = Helpers.initialize_jumpdests(
+        bytecode_len, bytecode
+    );
+    let (keys_len, keys) = dict_keys(valid_jumpdests_start, valid_jumpdests);
+    memcpy(output_ptr, keys, keys_len);
 
     return ();
 }

--- a/cairo/tests/utils/dict.cairo
+++ b/cairo/tests/utils/dict.cairo
@@ -1,0 +1,39 @@
+from starkware.cairo.common.alloc import alloc
+from starkware.cairo.common.dict_access import DictAccess
+from src.utils.maths import unsigned_div_rem
+
+func dict_keys{range_check_ptr}(dict_start: DictAccess*, dict_end: DictAccess*) -> (
+    keys_len: felt, keys: felt*
+) {
+    alloc_locals;
+    let (local keys_start: felt*) = alloc();
+    let dict_len = dict_end - dict_start;
+    let (local keys_len, _) = unsigned_div_rem(dict_len, DictAccess.SIZE);
+    local range_check_ptr = range_check_ptr;
+
+    if (dict_len == 0) {
+        return (keys_len, keys_start);
+    }
+
+    tempvar keys = keys_start;
+    tempvar len = keys_len;
+    tempvar dict = dict_start;
+
+    loop:
+    let keys = cast([ap - 3], felt*);
+    let len = [ap - 2];
+    let dict = cast([ap - 1], DictAccess*);
+
+    assert [keys] = dict.key;
+    tempvar keys = keys + 1;
+    tempvar len = len - 1;
+    tempvar dict = dict + DictAccess.SIZE;
+
+    static_assert keys == [ap - 3];
+    static_assert len == [ap - 2];
+    static_assert dict == [ap - 1];
+
+    jmp loop if len != 0;
+
+    return (keys_len, keys_start);
+}

--- a/cairo/tests/utils/hints.py
+++ b/cairo/tests/utils/hints.py
@@ -162,12 +162,25 @@ def implement_hints(program):
 
 
 @contextmanager
-def patch_hint(program, hint, new_hint):
+def patch_hint(program, hint, new_hint, scope: Optional[str] = None):
+    """
+    Patch a Cairo hint in a program with a new hint.
+    Args:
+        program: The Cairo program containing the hints
+        hint: The original hint code to replace
+        new_hint: The new hint code to use instead
+        scope: Optional scope name to restrict which hints are patched. If provided,
+              only hints in scope containing this string will be patched.
+    Example:
+        with patch_hint(program, "old_hint", "new_hint", "initialize_jumpdests"):
+            # Code that runs with the patched hint
+    """
     patched_hints = {
         k: [
             (
                 hint_
                 if hint_.code != hint
+                or (scope is not None and scope not in str(hint_.accessible_scopes[-1]))
                 else CairoHint(
                     accessible_scopes=hint_.accessible_scopes,
                     flow_tracking_data=hint_.flow_tracking_data,

--- a/solidity_contracts/src/mocks/Counter.sol
+++ b/solidity_contracts/src/mocks/Counter.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+contract Counter {
+    uint256 public count;
+
+    modifier greaterThanZero() {
+        require(count > 0, "count should be strictly greater than 0");
+        _;
+    }
+
+    constructor() {
+        count = 0;
+    }
+
+    function inc() public {
+        count += 1;
+    }
+
+    function dec() public {
+        count -= 1;
+    }
+
+    function decInPlace() public {
+        count--;
+    }
+
+    function decWithModifier() public greaterThanZero {
+        count -= 1;
+    }
+
+    function decUnchecked() public {
+        unchecked {
+            count -= 1;
+        }
+    }
+
+    function reset() public {
+        count = 0;
+    }
+
+    function incForLoop(uint256 iterations) public {
+        count = 0;
+        for (uint256 i = 0; i < iterations; i++) {
+            count++;
+        }
+    }
+
+    function incWhileLoop(uint256 iterations) public {
+        count = 0;
+        while (count < iterations) {
+            count++;
+        }
+    }
+}


### PR DESCRIPTION
Closes #158

Avoids a malicious prover to continue iterating over the bytecode limit and consuming extra resources, but has no impact over code execution

Note to reviewer: this is a fix imported from C4 mitigation, ensure the fix was correctly ported by looking at the corresponding issue and PR.