### PR TITLE
Do not instantiate useless TracerData class

### DIFF
--- a/cairo/tests/fixtures/runner.py
+++ b/cairo/tests/fixtures/runner.py
@@ -24,7 +24,6 @@ from starkware.cairo.common.dict import DictManager
 from starkware.cairo.lang.builtins.all_builtins import ALL_BUILTINS
 from starkware.cairo.lang.compiler.ast.cairo_types import CairoType, TypeStruct
 from starkware.cairo.lang.compiler.scoped_name import ScopedName
-from starkware.cairo.lang.tracer.tracer_data import TracerData
 from starkware.cairo.lang.vm.cairo_run import (
     write_air_public_input,
     write_binary_memory,
@@ -283,14 +282,12 @@ def cairo_run(request, cairo_program, cairo_file, main_path):
             f"{output_stem[:160]}_{int(time_ns())}_{md5(output_stem.encode()).digest().hex()[:8]}"
         )
         if request.config.getoption("profile_cairo"):
-            tracer_data = TracerData(
+            stats, prof_dict = profile_from_tracer_data(
                 program=cairo_program,
-                memory=runner.relocated_memory,
                 trace=runner.relocated_trace,
                 debug_info=runner.get_relocated_debug_info(),
                 program_base=PROGRAM_BASE,
             )
-            stats, prof_dict = profile_from_tracer_data(tracer_data)
             stats = stats[
                 "scope",
                 "primitive_call",

--- a/cairo/tests/utils/reporting.py
+++ b/cairo/tests/utils/reporting.py
@@ -1,6 +1,5 @@
 import json
 import logging
-from dataclasses import asdict
 from pathlib import Path
 from time import perf_counter
 from typing import List, Union
@@ -34,7 +33,7 @@ def dump_coverage(path: Union[str, Path], files: List[CoverageFile]):
 def profile_from_tracer_data(program, trace, debug_info, program_base):
     logger.info("Begin profiling")
     start = perf_counter()
-    trace = pl.DataFrame([asdict(x) for x in trace])
+    trace = pl.DataFrame([{"pc": x.pc, "ap": x.ap, "fp": x.fp} for x in trace])
     debug_info = (
         pl.DataFrame(
             {

--- a/cairo/tests/utils/reporting.py
+++ b/cairo/tests/utils/reporting.py
@@ -3,7 +3,7 @@ import logging
 from dataclasses import asdict
 from pathlib import Path
 from time import perf_counter
-from typing import Any, Callable, List, TypeVar, Union
+from typing import List, Union
 
 import polars as pl
 
@@ -11,8 +11,6 @@ from tests.utils.coverage import CoverageFile
 
 logging.basicConfig(format="%(levelname)-8s %(message)s")
 logger = logging.getLogger("timer")
-
-T = TypeVar("T", bound=Callable[..., Any])
 
 
 def dump_coverage(path: Union[str, Path], files: List[CoverageFile]):
@@ -33,15 +31,14 @@ def dump_coverage(path: Union[str, Path], files: List[CoverageFile]):
     )
 
 
-def profile_from_tracer_data(tracer_data):
+def profile_from_tracer_data(program, trace, debug_info, program_base):
     logger.info("Begin profiling")
     start = perf_counter()
-    program = tracer_data.program
-    trace = pl.DataFrame([asdict(x) for x in tracer_data.trace])
+    trace = pl.DataFrame([asdict(x) for x in trace])
     debug_info = (
         pl.DataFrame(
             {
-                "pc": key + tracer_data.program_base,
+                "pc": key + program_base,
                 "scope": str(instruction_location.accessible_scopes[-1]),
                 "instruction": str(instruction_location.inst),
             }


### PR DESCRIPTION
Speed up a bit the profiler by avoiding heavy useless ops, from 10+s to 0.7s for the test_erc20 (1.4M steps)