### PR TITLE
feat: improve rust bindings compat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,7 +145,7 @@ checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 [[package]]
 name = "cairo-vm"
 version = "2.0.0-rc3"
-source = "git+https://github.com/ClementWalter/cairo-rs#5f29188c8570470bbebce7bf82697a6d6a5e0724"
+source = "git+https://github.com/kkrt-labs/cairo-vm?rev=dd3d3f6e76248fc02395b31cbefe5fe8183222f1#dd3d3f6e76248fc02395b31cbefe5fe8183222f1"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,4 +59,4 @@ cairo-vm = { git = "https://github.com/lambdaclass/cairo-vm.git", tag = "v2.0.0-
 ] }
 
 [patch."https://github.com/lambdaclass/cairo-vm.git"]
-cairo-vm = { git = "https://github.com/ClementWalter/cairo-rs" }
+cairo-vm = { git = "https://github.com/kkrt-labs/cairo-vm", rev = "dd3d3f6e76248fc02395b31cbefe5fe8183222f1" }

--- a/cairo/tests/ethereum/cancun/test_fork_types.py
+++ b/cairo/tests/ethereum/cancun/test_fork_types.py
@@ -1,6 +1,9 @@
+import pytest
 from hypothesis import given
 
 from ethereum.cancun.fork_types import EMPTY_ACCOUNT, Account
+
+pytestmark = pytest.mark.python_vm
 
 
 class TestForkTypes:

--- a/cairo/tests/ethereum/cancun/test_fork_types.py
+++ b/cairo/tests/ethereum/cancun/test_fork_types.py
@@ -1,9 +1,6 @@
-import pytest
 from hypothesis import given
 
 from ethereum.cancun.fork_types import EMPTY_ACCOUNT, Account
-
-pytestmark = pytest.mark.python_vm
 
 
 class TestForkTypes:

--- a/cairo/tests/ethereum/cancun/utils/test_address.py
+++ b/cairo/tests/ethereum/cancun/utils/test_address.py
@@ -1,6 +1,5 @@
 from typing import Union
 
-import pytest
 from ethereum_types.bytes import Bytes32
 from ethereum_types.numeric import U256, Uint
 from hypothesis import given
@@ -11,8 +10,6 @@ from ethereum.cancun.utils.address import (
     compute_create2_contract_address,
     to_address,
 )
-
-pytestmark = pytest.mark.python_vm
 
 
 class TestAddress:

