### PR TITLE
test: reduce max examples nightly

### DIFF
--- a/cairo/tests/conftest.py
+++ b/cairo/tests/conftest.py
@@ -76,7 +76,7 @@ register_type_strategies()
 settings.register_profile(
     "nightly",
     deadline=None,
-    max_examples=1500,
+    max_examples=700,
     phases=[Phase.explicit, Phase.reuse, Phase.generate, Phase.target],
     report_multiple_bugs=True,
     suppress_health_check=[HealthCheck.too_slow],

--- a/cairo/tests/ethereum/cancun/test_trie.py
+++ b/cairo/tests/ethereum/cancun/test_trie.py
@@ -35,7 +35,7 @@ class TestTrie:
         )
 
     @pytest.mark.slow
-    @settings(max_examples=300)
+    @settings(max_examples=20)  # for max_examples=2, it takes 129.91s in local
     @given(node=..., storage_root=...)
     def test_encode_node(self, cairo_run, node: Node, storage_root: Optional[Bytes]):
         assume(node is not None)
@@ -145,7 +145,7 @@ class TestTrie:
         assert value == obj.get(level, b"")
 
     @pytest.mark.slow
-    @settings(max_examples=300)
+    @settings(max_examples=5)  # for max_examples=2, it takes 239.03s in local
     @given(obj=st.dictionaries(nibble, bytes32))
     def test_patricialize(self, cairo_run, obj: Mapping[Bytes, Bytes]):
         assert patricialize(obj, Uint(0)) == cairo_run("patricialize", obj, Uint(0))

--- a/cairo/tests/ethereum/test_rlp.py
+++ b/cairo/tests/ethereum/test_rlp.py
@@ -111,7 +111,7 @@ class TestRlp:
             assert encode(log) == cairo_run("encode_log", log)
 
         @pytest.mark.slow
-        @settings(max_examples=300)
+        @settings(max_examples=200)
         @given(tuple_log=...)
         def test_encode_tuple_log(self, cairo_run, tuple_log: Tuple[Log, ...]):
             assert encode(tuple_log) == cairo_run("encode_tuple_log", tuple_log)
@@ -121,7 +121,7 @@ class TestRlp:
             assert encode(bloom) == cairo_run("encode_bloom", bloom)
 
         @pytest.mark.slow
-        @settings(max_examples=300)
+        @settings(max_examples=200)
         @given(receipt=...)
         def test_encode_receipt(self, cairo_run, receipt: Receipt):
             assert encode(receipt) == cairo_run("encode_receipt", receipt)

--- a/cairo/tests/programs/test_os.py
+++ b/cairo/tests/programs/test_os.py
@@ -236,6 +236,7 @@ class TestOs:
                 state=State.model_validate(initial_state),
             )
 
