### PR TITLE
fix: set code_address of the deployment code to the created address

### DIFF
--- a/cairo/src/instructions/system_operations.cairo
+++ b/cairo/src/instructions/system_operations.cairo
@@ -151,7 +151,6 @@ namespace SystemOperations {
         let (valid_jumpdests_start, valid_jumpdests) = Helpers.initialize_jumpdests(
             bytecode_len=size.low, bytecode=bytecode
         );
-        tempvar address_zero = 0;
         tempvar message = new model.Message(
             bytecode=bytecode,
             bytecode_len=size.low,
@@ -163,7 +162,7 @@ namespace SystemOperations {
             caller=evm.message.address,
             parent=parent,
             address=target_address,
-            code_address=address_zero,
+            code_address=target_address,
             read_only=FALSE,
             is_create=TRUE,
             depth=evm.message.depth + 1,

--- a/cairo/src/interpreter.cairo
+++ b/cairo/src/interpreter.cairo
@@ -860,7 +860,7 @@ namespace Interpreter {
         local bytecode: felt*;
         local calldata: felt*;
         local intrinsic_gas: felt;
-        local code_address: felt;
+        let code_address = address;
         if (is_deploy_tx != FALSE) {
             let (empty: felt*) = alloc();
             let (init_code_words, _) = unsigned_div_rem(bytecode_len + 31, 32);
@@ -868,13 +868,11 @@ namespace Interpreter {
             assert bytecode = tmp_calldata;
             assert calldata = empty;
             assert intrinsic_gas = tmp_intrinsic_gas + Gas.CREATE + init_code_gas;
-            assert code_address = 0;
             tempvar range_check_ptr = range_check_ptr;
         } else {
             assert bytecode = tmp_bytecode;
             assert calldata = tmp_calldata;
             assert intrinsic_gas = tmp_intrinsic_gas;
-            assert code_address = address;
             tempvar range_check_ptr = range_check_ptr;
         }
 

--- a/cairo/tests/programs/test_os.py
+++ b/cairo/tests/programs/test_os.py
@@ -229,7 +229,6 @@ class TestOs:
             state=State.model_validate(initial_state),
         )
 
-
     def test_create_opcode(self, cairo_run):
         plain_opcodes = get_contract("PlainOpcodes", "PlainOpcodes")
 

--- a/cairo/tests/programs/test_os.py
+++ b/cairo/tests/programs/test_os.py
@@ -187,3 +187,84 @@ class TestOs:
         bytes.fromhex(
             "7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3"
         ) == state["accounts"]["0x32dCAB0EF3FB2De2fce1D2E0799D36239671F04A"]["code"]
+
+    def test_jump_creation_code_deploy_tx_should_succeed(self, cairo_run):
+        initial_state = {
+            OWNER: {
+                "code": [],
+                "storage": {},
+                "balance": int(1e18),
+                "nonce": 0,
+            },
+            "0x32dCAB0EF3FB2De2fce1D2E0799D36239671F04A": {
+                "code": [],
+                "storage": {},
+                "balance": 0,
+                "nonce": 0,
+            },
+            COINBASE: {
+                "code": [],
+                "storage": {},
+                "balance": int(1e18),
+                "nonce": 0,
+            },
+            "0xc68b9a5f0f00048f2956aac21cba12fb731a1934": {
+                "code": [],
+                "storage": {},
+                "balance": 0,
+                "nonce": 0,
+            },
+        }
+        transactions = [
+            {
+                "to": "",
+                "data": bytes.fromhex("605f5f53605660015360025f5ff0"),
+                "value": 0,
+                "signer": OWNER,
+            }
+        ]
+        cairo_run(
+            "test_os",
+            block=block(transactions),
+            state=State.model_validate(initial_state),
+        )
+
+
+    def test_create_opcode(self, cairo_run):
+        plain_opcodes = get_contract("PlainOpcodes", "PlainOpcodes")
+
+        initial_state = {
+            plain_opcodes.address: {
+                "code": list(plain_opcodes.bytecode_runtime),
+                "storage": {},
+                "balance": 0,
+                "nonce": 0,
+            },
+            OWNER: {
+                "code": [],
+                "storage": {},
+                "balance": int(1e18),
+                "nonce": 0,
+            },
+            COINBASE: {
+                "code": [],
+                "storage": {},
+                "balance": int(1e18),
+                "nonce": 0,
+            },
+            "0x8bbc3514477d75ec797bbe4e19d7961660bb849c": {
+                "code": [],
+                "storage": {},
+                "balance": 0,
+                "nonce": 0,
+            },
+        }
+        transactions = [
+            plain_opcodes.create(bytes.fromhex("5f56"), 1, signer=OWNER),
+        ]
+
+        cairo_run(
+            "test_os",
+            block=block(transactions),
+            state=State.model_validate(initial_state),
+        )

--- a/solidity_contracts/src/mocks/PlainOpcodes.sol
+++ b/solidity_contracts/src/mocks/PlainOpcodes.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity >=0.8.0;
+
+/// @notice Contract for integration testing of EVM opcodes.
+/// @author Kakarot9000
+/// @dev Add functions and storage variables for opcodes accordingly.
+contract PlainOpcodes {
+    /*//////////////////////////////////////////////////////////////
+                                EVENTS
+    //////////////////////////////////////////////////////////////*/
+
+    event CreateAddress(address _address) anonymous;
+    event Create2Address(address _address) anonymous;
+
+    function create(bytes memory bytecode, uint256 count) public returns (address[] memory) {
+        address[] memory addresses = new address[](count);
+        address _address;
+        for (uint256 i = 0; i < count; i++) {
+            assembly {
+                _address := create(0, add(bytecode, 32), mload(bytecode))
+            }
+            addresses[i] = _address;
+            emit CreateAddress(_address);
+        }
+        return addresses;
+    }
+
+    function create2(bytes memory bytecode, uint256 salt) public returns (address _address) {
+        assembly {
+            _address := create2(0, add(bytecode, 32), mload(bytecode), salt)
+        }
+        emit Create2Address(_address);
+    }
+
+}

--- a/solidity_contracts/src/mocks/PlainOpcodes.sol
+++ b/solidity_contracts/src/mocks/PlainOpcodes.sol
@@ -31,5 +31,4 @@ contract PlainOpcodes {
         }
         emit Create2Address(_address);
     }
-
 }


### PR DESCRIPTION
Closes #149 

Set code_address of the deployment code to the created address

Note to reviewer: this is a fix imported from C4 mitigation, ensure the fix was correctly ported by looking at the corresponding issue and PR.