### PR TITLE
fix: Clarify comment regarding item fetch limit

### DIFF
--- a/keth_scripts/github_project_manager.py
+++ b/keth_scripts/github_project_manager.py
@@ -54,7 +54,7 @@ def clear_project_items(token: str, project_id: str) -> None:
     """
 
     # First get all items
-    variables = {"project_id": project_id, "first": 100}  # Adjust if needed
+    variables = {"project_id": project_id, "first": 100}  # Adjust the number of items fetched per request if needed
     result = make_graphql_request(token, query, variables)
 
     # Then delete each item


### PR DESCRIPTION

While reviewing the code, I noticed a comment that could be made more explicit for clarity:  

```python  
# Adjust if needed  
```  

This has been updated to:  

```python  
# Adjust the number of items fetched per request if needed  
```  

The new phrasing makes it clear that the comment refers to the number of items fetched in a single GraphQL request.

This should help anyone reading or maintaining the code to understand the context better without requiring further investigation.