### PR TITLE
Simplify VMWithCoverage

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -7,6 +7,7 @@ permissions: read-all
 
 jobs:
   paths-filter:
+    name: Paths filter
     runs-on: ubuntu-latest
     outputs:
       src: ${{ steps.filter.outputs.src }}

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ cairo/tests/ef_tests/test_data
 .vscode/
 
 cache
+prof
+profile*.png

--- a/cairo/tests/programs/test_os.py
+++ b/cairo/tests/programs/test_os.py
@@ -1,5 +1,5 @@
 import pytest
-from eth_abi import encode
+from eth_abi.abi import encode
 from ethereum_types.numeric import U256
 from hypothesis import given
 from hypothesis.strategies import integers
@@ -132,7 +132,7 @@ class TestOs:
 
     @given(
         s_value=integers(
-            min_value=SECP256K1N // U256(2) + U256(1), max_value=SECP256K1N
+            min_value=int(SECP256K1N // U256(2) + U256(1)), max_value=int(SECP256K1N)
         )
     )
     def test_should_raise_on_invalid_s_value(self, cairo_run, s_value):
@@ -191,9 +191,12 @@ class TestOs:
             state=State.model_validate(initial_state),
         )
 
-        bytes.fromhex(
-            "7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3"
-        ) == state["accounts"]["0x32dCAB0EF3FB2De2fce1D2E0799D36239671F04A"]["code"]
+        assert (
+            bytes.fromhex(
+                "7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3"
+            )
+            == state["accounts"]["0x32dCAB0EF3FB2De2fce1D2E0799D36239671F04A"]["code"]
+        )
 
     @given(nonce=integers(min_value=2**64, max_value=2**248 - 1))
     def test_should_raise_when_nonce_is_greater_u64(self, cairo_run, nonce):

--- a/cairo/tests/src/utils/test_signature.py
+++ b/cairo/tests/src/utils/test_signature.py
@@ -23,11 +23,7 @@ class TestSignature:
             y = U256.from_be_bytes(public_key_bytes[32:64])
 
             expected_address = public_key.to_address()
-            result = cairo_run(
-                "test__public_key_point_to_eth_address",
-                x=x,
-                y=y,
-            )
+            result = cairo_run("test__public_key_point_to_eth_address", x=x, y=y)
             assert result == int(expected_address, 16)
 
     class TestVerifyEthSignature:
@@ -49,8 +45,8 @@ class TestSignature:
 
         @given(
             msg_hash=...,
-            r=st.integers(min_value=U256(1), max_value=SECP256K1N - U256(1)).map(U256),
-            s=st.integers(min_value=U256(1), max_value=SECP256K1N - U256(1)).map(U256),
+            r=st.integers(min_value=1, max_value=int(SECP256K1N) - 1).map(U256),
+            s=st.integers(min_value=1, max_value=int(SECP256K1N) - 1).map(U256),
             y_parity=st.integers(min_value=2, max_value=DEFAULT_PRIME - 1),
             eth_address=felt,
         )
