### PR TITLE
dev: limit examples for slow tests

### DIFF
--- a/cairo/tests/ethereum/cancun/test_trie.py
+++ b/cairo/tests/ethereum/cancun/test_trie.py
@@ -3,7 +3,7 @@ from typing import Mapping, Optional
 import pytest
 from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import Uint
-from hypothesis import assume, given
+from hypothesis import assume, given, settings
 from hypothesis import strategies as st
 
 from ethereum.cancun.fork_types import Account
@@ -30,6 +30,8 @@ class TestTrie:
             encode_internal_node(node), cairo_run("encode_internal_node", node)
         )
 
+    @pytest.mark.slow
+    @settings(max_examples=300)
     @given(node=..., storage_root=...)
     def test_encode_node(self, cairo_run, node: Node, storage_root: Optional[Bytes]):
         assume(node is not None)
@@ -138,6 +140,8 @@ class TestTrie:
         )
         assert value == obj.get(level, b"")
 
+    @pytest.mark.slow
+    @settings(max_examples=300)
     @given(obj=st.dictionaries(nibble, bytes32))
     def test_patricialize(self, cairo_run, obj: Mapping[Bytes, Bytes]):
         assert patricialize(obj, Uint(0)) == cairo_run("patricialize", obj, Uint(0))

--- a/cairo/tests/ethereum/test_rlp.py
+++ b/cairo/tests/ethereum/test_rlp.py
@@ -3,7 +3,7 @@ from typing import Sequence, Tuple, Union
 import pytest
 from ethereum_types.bytes import Bytes, Bytes0, Bytes32
 from ethereum_types.numeric import U256, Uint
-from hypothesis import assume, given
+from hypothesis import assume, given, settings
 
 from ethereum.cancun.blocks import Log, Receipt, Withdrawal
 from ethereum.cancun.fork_types import Account, Address, Bloom, encode_account
@@ -48,12 +48,16 @@ class TestRlp:
         def test_encode_bytes(self, cairo_run, raw_bytes: Bytes):
             assert encode_bytes(raw_bytes) == cairo_run("encode_bytes", raw_bytes)
 
+        @pytest.mark.slow
+        @settings(max_examples=300)
         @given(raw_sequence=...)
         def test_encode_sequence(self, cairo_run, raw_sequence: Sequence[Extended]):
             assert encode_sequence(raw_sequence) == cairo_run(
                 "encode_sequence", raw_sequence
             )
 
+        @pytest.mark.slow
+        @settings(max_examples=300)
         @given(raw_sequence=...)
         def test_get_joined_encodings(
             self, cairo_run, raw_sequence: Sequence[Extended]
@@ -98,10 +102,14 @@ class TestRlp:
         def test_encode_legacy_transaction(self, cairo_run, tx: LegacyTransaction):
             assert encode(tx) == cairo_run("encode_legacy_transaction", tx)
 
+        @pytest.mark.slow
+        @settings(max_examples=300)
         @given(log=...)
         def test_encode_log(self, cairo_run, log: Log):
             assert encode(log) == cairo_run("encode_log", log)
 
+        @pytest.mark.slow
+        @settings(max_examples=300)
         @given(tuple_log=...)
         def test_encode_tuple_log(self, cairo_run, tuple_log: Tuple[Log, ...]):
             assert encode(tuple_log) == cairo_run("encode_tuple_log", tuple_log)
@@ -110,6 +118,8 @@ class TestRlp:
         def test_encode_bloom(self, cairo_run, bloom: Bloom):
             assert encode(bloom) == cairo_run("encode_bloom", bloom)
 
+        @pytest.mark.slow
+        @settings(max_examples=300)
         @given(receipt=...)
         def test_encode_receipt(self, cairo_run, receipt: Receipt):
             assert encode(receipt) == cairo_run("encode_receipt", receipt)
@@ -145,6 +155,8 @@ class TestRlp:
             if decoded_bytes is not None:
                 assert decoded_bytes == decode_to_bytes(encoded_bytes)
 
+        @pytest.mark.slow
+        @settings(max_examples=300)
         @given(raw_data=...)
         def test_decode_to_sequence(self, cairo_run, raw_data: Sequence[Extended]):
             assume(isinstance(raw_data, list))

--- a/cairo/tests/programs/test_os.py
+++ b/cairo/tests/programs/test_os.py
@@ -6,7 +6,7 @@ import pytest
 from eth_abi.abi import encode
 from ethereum_types.numeric import U256
 from hexbytes import HexBytes
-from hypothesis import given
+from hypothesis import given, settings
 from hypothesis.strategies import integers
 
 from ethereum.crypto.elliptic_curve import SECP256K1N
@@ -274,6 +274,8 @@ class TestOs:
             == state["accounts"]["0x32dCAB0EF3FB2De2fce1D2E0799D36239671F04A"]["code"]
         )
 
