### PR TITLE
fix: Selfdestruct send to burn address

### DIFF
--- a/cairo/src/instructions/system_operations.cairo
+++ b/cairo/src/instructions/system_operations.cairo
@@ -813,9 +813,9 @@ namespace SystemOperations {
 
         // If the account was created in the same transaction and recipient is self, the native token is burnt
         tempvar is_recipient_not_self = is_not_zero(recipient - evm.message.address);
-
         if (self_account.created != FALSE) {
-            tempvar recipient = is_recipient_not_self * recipient;
+            tempvar recipient = (1 - is_recipient_not_self) * Constants.BURN_ADDRESS +
+                is_recipient_not_self * recipient;
         } else {
             tempvar recipient = recipient;
         }


### PR DESCRIPTION
Close #157 

Note to reviewer: this is a fix imported from C4 mitigation, ensure the fix was correctly ported by looking at the corresponding issue and PR.