### PR TITLE
fix: add constraint on nibbles

### DIFF
--- a/cairo/ethereum/cancun/trie.cairo
+++ b/cairo/ethereum/cancun/trie.cairo
@@ -84,8 +84,8 @@ func encode_internal_node{
     range_check_ptr, bitwise_ptr: BitwiseBuiltin*, keccak_ptr: KeccakBuiltin*
 }(node: InternalNode) -> Extended {
     alloc_locals;
-
     local unencoded: Extended;
+    local range_check_ptr_end;
 
     tempvar is_leaf = cast(node.value.leaf_node.value, felt);
     jmp leaf_node if is_leaf != 0;
@@ -110,6 +110,7 @@ func encode_internal_node{
     tempvar sequence = SequenceExtended(new SequenceExtendedStruct(sequence_data, 2));
     let unencoded_ = ExtendedImpl.sequence(sequence);
     assert unencoded = unencoded_;
+    assert range_check_ptr_end = range_check_ptr;
     jmp common;
 
     extension_node:
@@ -121,6 +122,7 @@ func encode_internal_node{
     tempvar sequence = SequenceExtended(new SequenceExtendedStruct(sequence_data, 2));
     let unencoded_ = ExtendedImpl.sequence(sequence);
     assert unencoded = unencoded_;
+    assert range_check_ptr_end = range_check_ptr;
     jmp common;
 
     branch_node:
@@ -132,9 +134,11 @@ func encode_internal_node{
     tempvar sequence = SequenceExtended(new SequenceExtendedStruct(value, len + 1));
     let unencoded_ = ExtendedImpl.sequence(sequence);
     assert unencoded = unencoded_;
+    assert range_check_ptr_end = range_check_ptr;
     jmp common;
 
     common:
+    let range_check_ptr = range_check_ptr_end;
     let encoded = encode(unencoded);
 
     let cond = is_le(encoded.value.len, 32 - 1);
@@ -238,9 +242,10 @@ func common_prefix_length(a: Bytes, b: Bytes) -> felt {
     return result;
 }
 
-func nibble_list_to_compact(x: Bytes, is_leaf: bool) -> Bytes {
+func nibble_list_to_compact{range_check_ptr: felt}(x: Bytes, is_leaf: bool) -> Bytes {
     alloc_locals;
     let (local compact) = alloc();
+    local range_check_ptr_end;
 
     if (x.value.len == 0) {
         assert [compact] = 16 * (2 * is_leaf.value);
@@ -248,8 +253,15 @@ func nibble_list_to_compact(x: Bytes, is_leaf: bool) -> Bytes {
         return result;
     }
 
-    local remainder = nondet %{ ids.x.value.len % 2 %};
-    assert remainder * (1 - remainder) = 0;
+    // TODO: add a way to patch `nondet %{ ids.x.value.len % 2 %};` in test runner
+    local remainder;
+    %{ ids.remainder = ids.x.value.len % 2 %}
+    with_attr error_message("nibble_list_to_compact: invalid remainder") {
+        assert remainder * (1 - remainder) = 0;
+        tempvar underflow_check = (x.value.len - remainder) / 2;
+        assert [range_check_ptr] = underflow_check;
+    }
+    let range_check_ptr = range_check_ptr + 1;
     assert [compact] = 16 * (2 * is_leaf.value + remainder) + x.value.data[0] * remainder;
 
     if (x.value.len == 1) {
@@ -259,6 +271,7 @@ func nibble_list_to_compact(x: Bytes, is_leaf: bool) -> Bytes {
 
     tempvar compact = compact + 1;
     tempvar i = remainder;
+    assert range_check_ptr_end = range_check_ptr;
 
     loop:
     let compact = cast([ap - 2], felt*);
@@ -276,6 +289,7 @@ func nibble_list_to_compact(x: Bytes, is_leaf: bool) -> Bytes {
     let len = (i - remainder) / 2;
 
     let compact = cast([fp], felt*);
+    let range_check_ptr = range_check_ptr_end;
     tempvar result = Bytes(new BytesStruct(compact, 1 + len));
     return result;
 }

--- a/cairo/ethereum/cancun/trie.cairo
+++ b/cairo/ethereum/cancun/trie.cairo
@@ -253,9 +253,7 @@ func nibble_list_to_compact{range_check_ptr: felt}(x: Bytes, is_leaf: bool) -> B
         return result;
     }
 
-    // TODO: add a way to patch `nondet %{ ids.x.value.len % 2 %};` in test runner
-    local remainder;
-    %{ ids.remainder = ids.x.value.len % 2 %}
+    local remainder = nondet %{ ids.x.value.len % 2 %};
     with_attr error_message("nibble_list_to_compact: invalid remainder") {
         assert remainder * (1 - remainder) = 0;
         tempvar underflow_check = (x.value.len - remainder) / 2;

--- a/cairo/tests/ethereum/cancun/test_trie.py
+++ b/cairo/tests/ethereum/cancun/test_trie.py
@@ -64,6 +64,22 @@ class TestTrie:
             "nibble_list_to_compact", x, is_leaf
         )
 
+    @given(x=nibble.filter(lambda x: len(x) != 0), is_leaf=...)
+    def test_nibble_list_to_compact_should_raise_when_wrong_remainder(
+        self, cairo_program, cairo_run, x, is_leaf: bool
+    ):
+        with (
+            patch_hint(
+                cairo_program,
+                "ids.remainder = ids.x.value.len % 2",
+                "ids.remainder = not (ids.x.value.len % 2)",
+            ),
+            cairo_error(message="nibble_list_to_compact: invalid remainder"),
+        ):
+            nibble_list_to_compact(x, is_leaf) == cairo_run(
+                "nibble_list_to_compact", x, is_leaf
+            )
+
     @given(bytes_=...)
     def test_bytes_to_nibble_list(self, cairo_run, bytes_: Bytes):
         assert bytes_to_nibble_list(bytes_) == cairo_run("bytes_to_nibble_list", bytes_)

--- a/cairo/tests/ethereum/cancun/test_trie.py
+++ b/cairo/tests/ethereum/cancun/test_trie.py
@@ -71,8 +71,8 @@ class TestTrie:
         with (
             patch_hint(
                 cairo_program,
-                "ids.remainder = ids.x.value.len % 2",
-                "ids.remainder = not (ids.x.value.len % 2)",
+                "nondet %{ ids.x.value.len % 2 %};",
+                "nondet %{ not (ids.x.value.len % 2) %};",
             ),
             cairo_error(message="nibble_list_to_compact: invalid remainder"),
         ):

--- a/cairo/tests/utils/hints.py
+++ b/cairo/tests/utils/hints.py
@@ -170,15 +170,13 @@ def patch_hint(program, hint: str, new_hint: str, scope: Optional[str] = None):
     1. Nondet hints in the format: 'nondet %{arg%};'
     2. Regular hints with arbitrary code
 
-    When patching nondet hints, the function will automatically handle the memory assignment
-    pattern 'memory[fp + <i>] = to_felt_or_relocatable(arg)'.
+    When patching nondet hints, the function will automatically look for the memory assignment
+    pattern 'memory[fp + <i>] = to_felt_or_relocatable(arg)' and replace the argument.
 
     Args:
         program: The Cairo program containing the hints to patch
         hint: The original hint code to replace. Can be either a regular hint or a nondet hint.
-        new_hint: The new hint code to use. For nondet hints, this can be either:
-                 - A new nondet hint (will preserve the nondet format)
-                 - Raw code (will be inserted into the memory assignment)
+        new_hint: The new hint code to use. For nondet hints, this should be a new nondet hint.
         scope: Optional scope name to restrict which hints are patched. If provided,
                only hints within matching scopes will be modified
 
@@ -235,7 +233,7 @@ def patch_hint(program, hint: str, new_hint: str, scope: Optional[str] = None):
                         CairoHint(
                             accessible_scopes=hint_.accessible_scopes,
                             flow_tracking_data=hint_.flow_tracking_data,
-                            code=f"memory[{mem_loc}] = to_felt_or_relocatable({new_nondet_arg or new_hint})",
+                            code=f"memory[{mem_loc}] = to_felt_or_relocatable({new_nondet_arg})",
                         )
                     )
                 else:


### PR DESCRIPTION
Closes https://github.com/kkrt-labs/keth/issues/212
Closes https://github.com/kkrt-labs/keth/issues/214

- Adds a constraint that `(x.value.len - remainder) / 2;` is in range [0, range_check[; if it doesn't, the prover has provided a wrong value.

- Adds support to patch `nondet` hints.