+    @pytest.mark.slow
+    @settings(max_examples=300)
     @given(nonce=integers(min_value=2**64, max_value=2**248 - 1))
     def test_should_raise_when_nonce_is_greater_u64(self, cairo_run, nonce):
         initial_state = {

--- a/cairo/tests/src/instructions/test_environmental_information.py
+++ b/cairo/tests/src/instructions/test_environmental_information.py
@@ -2,7 +2,7 @@ import random
 
 import pytest
 from Crypto.Hash import keccak
-from hypothesis import example, given
+from hypothesis import example, given, settings
 from hypothesis import strategies as st
 
 EXISTING_ACCOUNT = 0xABDE1
@@ -69,6 +69,8 @@ class TestEnvironmentalInformation:
                 == copied_bytecode
             )
 
+        @pytest.mark.slow
+        @settings(max_examples=300)
         @given(
             opcode_number=st.sampled_from([0x39, 0x37]),
             offset=st.integers(0, 2**128 - 1),

--- a/cairo/tests/src/precompiles/test_ripemd160.py
+++ b/cairo/tests/src/precompiles/test_ripemd160.py
@@ -1,6 +1,6 @@
 import pytest
 from Crypto.Hash import RIPEMD160
-from hypothesis import example, given
+from hypothesis import example, given, settings
 from hypothesis.strategies import binary
 
 from tests.utils.errors import cairo_error
@@ -9,6 +9,7 @@ from tests.utils.hints import insert_hint
 
 @pytest.mark.slow
 class TestRIPEMD160:
+    @settings(max_examples=300)
     @given(msg_bytes=binary(min_size=1, max_size=200))
     @example(msg_bytes=b"abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmomnopnopq")
     def test_ripemd160_should_return_correct_hash(self, cairo_run, msg_bytes):

--- a/cairo/tests/src/utils/test_signature.py
+++ b/cairo/tests/src/utils/test_signature.py
@@ -2,7 +2,7 @@ import pytest
 from eth_keys.datatypes import PrivateKey
 from ethereum_types.bytes import Bytes32
 from ethereum_types.numeric import U256
-from hypothesis import given
+from hypothesis import given, settings
 from hypothesis import strategies as st
 from starkware.cairo.lang.cairo_constants import DEFAULT_PRIME
 
@@ -28,6 +28,7 @@ class TestSignature:
 
     class TestVerifyEthSignature:
         @pytest.mark.slow
+        @settings(max_examples=300)
         @given(private_key=..., message=...)
         def test__verify_eth_signature_uint256(
             self, cairo_run, private_key: PrivateKey, message: Bytes32
@@ -123,6 +124,7 @@ class TestSignature:
 
     class TestTryRecoverEthAddress:
         @pytest.mark.slow
+        @settings(max_examples=300)
         @given(private_key=..., message=...)
         def test__try_recover_eth_address(
             self, cairo_run, private_key: PrivateKey, message: Bytes32


### PR DESCRIPTION
Part of #318 

For test > 2000s from https://github.com/kkrt-labs/keth/actions/runs/12526214515/job/34938536446, mark those test slow and set the max example to 300. 
At time of writing the max_examples for nightly is 1500 hence a division by 5 but still more than the main ci (which is 100)