+    @pytest.mark.slow
     def test_create_tx_returndata(self, cairo_run):
         initial_state = {
             OWNER: {
@@ -277,7 +278,7 @@ class TestOs:
         )
 
     @pytest.mark.slow
-    @settings(max_examples=300)
+    @settings(max_examples=1)  # for max_examples=2, it takes 1773.25s in local
     @given(nonce=integers(min_value=2**64, max_value=2**248 - 1))
     def test_should_raise_when_nonce_is_greater_u64(self, cairo_run, nonce):
         initial_state = {

--- a/cairo/tests/src/instructions/test_environmental_information.py
+++ b/cairo/tests/src/instructions/test_environmental_information.py
@@ -72,7 +72,7 @@ class TestEnvironmentalInformation:
             )
 
         @pytest.mark.slow
-        @settings(max_examples=300)
+        @settings(max_examples=20)  # for max_examples=2, it takes 45.71s in local
         @given(
             opcode_number=st.sampled_from([0x39, 0x37]),
             offset=st.integers(0, 2**128 - 1),

--- a/cairo/tests/src/precompiles/test_ec_recover.py
+++ b/cairo/tests/src/precompiles/test_ec_recover.py
@@ -1,6 +1,6 @@
 import pytest
 from ethereum_types.numeric import U256
-from hypothesis import given
+from hypothesis import given, settings
 from hypothesis import strategies as st
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
@@ -38,6 +38,7 @@ def ecrecover(data):
 
 @pytest.mark.EC_RECOVER
 class TestEcRecover:
+    @settings(max_examples=20)  # for max_examples=2, it takes 19.12s in local
     @given(message=st.binary(min_size=1, max_size=1000))
     def test_valid_signature(self, message, cairo_run):
         """Test with valid signatures generated from random messages."""
@@ -76,6 +77,7 @@ class TestEcRecover:
         output = cairo_run("test__ec_recover", input=input_data)
         assert output == py_result
 
+    @settings(max_examples=20)  # for max_examples=2, it takes 12.49s in local
     @given(
         v=st.integers(min_value=27, max_value=28),
         msg=st.binary(min_size=32, max_size=32),

--- a/cairo/tests/src/precompiles/test_ripemd160.py
+++ b/cairo/tests/src/precompiles/test_ripemd160.py
@@ -11,7 +11,7 @@ pytestmark = pytest.mark.python_vm
 
 @pytest.mark.slow
 class TestRIPEMD160:
-    @settings(max_examples=300)
+    @settings(max_examples=1)  # for max_examples=2, it takes 1258.60s in local
     @given(msg_bytes=binary(min_size=1, max_size=200))
     @example(msg_bytes=b"abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmomnopnopq")
     def test_ripemd160_should_return_correct_hash(self, cairo_run, msg_bytes):

--- a/cairo/tests/src/precompiles/test_sha256.py
+++ b/cairo/tests/src/precompiles/test_sha256.py
@@ -10,8 +10,8 @@ pytestmark = pytest.mark.python_vm
 @pytest.mark.SHA256
 class TestSHA256:
     @pytest.mark.slow
-    @given(message_bytes=binary(min_size=1, max_size=56))
     @settings(max_examples=10)
+    @given(message_bytes=binary(min_size=1, max_size=56))
     def test_sha256_should_return_correct_hash(self, cairo_run, message_bytes):
         # Hash with SHA256
         m = py_sha256()

--- a/cairo/tests/src/utils/test_signature.py
+++ b/cairo/tests/src/utils/test_signature.py
@@ -30,7 +30,7 @@ class TestSignature:
 
     class TestVerifyEthSignature:
         @pytest.mark.slow
-        @settings(max_examples=300)
+        @settings(max_examples=1)  # for max_examples=2, it takes 1934.87s in local
         @given(private_key=..., message=...)
         def test__verify_eth_signature_uint256(
             self, cairo_run, private_key: PrivateKey, message: Bytes32
@@ -126,7 +126,7 @@ class TestSignature:
 
     class TestTryRecoverEthAddress:
         @pytest.mark.slow
-        @settings(max_examples=300)
+        @settings(max_examples=1)  # for max_examples=2, it takes 1934.87s in local
         @given(private_key=..., message=...)
         def test__try_recover_eth_address(
             self, cairo_run, private_key: PrivateKey, message: Bytes32

--- a/cairo/tests/src/utils/test_transaction.py
+++ b/cairo/tests/src/utils/test_transaction.py
@@ -3,7 +3,7 @@ from eth_account._utils.transaction_utils import transaction_rpc_to_rlp_structur
 from eth_account._utils.validation import LEGACY_TRANSACTION_VALID_VALUES
 from eth_account.typed_transactions.access_list_transaction import AccessListTransaction
 from eth_account.typed_transactions.dynamic_fee_transaction import DynamicFeeTransaction
-from hypothesis import given
+from hypothesis import given, settings
 from hypothesis import strategies as st
 from rlp import encode
 
@@ -47,6 +47,7 @@ class TestTransaction:
                 encoded_unsigned_tx = rlp_encode_signed_data(transaction)
                 cairo_run("test__decode", data=list(encoded_unsigned_tx))
 
+        @settings(max_examples=len(TRANSACTIONS))
         @given(value=st.integers(min_value=2**248))
         @pytest.mark.parametrize("transaction", TRANSACTIONS)
         @pytest.mark.parametrize(


### PR DESCRIPTION
Close #318
The nightly CI always fails due to being [too long](https://github.com/kkrt-labs/keth/issues/318#issuecomment-2574718661)

This PR reduce the number of examples and even more for specific very slow tests: the CI passes https://github.com/kkrt-labs/keth/actions/runs/12706365504


This could be review if self hosted runners are introduced