@@ -70,8 +66,10 @@ class TestSignature:
         @given(
             msg_hash=...,
             r=st.one_of(
-                st.just(U256(0)),
-                st.integers(min_value=SECP256K1N, max_value=U256(2**256 - 1)).map(U256),
+                st.just(0),
+                st.integers(
+                    min_value=int(SECP256K1N), max_value=int(U256.MAX_VALUE)
+                ).map(U256),
             ),
             s=...,
             y_parity=...,
@@ -100,8 +98,10 @@ class TestSignature:
             msg_hash=...,
             r=...,
             s=st.one_of(
-                st.just(U256(0)),
-                st.integers(min_value=SECP256K1N, max_value=U256.MAX_VALUE).map(U256),
+                st.just(0),
+                st.integers(
+                    min_value=int(SECP256K1N), max_value=int(U256.MAX_VALUE)
+                ).map(U256),
             ),
             y_parity=...,
             eth_address=felt,

--- a/cairo/tests/utils/coverage.py
+++ b/cairo/tests/utils/coverage.py
@@ -6,7 +6,6 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import DefaultDict, List, Optional, Set
 
-from starkware.cairo.lang.compiler.instruction import Instruction
 from starkware.cairo.lang.vm.vm_core import VirtualMachine
 
 
@@ -63,12 +62,6 @@ class VmWithCoverage(VirtualMachine):
         self.old_as_vm_exception = (
             super().as_vm_exception
         )  # Save the old vm as exception function to wrap it afterwards.
-        self.touched_pcs: List[int] = []
-
-    def run_instruction(self, instruction: Instruction):
-        """Save the current pc and runs the instruction."""
-        self.touched_pcs.append(self.run_context.pc.offset)
-        self.old_run_instruction(instruction=instruction)
 
     def end_run(self):
         """In case the run doesn't fail creates report coverage."""
@@ -85,6 +78,10 @@ class VmWithCoverage(VirtualMachine):
         """In case the run fails creates report coverage."""
         self.cover_file()
         return self.old_as_vm_exception(exc, with_traceback, notes, hint_index)
+
+    @property
+    def touched_pcs(self):
+        return [trace.pc.offset for trace in self.trace]
 
     def pc_to_line(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 
 [tool.uv]
-dev-dependencies = ["jupyter>=1.1.1"]
+dev-dependencies = ["jupyter>=1.1.1", "snakeviz>=2.2.2"]
 
 [tool.uv.workspace]
 members = ["cairo", "keth_scripts"]

--- a/uv.lock
+++ b/uv.lock
@@ -705,7 +705,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/98/65/13d9e76ca19b0ba5603d71ac8424b5694415b348e719db277b5edc985ff5/cryptography-44.0.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:761817a3377ef15ac23cd7834715081791d4ec77f9297ee694ca1ee9c2c7e5eb", size = 3915420 },
     { url = "https://files.pythonhosted.org/packages/b1/07/40fe09ce96b91fc9276a9ad272832ead0fddedcba87f1190372af8e3039c/cryptography-44.0.0-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3c672a53c0fb4725a29c303be906d3c1fa99c32f58abe008a82705f9ee96f40b", size = 4154498 },
     { url = "https://files.pythonhosted.org/packages/75/ea/af65619c800ec0a7e4034207aec543acdf248d9bffba0533342d1bd435e1/cryptography-44.0.0-cp37-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:4ac4c9f37eba52cb6fbeaf5b59c152ea976726b865bd4cf87883a7e7006cc543", size = 3932569 },
-    { url = "https://files.pythonhosted.org/packages/4e/d5/9cc182bf24c86f542129565976c21301d4ac397e74bf5a16e48241aab8a6/cryptography-44.0.0-cp37-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:60eb32934076fa07e4316b7b2742fa52cbb190b42c2df2863dbc4230a0a9b385", size = 4164756 },
     { url = "https://files.pythonhosted.org/packages/c7/af/d1deb0c04d59612e3d5e54203159e284d3e7a6921e565bb0eeb6269bdd8a/cryptography-44.0.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ed3534eb1090483c96178fcb0f8893719d96d5274dfde98aa6add34614e97c8e", size = 4016721 },
     { url = "https://files.pythonhosted.org/packages/bd/69/7ca326c55698d0688db867795134bdfac87136b80ef373aaa42b225d6dd5/cryptography-44.0.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f3f6fdfa89ee2d9d496e2c087cebef9d4fcbb0ad63c40e821b39f74bf48d9c5e", size = 4240915 },
     { url = "https://files.pythonhosted.org/packages/ef/d4/cae11bf68c0f981e0413906c6dd03ae7fa864347ed5fac40021df1ef467c/cryptography-44.0.0-cp37-abi3-win32.whl", hash = "sha256:eb33480f1bad5b78233b0ad3e1b0be21e8ef1da745d8d2aecbb20671658b9053", size = 2757925 },
@@ -716,7 +715,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/c7/c656eb08fd22255d21bc3129625ed9cd5ee305f33752ef2278711b3fa98b/cryptography-44.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:c5eb858beed7835e5ad1faba59e865109f3e52b3783b9ac21e7e47dc5554e289", size = 3915417 },
     { url = "https://files.pythonhosted.org/packages/ef/82/72403624f197af0db6bac4e58153bc9ac0e6020e57234115db9596eee85d/cryptography-44.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f53c2c87e0fb4b0c00fa9571082a057e37690a8f12233306161c8f4b819960b7", size = 4155160 },
     { url = "https://files.pythonhosted.org/packages/a2/cd/2f3c440913d4329ade49b146d74f2e9766422e1732613f57097fea61f344/cryptography-44.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:9e6fc8a08e116fb7c7dd1f040074c9d7b51d74a8ea40d4df2fc7aa08b76b9e6c", size = 3932331 },
-    { url = "https://files.pythonhosted.org/packages/31/d9/90409720277f88eb3ab72f9a32bfa54acdd97e94225df699e7713e850bd4/cryptography-44.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9abcc2e083cbe8dde89124a47e5e53ec38751f0d7dfd36801008f316a127d7ba", size = 4165207 },
     { url = "https://files.pythonhosted.org/packages/7f/df/8be88797f0a1cca6e255189a57bb49237402b1880d6e8721690c5603ac23/cryptography-44.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:d2436114e46b36d00f8b72ff57e598978b37399d2786fd39793c36c6d5cb1c64", size = 4017372 },
     { url = "https://files.pythonhosted.org/packages/af/36/5ccc376f025a834e72b8e52e18746b927f34e4520487098e283a719c205e/cryptography-44.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a01956ddfa0a6790d594f5b34fc1bfa6098aca434696a03cfdbe469b8ed79285", size = 4239657 },
     { url = "https://files.pythonhosted.org/packages/46/b0/f4f7d0d0bcfbc8dd6296c1449be326d04217c57afb8b2594f017eed95533/cryptography-44.0.0-cp39-abi3-win32.whl", hash = "sha256:eca27345e1214d1b9f9490d200f9db5a874479be914199194e746c893788d417", size = 2758672 },
@@ -1590,12 +1588,16 @@ source = { virtual = "." }
 [package.dev-dependencies]
 dev = [
     { name = "jupyter" },
+    { name = "snakeviz" },
 ]
 
 [package.metadata]
 
 [package.metadata.requires-dev]
-dev = [{ name = "jupyter", specifier = ">=1.1.1" }]
+dev = [
+    { name = "jupyter", specifier = ">=1.1.1" },
+    { name = "snakeviz", specifier = ">=2.2.2" },
+]
 
 [[package]]
 name = "keth-scripts"
@@ -2913,6 +2915,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050 },
+]
+
+[[package]]
+name = "snakeviz"
+version = "2.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tornado" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/06/82f56563b16d33c2586ac2615a3034a83a4ff1969b84c8d79339e5d07d73/snakeviz-2.2.2.tar.gz", hash = "sha256:08028c6f8e34a032ff14757a38424770abb8662fb2818985aeea0d9bc13a7d83", size = 182039 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/f7/83b00cdf4f114f10750a18b64c27dc34636d0ac990ccac98282f5c0fbb43/snakeviz-2.2.2-py3-none-any.whl", hash = "sha256:77e7b9c82f6152edc330040319b97612351cd9b48c706434c535c2df31d10ac5", size = 183477 },
 ]
 
 [[package]]


### PR DESCRIPTION
Also added `snakeviz` to be able to profile tests with `--profile`, for example

```
uv run pytest path/to/test_file.py --profile
```

and then use `snakeviz` to visualize the python tracing