### PR TITLE
dev: add pre-push trunk hook

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -88,7 +88,7 @@ lint:
 actions:
   disabled:
     - trunk-announce
-    - trunk-check-pre-push
     - trunk-fmt-pre-commit
   enabled:
+    - trunk-check-pre-push
     - trunk-upgrade-available


### PR DESCRIPTION
Adds the pre-push trunk hook back, to avoid cases where CI fails because of a lint check 