--- a/cairo/tests/ethereum/cancun/vm/instructions/test_arithmetic.py
+++ b/cairo/tests/ethereum/cancun/vm/instructions/test_arithmetic.py
@@ -17,8 +17,6 @@ from ethereum.cancun.vm.instructions.arithmetic import (
 from tests.utils.args_gen import Evm
 from tests.utils.evm_builder import EvmBuilder
 
-pytestmark = pytest.mark.python_vm
-
 
 class TestArithmetic:
     @given(evm=EvmBuilder().with_stack().with_gas_left().build())

--- a/cairo/tests/ethereum/cancun/vm/instructions/test_bitwise.py
+++ b/cairo/tests/ethereum/cancun/vm/instructions/test_bitwise.py
@@ -15,8 +15,6 @@ from ethereum.cancun.vm.instructions.bitwise import (
 from tests.utils.args_gen import Evm
 from tests.utils.evm_builder import EvmBuilder
 
-pytestmark = pytest.mark.python_vm
-
 
 class TestBitwise:
     @given(evm=EvmBuilder().with_stack().with_gas_left().build())

--- a/cairo/tests/ethereum/cancun/vm/instructions/test_block.py
+++ b/cairo/tests/ethereum/cancun/vm/instructions/test_block.py
@@ -24,8 +24,6 @@ from tests.utils.strategies import (
     uint256,
 )
 
-pytestmark = pytest.mark.python_vm
-
 
 # Specific environment strategy with minimal items:
 # block_hashes, coinbase, number, gas_limit, time, prev_randao, chain_id are

--- a/cairo/tests/ethereum/cancun/vm/instructions/test_block.py
+++ b/cairo/tests/ethereum/cancun/vm/instructions/test_block.py
@@ -24,7 +24,6 @@ from tests.utils.strategies import (
     uint256,
 )
 
-
 # Specific environment strategy with minimal items:
 # block_hashes, coinbase, number, gas_limit, time, prev_randao, chain_id are
 # strategies, the rest:

--- a/cairo/tests/ethereum/cancun/vm/instructions/test_comparison.py
+++ b/cairo/tests/ethereum/cancun/vm/instructions/test_comparison.py
@@ -13,8 +13,6 @@ from ethereum.cancun.vm.instructions.comparison import (
 from tests.utils.args_gen import Evm
 from tests.utils.strategies import evm_lite
 
-pytestmark = pytest.mark.python_vm
-
 
 class TestComparison:
     @given(evm=evm_lite)

--- a/cairo/tests/ethereum/cancun/vm/instructions/test_control_flow.py
+++ b/cairo/tests/ethereum/cancun/vm/instructions/test_control_flow.py
@@ -15,8 +15,6 @@ from ethereum.cancun.vm.stack import push
 from tests.utils.args_gen import Evm
 from tests.utils.strategies import evm_lite
 
-pytestmark = pytest.mark.python_vm
-
 
 class TestControlFlow:
     @given(evm=evm_lite)

--- a/cairo/tests/ethereum/cancun/vm/instructions/test_control_flow.py
+++ b/cairo/tests/ethereum/cancun/vm/instructions/test_control_flow.py
@@ -15,6 +15,8 @@ from ethereum.cancun.vm.stack import push
 from tests.utils.args_gen import Evm
 from tests.utils.strategies import evm_lite
 
+pytestmark = pytest.mark.python_vm
+
 
 class TestControlFlow:
     @given(evm=evm_lite)

--- a/cairo/tests/ethereum/cancun/vm/instructions/test_keccak.py
+++ b/cairo/tests/ethereum/cancun/vm/instructions/test_keccak.py
@@ -8,8 +8,6 @@ from ethereum.cancun.vm.stack import push
 from tests.utils.args_gen import Evm
 from tests.utils.strategies import evm_lite, memory_access_size, memory_start_position
 
-pytestmark = pytest.mark.python_vm
-
 
 class TestKeccak:
     @given(

--- a/cairo/tests/ethereum/cancun/vm/instructions/test_log.py
+++ b/cairo/tests/ethereum/cancun/vm/instructions/test_log.py
@@ -8,8 +8,6 @@ from ethereum.cancun.vm.stack import push
 from tests.utils.args_gen import Evm
 from tests.utils.strategies import evm_lite, memory_access_size, memory_start_position
 
-pytestmark = pytest.mark.python_vm
-
 
 class TestLog:
     @given(

--- a/cairo/tests/ethereum/cancun/vm/instructions/test_memory_instructions.py
+++ b/cairo/tests/ethereum/cancun/vm/instructions/test_memory_instructions.py
@@ -6,8 +6,6 @@ from ethereum.cancun.vm.instructions.memory import mcopy, mload, msize, mstore, 
 from tests.utils.args_gen import Evm
 from tests.utils.strategies import evm_lite
 
-pytestmark = pytest.mark.python_vm
-
 
 class TestMemory:
     @given(evm=evm_lite)

--- a/cairo/tests/ethereum/cancun/vm/test_memory.py
+++ b/cairo/tests/ethereum/cancun/vm/test_memory.py
@@ -1,4 +1,3 @@
-import pytest
 from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import U256
 from hypothesis import given
@@ -36,9 +35,6 @@ def memory_read_strategy(draw):
     )
 
     return memory, start_position, size
-
-
-pytestmark = pytest.mark.python_vm
 
 
 class TestMemory:

--- a/cairo/tests/ethereum/cancun/vm/test_runtime.py
+++ b/cairo/tests/ethereum/cancun/vm/test_runtime.py
@@ -1,10 +1,7 @@
-import pytest
 from ethereum_types.bytes import Bytes
 from hypothesis import given
 
 from ethereum.cancun.vm.runtime import get_valid_jump_destinations
-
-pytestmark = pytest.mark.python_vm
 
 
 class TestRuntime:

--- a/cairo/tests/ethereum/cancun/vm/test_stack.py
+++ b/cairo/tests/ethereum/cancun/vm/test_stack.py
@@ -7,8 +7,6 @@ from hypothesis import assume, given
 from ethereum.cancun.vm.exceptions import StackOverflowError, StackUnderflowError
 from ethereum.cancun.vm.stack import pop, push
 
-pytestmark = pytest.mark.python_vm
-
 
 class TestStack:
     def test_pop_underflow(self, cairo_run):

--- a/cairo/tests/ethereum/crypto/test_hash.py
+++ b/cairo/tests/ethereum/crypto/test_hash.py
@@ -1,10 +1,7 @@
-import pytest
 from ethereum_types.bytes import Bytes
 from hypothesis import assume, given
 
 from ethereum.crypto.hash import keccak256
-
-pytestmark = pytest.mark.python_vm
 
 
 class TestHash:

--- a/cairo/tests/ethereum/test_rlp.py
+++ b/cairo/tests/ethereum/test_rlp.py
@@ -23,8 +23,6 @@ from ethereum.rlp import (
 )
 from tests.utils.errors import cairo_error
 
-pytestmark = pytest.mark.python_vm
-
 
 class TestRlp:
     class TestEncode:

--- a/cairo/tests/src/test_stack.py
+++ b/cairo/tests/src/test_stack.py
@@ -1,8 +1,3 @@
-import pytest
-
-pytestmark = pytest.mark.python_vm
-
-
 class TestStack:
     class TestPeek:
         def test_should_return_stack_at_given_index__when_value_is_0(self, cairo_run):

--- a/cairo/tests/test_serde.py
+++ b/cairo/tests/test_serde.py
@@ -166,9 +166,6 @@ def single_evm_parent(b: Union[Message, Evm]) -> bool:
     return True
 
 
-pytestmark = pytest.mark.python_vm
-
-
 class TestSerde:
     @given(b=...)
     # 20 examples per type

--- a/cairo/tests/utils/args_gen.py
+++ b/cairo/tests/utils/args_gen.py
@@ -74,6 +74,7 @@ from typing import (
 )
 
 from cairo_addons.vm import DictTracker as RustDictTracker
+from cairo_addons.vm import MemorySegmentManager as RustMemorySegmentManager
 from cairo_addons.vm import Relocatable as RustRelocatable
 from ethereum_types.bytes import (
     Bytes,
@@ -100,6 +101,7 @@ from starkware.cairo.lang.compiler.identifier_definition import (
 from starkware.cairo.lang.compiler.program import Program
 from starkware.cairo.lang.compiler.scoped_name import ScopedName
 from starkware.cairo.lang.vm.crypto import poseidon_hash_many
+from starkware.cairo.lang.vm.memory_segments import MemorySegmentManager
 from starkware.cairo.lang.vm.relocatable import RelocatableValue
 
 from ethereum.cancun.blocks import Header, Log, Receipt, Withdrawal
@@ -374,7 +376,7 @@ def gen_arg(dict_manager, segments):
 
 def _gen_arg(
     dict_manager,
-    segments,
+    segments: Union[MemorySegmentManager, RustMemorySegmentManager],
     arg_type: Type,
     arg: Any,
     annotations: Optional[Any] = None,
@@ -545,19 +547,15 @@ def _gen_arg(
                 data=data, current_ptr=current_ptr
             )
         else:
-            dict_manager.insert(
-                dict_ptr.segment_index,
-                RustDictTracker(
-                    keys=list(data.keys()),
-                    values=list(data.values()),
-                    current_ptr=current_ptr,
-                    default_value=(
-                        data.default_factory()
-                        if isinstance(data, defaultdict)
-                        else None
-                    ),
-                ),
+            default_value = (
+                data.default_factory() if isinstance(data, defaultdict) else None
             )
+            dict_manager.trackers[dict_ptr.segment_index] = RustDictTracker(
+                data=data,
+                current_ptr=current_ptr,
+                default_value=default_value,
+            )
+
         base = segments.add()
         segments.load_data(base, [dict_ptr, current_ptr])
         return base
@@ -589,11 +587,17 @@ def _gen_arg(
 
         if arg_type_origin is Trie:
             # In case of a Trie, we need the dict to be a defaultdict with the trie.default as the default value.
-            dict_ptr = segments.memory[data[2]]
-            dict_manager.trackers[dict_ptr.segment_index].data = defaultdict(
-                lambda: data[1], dict_manager.trackers[dict_ptr.segment_index].data
-            )
-
+            dict_ptr = segments.memory.get(data[2])
+            if isinstance(dict_manager, DictManager):
+                dict_manager.trackers[dict_ptr.segment_index].data = defaultdict(
+                    lambda: data[1], dict_manager.trackers[dict_ptr.segment_index].data
+                )
+            else:
+                dict_manager.trackers[dict_ptr.segment_index] = RustDictTracker(
+                    data=dict_manager.trackers[dict_ptr.segment_index].data,
+                    current_ptr=dict_ptr,
+                    default_value=data[1],
+                )
         return struct_ptr
 
     if arg_type in (U256, Hash32, Bytes32, Bytes256):

--- a/cairo/tests/utils/serde.py
+++ b/cairo/tests/utils/serde.py
@@ -105,9 +105,7 @@ class Serde:
         cairo_file=None,
     ):
         self.segments = segments
-        self.memory = (
-            segments.memory if isinstance(segments, MemorySegmentManager) else segments
-        )
+        self.memory = segments.memory
         self.program = program
         self.dict_manager = dict_manager
         self.cairo_file = cairo_file or Path()

--- a/crates/cairo-addons/src/vm/dict_manager.rs
+++ b/crates/cairo-addons/src/vm/dict_manager.rs
@@ -1,13 +1,83 @@
 use cairo_vm::{
     hint_processor::builtin_hint_processor::dict_manager::{
-        DictManager as RustDictManager, DictTracker,
+        DictKey as RustDictKey, DictManager as RustDictManager, DictTracker,
     },
     types::relocatable::MaybeRelocatable,
 };
-use pyo3::prelude::*;
+use pyo3::{prelude::*, types::PyTuple};
 use std::{cell::RefCell, collections::HashMap, rc::Rc};
 
 use super::{maybe_relocatable::PyMaybeRelocatable, relocatable::PyRelocatable};
+
+#[derive(FromPyObject, Eq, PartialEq, Hash)]
+pub enum PyDictKey {
+    #[pyo3(transparent)]
+    Simple(PyMaybeRelocatable),
+    #[pyo3(transparent)]
+    Compound(Vec<PyMaybeRelocatable>),
+}
+
+impl IntoPy<PyObject> for PyDictKey {
+    fn into_py(self, py: Python<'_>) -> PyObject {
+        match self {
+            PyDictKey::Simple(val) => val.into_py(py),
+            PyDictKey::Compound(vals) => {
+                // Convert Vec to tuple
+                let elements: Vec<PyObject> = vals.into_iter().map(|v| v.into_py(py)).collect();
+                PyTuple::new_bound(py, elements).into()
+            }
+        }
+    }
+}
+
+impl From<PyDictKey> for RustDictKey {
+    fn from(value: PyDictKey) -> Self {
+        match value {
+            PyDictKey::Simple(val) => RustDictKey::Simple(val.into()),
+            PyDictKey::Compound(vals) => {
+                RustDictKey::Compound(vals.into_iter().map(|v| v.into()).collect())
+            }
+        }
+    }
+}
+
+impl From<RustDictKey> for PyDictKey {
+    fn from(value: RustDictKey) -> Self {
+        match value {
+            RustDictKey::Simple(val) => PyDictKey::Simple(val.into()),
+            RustDictKey::Compound(vals) => {
+                PyDictKey::Compound(vals.into_iter().map(|v| v.into()).collect())
+            }
+        }
+    }
+}
+
+/// Object returned by DictManager.trackers enabling access to the trackers by index and mutating
+/// the trackers with manager.trackers[index] = tracker
+#[pyclass(name = "TrackerMapping", unsendable)]
+pub struct PyTrackerMapping {
+    inner: Rc<RefCell<RustDictManager>>,
+}
+
+#[pymethods]
+impl PyTrackerMapping {
+    fn __getitem__(&self, key: isize) -> PyResult<PyDictTracker> {
+        self.inner
+            .borrow()
+            .trackers
+            .get(&key)
+            .cloned()
+            .map(|tracker| PyDictTracker { inner: tracker })
+            .ok_or_else(|| {
+                PyErr::new::<pyo3::exceptions::PyKeyError, _>(format!("Key {} not found", key))
+            })
+    }
+
+    fn __setitem__(&mut self, key: isize, value: PyDictTracker) -> PyResult<()> {
+        self.inner.borrow_mut().trackers.insert(key, value.inner);
+        Ok(())
+    }
+}
 
 #[pyclass(name = "DictManager", unsendable)]
 pub struct PyDictManager {
@@ -16,6 +86,16 @@ pub struct PyDictManager {
 
 #[pymethods]
 impl PyDictManager {
+    #[new]
+    fn new() -> Self {
+        Self { inner: Rc::new(RefCell::new(RustDictManager::new())) }
+    }
+
+    #[getter]
+    fn trackers(&self) -> PyResult<PyTrackerMapping> {
+        Ok(PyTrackerMapping { inner: self.inner.clone() })
+    }
+
     fn insert(&mut self, segment_index: isize, value: &PyDictTracker) -> PyResult<()> {
         if self.inner.borrow().trackers.contains_key(&segment_index) {
             return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
@@ -26,11 +106,7 @@ impl PyDictManager {
         Ok(())
     }
 
-    fn get_value(
-        &self,
-        segment_index: isize,
-        key: PyMaybeRelocatable,
-    ) -> PyResult<PyMaybeRelocatable> {
+    fn get_value(&self, segment_index: isize, key: PyDictKey) -> PyResult<PyMaybeRelocatable> {
         let value = self
             .inner
             .borrow_mut()
@@ -47,24 +123,22 @@ impl PyDictManager {
 }
 
 #[pyclass(name = "DictTracker")]
+#[derive(Clone)]
 pub struct PyDictTracker {
     inner: DictTracker,
 }
 
 #[pymethods]
 impl PyDictTracker {
-    // Note: This is a temporary implementation, need to understand why HashMap<PyMaybeRelocatable,
-    // PyMaybeRelocatable> is not working
     #[new]
-    #[pyo3(signature = (keys, values, current_ptr, default_value=None))]
+    #[pyo3(signature = (data, current_ptr, default_value=None))]
     fn new(
-        keys: Vec<PyMaybeRelocatable>,
-        values: Vec<PyMaybeRelocatable>,
+        data: HashMap<PyDictKey, PyMaybeRelocatable>,
         current_ptr: PyRelocatable,
         default_value: Option<PyMaybeRelocatable>,
     ) -> PyResult<Self> {
-        let data: HashMap<MaybeRelocatable, MaybeRelocatable> =
-            keys.into_iter().zip(values).map(|(k, v)| (k.into(), v.into())).collect();
+        let data: HashMap<RustDictKey, MaybeRelocatable> =
+            data.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
 
         if let Some(default_value) = default_value {
             let default_value = default_value.into();
@@ -74,5 +148,34 @@ impl PyDictTracker {
         } else {
             Ok(Self { inner: DictTracker::new_with_initial(current_ptr.inner, data) })
         }
+    }
+
+    #[getter]
+    fn current_ptr(&self) -> PyRelocatable {
+        PyRelocatable { inner: self.inner.current_ptr }
+    }
+
+    #[getter]
+    fn data(&self) -> HashMap<PyDictKey, PyMaybeRelocatable> {
+        self.inner
+            .get_dictionary_ref()
+            .iter()
+            .map(|(k, v)| (PyDictKey::from(k.clone()), PyMaybeRelocatable::from(v.clone())))
+            .collect()
+    }
+
+    fn __repr__(&self) -> PyResult<String> {
+        let mut pairs: Vec<_> = self.inner.get_dictionary_ref().iter().collect();
+
+        // Sort by key
+        pairs.sort_by(|(k1, _), (k2, _)| k1.partial_cmp(k2).unwrap_or(std::cmp::Ordering::Equal));
+
+        let data_str =
+            pairs.into_iter().map(|(k, v)| format!("{}: {}", k, v)).collect::<Vec<_>>().join(", ");
+
+        Ok(format!(
+            "DictTracker(data={{{}}}, current_ptr=Relocatable(segment_index={}, offset={}))",
+            data_str, self.inner.current_ptr.segment_index, self.inner.current_ptr.offset
+        ))
     }
 }

--- a/crates/cairo-addons/src/vm/felt.rs
+++ b/crates/cairo-addons/src/vm/felt.rs
@@ -16,7 +16,7 @@ impl Felt252Input {
 }
 
 #[pyclass(name = "Felt")]
-#[derive(Clone)]
+#[derive(Clone, Eq, PartialEq, Hash)]
 pub struct PyFelt {
     pub(crate) inner: Felt252,
 }

--- a/crates/cairo-addons/src/vm/maybe_relocatable.rs
+++ b/crates/cairo-addons/src/vm/maybe_relocatable.rs
@@ -3,7 +3,7 @@ use cairo_vm::types::relocatable::MaybeRelocatable as RustMaybeRelocatable;
 use num_bigint::BigUint;
 use pyo3::{FromPyObject, IntoPy, PyObject, Python};
 
-#[derive(FromPyObject)]
+#[derive(FromPyObject, Eq, PartialEq, Hash)]
 pub enum PyMaybeRelocatable {
     #[pyo3(transparent)]
     Felt(PyFelt),

--- a/crates/cairo-addons/src/vm/relocatable.rs
+++ b/crates/cairo-addons/src/vm/relocatable.rs
@@ -6,7 +6,7 @@ use pyo3::prelude::*;
 use super::maybe_relocatable::PyMaybeRelocatable;
 
 #[pyclass(name = "Relocatable")]
-#[derive(Clone)]
+#[derive(Clone, Eq, PartialEq, Hash)]
 pub struct PyRelocatable {
     pub(crate) inner: RustRelocatable,
 }

--- a/python/cairo-addons/tests/test_dict_manager.py
+++ b/python/cairo-addons/tests/test_dict_manager.py
@@ -1,5 +1,9 @@
 import pytest
-from cairo_addons.vm import CairoRunner, DictTracker
+from cairo_addons.vm import CairoRunner
+from cairo_addons.vm import DictManager as RustDictManager
+from cairo_addons.vm import DictTracker as RustDictTracker
+from cairo_addons.vm import Relocatable as RustRelocatable
+from starkware.cairo.common.dict import DictManager, DictTracker
 
 
 @pytest.fixture
@@ -17,9 +21,8 @@ class TestDictManager:
         current_ptr = dict_ptr + len(initial_data)
         runner.dict_manager.insert(
             dict_ptr.segment_index,
-            DictTracker(
-                keys=list(data.keys()),
-                values=list(data.values()),
+            RustDictTracker(
+                data=data,
                 current_ptr=current_ptr,
             ),
         )
@@ -30,9 +33,7 @@ class TestDictManager:
         dict_ptr = runner.segments.add()
         runner.dict_manager.insert(
             dict_ptr.segment_index,
-            DictTracker(
-                keys=[], values=[], current_ptr=dict_ptr, default_value=0xABDE1
-            ),
+            RustDictTracker(data={}, current_ptr=dict_ptr, default_value=0xABDE1),
         )
         assert runner.dict_manager.get_value(dict_ptr.segment_index, 1) == 0xABDE1
 
@@ -40,10 +41,30 @@ class TestDictManager:
         dict_ptr = runner.segments.add()
         runner.dict_manager.insert(
             dict_ptr.segment_index,
-            DictTracker(keys=[], values=[], current_ptr=dict_ptr),
+            RustDictTracker(data={}, current_ptr=dict_ptr),
         )
         with pytest.raises(ValueError, match="Segment index already exists"):
             runner.dict_manager.insert(
                 dict_ptr.segment_index,
-                DictTracker(keys=[], values=[], current_ptr=dict_ptr),
+                RustDictTracker(data={}, current_ptr=dict_ptr),
             )
+
+    def test_api_compatibility(self):
+        rust_manager = RustDictManager()
+        python_manager = DictManager()
+        data = {1: 4, 2: 5, 3: 6}
+        dict_ptr = RustRelocatable(segment_index=0, offset=0)
+
+        rust_tracker = RustDictTracker(
+            data=data, current_ptr=dict_ptr, default_value=None
+        )
+        python_tracker = DictTracker(data=data, current_ptr=dict_ptr)
+
+        assert rust_tracker.current_ptr == python_tracker.current_ptr
+        assert rust_tracker.data == python_tracker.data
+        assert str(rust_tracker) == str(python_tracker)
+        rust_manager.trackers[dict_ptr.segment_index] = rust_tracker
+        python_manager.trackers[dict_ptr.segment_index] = python_tracker
+        assert str(rust_manager.trackers[dict_ptr.segment_index]) == str(
+            python_manager.trackers[dict_ptr.segment_index]
+        )

--- a/python/cairo-addons/tests/test_memory_segments.py
+++ b/python/cairo-addons/tests/test_memory_segments.py
@@ -53,3 +53,8 @@ class TestMemorySegmentManager:
         assert sizes == [4]
         assert runner.segments.get_segment_used_size(0) == 4
         assert runner.segments.get_segment_size(0) == 4
+
+    def test_memory_wrapper(self, runner):
+        ptr = runner.segments.add()
+        runner.segments.load_data(ptr, [Felt(1), Felt(2), Felt(3), Felt(4)])
+        assert runner.segments.memory.get(ptr) == Felt(1)


### PR DESCRIPTION
improve rust bindings compat, enabling syntaxes like
- segments.memory.get(idx)
or 
- dict_trackers[idx] = X

based on a custom fork of the cairo vm in which I unbotherly created a special `DictKey` type which is an 
enum

```rust
#[derive(
    Eq, Ord, Hash, PartialEq, PartialOrd, Clone, Debug,
)]
pub enum DictKey {
    Simple(MaybeRelocatable),
    Compound(Vec<MaybeRelocatable>),
}
```

Which allows a Vec of Felts / Relocatable to be used as dict keys. For us this is important because we need to track preimages that might not fit in a felt inside the dict tracker. 

This was implemented in a "dumb" way that is unconsidering of external side effects to the Cairo-VM - once synced with LC we will want to revisit the approach. see https://github.com/kkrt-labs/cairo-vm/tree/kkrt-compat