### PR TITLE
fix: ensure y_parity is 0 or 1

### DIFF
--- a/cairo/src/utils/signature.cairo
+++ b/cairo/src/utils/signature.cairo
@@ -18,7 +18,7 @@ namespace Signature {
     // A version of verify_eth_signature, with that msg_hash, r and s as Uint256 and
     // using the Cairo1 helpers class.
     func verify_eth_signature_uint256{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}(
-        msg_hash: Uint256, r: Uint256, s: Uint256, v: felt, eth_address: felt
+        msg_hash: Uint256, r: Uint256, s: Uint256, y_parity: felt, eth_address: felt
     ) {
         alloc_locals;
         let (msg_hash_bigint: BigInt3) = uint256_to_bigint(msg_hash);
@@ -30,9 +30,13 @@ namespace Signature {
             validate_signature_entry(s_bigint);
         }
 
+        with_attr error_message("Invalid y_parity") {
+            assert (1 - y_parity) * y_parity = 0;
+        }
+
         with_attr error_message("Invalid signature.") {
             let (success, recovered_address) = ICairo1Helpers.recover_eth_address(
-                msg_hash=msg_hash, r=r, s=s, y_parity=v
+                msg_hash=msg_hash, r=r, s=s, y_parity=y_parity
             );
             // TODO: uncomment when we have a working recover_eth_address
             // assert success = 1;

--- a/cairo/src/utils/transaction.cairo
+++ b/cairo/src/utils/transaction.cairo
@@ -412,7 +412,7 @@ namespace Transaction {
         let msg_hash = keccak(tx.rlp_len, tx.rlp);
 
         Signature.verify_eth_signature_uint256(
-            msg_hash=msg_hash, r=r, s=s, v=y_parity, eth_address=tx.sender
+            msg_hash=msg_hash, r=r, s=s, y_parity=y_parity, eth_address=tx.sender
         );
 
         return ();

--- a/cairo/tests/src/utils/test_signature.cairo
+++ b/cairo/tests/src/utils/test_signature.cairo
@@ -6,6 +6,8 @@ from src.utils.signature import Signature
 func test__verify_eth_signature_uint256{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}(
     msg_hash: U256, r: U256, s: U256, y_parity: felt, eth_address: felt
 ) {
-    Signature.verify_eth_signature_uint256([msg_hash.value], [r.value], [s.value], y_parity, eth_address);
+    Signature.verify_eth_signature_uint256(
+        [msg_hash.value], [r.value], [s.value], y_parity, eth_address
+    );
     return ();
 }

--- a/cairo/tests/src/utils/test_signature.cairo
+++ b/cairo/tests/src/utils/test_signature.cairo
@@ -1,0 +1,11 @@
+from starkware.cairo.common.cairo_builtins import BitwiseBuiltin
+
+from ethereum.base_types import U256
+from src.utils.signature import Signature
+
+func test__verify_eth_signature_uint256{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}(
+    msg_hash: U256, r: U256, s: U256, y_parity: felt, eth_address: felt
+) {
+    Signature.verify_eth_signature_uint256([msg_hash.value], [r.value], [s.value], y_parity, eth_address);
+    return ();
+}

--- a/cairo/tests/src/utils/test_signature.py
+++ b/cairo/tests/src/utils/test_signature.py
@@ -1,0 +1,16 @@
+from hypothesis import given, assume
+from hypothesis.strategies import integers
+
+from starkware.cairo.lang.cairo_constants import DEFAULT_PRIME
+from ethereum.base_types import U256
+from tests.utils.errors import cairo_error
+from tests.utils.strategies import felt
+
+class TestSignature:
+    @given(msg_hash=..., r=..., s=..., y_parity=integers(min_value=2, max_value=DEFAULT_PRIME - 1), eth_address=felt)
+    def test_should_raise_with_invalid_y_parity(
+        self, cairo_run, msg_hash: U256, r: U256, s: U256, y_parity, eth_address
+    ):
+        assume(r != 0 and s != 0)
+        with cairo_error("Invalid y_parity"):
+            cairo_run("test__verify_eth_signature_uint256", msg_hash, r, s, y_parity, eth_address)

--- a/cairo/tests/src/utils/test_signature.py
+++ b/cairo/tests/src/utils/test_signature.py
@@ -3,6 +3,7 @@ from hypothesis.strategies import integers
 from starkware.cairo.lang.cairo_constants import DEFAULT_PRIME
 
 from ethereum.base_types import U256
+from ethereum.crypto.elliptic_curve import SECP256K1N
 from tests.utils.errors import cairo_error
 from tests.utils.strategies import felt
 
@@ -19,6 +20,7 @@ class TestSignature:
         self, cairo_run, msg_hash: U256, r: U256, s: U256, y_parity, eth_address
     ):
         assume(r != 0 and s != 0)
+        assume(r < SECP256K1N and s < SECP256K1N)
         with cairo_error("Invalid y_parity"):
             cairo_run(
                 "test__verify_eth_signature_uint256",

--- a/cairo/tests/src/utils/test_signature.py
+++ b/cairo/tests/src/utils/test_signature.py
@@ -1,16 +1,30 @@
-from hypothesis import given, assume
+from hypothesis import assume, given
 from hypothesis.strategies import integers
-
 from starkware.cairo.lang.cairo_constants import DEFAULT_PRIME
+
 from ethereum.base_types import U256
 from tests.utils.errors import cairo_error
 from tests.utils.strategies import felt
 
+
 class TestSignature:
-    @given(msg_hash=..., r=..., s=..., y_parity=integers(min_value=2, max_value=DEFAULT_PRIME - 1), eth_address=felt)
+    @given(
+        msg_hash=...,
+        r=...,
+        s=...,
+        y_parity=integers(min_value=2, max_value=DEFAULT_PRIME - 1),
+        eth_address=felt,
+    )
     def test_should_raise_with_invalid_y_parity(
         self, cairo_run, msg_hash: U256, r: U256, s: U256, y_parity, eth_address
     ):
         assume(r != 0 and s != 0)
         with cairo_error("Invalid y_parity"):
-            cairo_run("test__verify_eth_signature_uint256", msg_hash, r, s, y_parity, eth_address)
+            cairo_run(
+                "test__verify_eth_signature_uint256",
+                msg_hash,
+                r,
+                s,
+                y_parity,
+                eth_address,
+            )


### PR DESCRIPTION
Closes #163

Ensure y_parity is 0 or 1. Adds also missing tests.

Note to reviewer: this is a fix imported from C4 mitigation, ensure the fix was correctly ported by looking at the corresponding issue and PR.