### PR TITLE
fix: stack_size_diff

### DIFF
--- a/cairo/src/constants.cairo
+++ b/cairo/src/constants.cairo
@@ -77,13 +77,13 @@ dw 0x08;
 dw Gas.MID;
 dw 3;
 dw 3;
-dw -1;
+dw -2;
 // MULMOD
 dw 0x09;
 dw Gas.MID;
 dw 3;
 dw 3;
-dw -1;
+dw -2;
 // EXP
 dw 0x0a;
 dw Gas.EXPONENTIATION;
@@ -179,7 +179,7 @@ dw 0x19;
 dw Gas.VERY_LOW;
 dw 1;
 dw 1;
-dw -1;
+dw 0;
 // BYTE
 dw 0x1a;
 dw Gas.VERY_LOW;
@@ -359,7 +359,7 @@ dw 0x37;
 dw Gas.VERY_LOW;
 dw 3;
 dw 3;
-dw 0;
+dw -3;
 // CODESIZE
 dw 0x38;
 dw Gas.BASE;
@@ -371,7 +371,7 @@ dw 0x39;
 dw Gas.VERY_LOW;
 dw 3;
 dw 3;
-dw 0;
+dw -3;
 // GASPRICE
 dw 0x3a;
 dw Gas.BASE;
@@ -401,7 +401,7 @@ dw 0x3e;
 dw Gas.VERY_LOW;
 dw 3;
 dw 3;
-dw 0;
+dw -3;
 // EXTCODEHASH
 dw 0x3f;
 dw 0;


### PR DESCRIPTION
Close #162

Several of the stack_size_diff values defined in constants.cairo are off put the right values.

Note to reviewer: this is a fix imported from C4 mitigation, ensure the fix was correctly ported by looking at the corresponding issue and PR.