### PR TITLE
dev: remove dead code in exec_create

### DIFF
--- a/cairo/src/instructions/system_operations.cairo
+++ b/cairo/src/instructions/system_operations.cairo
@@ -180,10 +180,9 @@ namespace SystemOperations {
 
         let transfer = model.Transfer(evm.message.address, target_address, [value]);
         let success = State.add_transfer(transfer);
-        if (success == 0) {
-            Stack.push_uint128(0);
-            return child_evm;
-        }
+
+        // @dev: This transfer cannot fail, as the balance was checked before.
+        State.add_transfer(transfer);
 
         return child_evm;
     }


### PR DESCRIPTION
Closes #153 

Note to reviewer: this is a fix imported from C4 mitigation, ensure the fix was correctly ported by looking at the corresponding issue and PR.