### PR TITLE
dev: remove useless computation in uint256_fast_exp

### DIFF
--- a/cairo/src/utils/uint256.cairo
+++ b/cairo/src/utils/uint256.cairo
@@ -367,7 +367,6 @@ func uint256_fast_exp{range_check_ptr}(value: Uint256, exponent: Uint256) -> Uin
         return res;
     }
 
-    let pow = uint256_fast_exp(value, half_exponent);
     let (res, _) = uint256_mul(pow, pow);
     return res;
 }


### PR DESCRIPTION
Closes #151

Remove useless computation in `uint256_fast_exp`

Note to reviewer: this is a fix imported from C4 mitigation, ensure the fix was correctly ported by looking at the corresponding issue and PR.