### PR TITLE
fix: Ensure sender nonce does not overflow

### DIFF
--- a/cairo/programs/os.cairo
+++ b/cairo/programs/os.cairo
@@ -87,6 +87,7 @@ func apply_transactions{
 
     // Validate nonce
     with_attr error_message("Invalid nonce") {
+        assert_le(tx.signer_nonce, 2 ** 64 - 2);
         assert tx.signer_nonce = account.nonce;
     }
 

--- a/cairo/tests/utils/data.py
+++ b/cairo/tests/utils/data.py
@@ -11,8 +11,8 @@ from tests.utils.constants import (
 from tests.utils.models import Block
 
 
-def block(transactions=None):
-    nonces = defaultdict(int)
+def block(transactions=None, nonces=None):
+    nonces = nonces or defaultdict(int)
     transactions = transactions or []
 
     for transaction in transactions:


### PR DESCRIPTION
Close #168 

Note to reviewer: this is a fix imported from C4 mitigation, ensure the fix was correctly ported by looking at the corresponding issue and PR.