### PR TITLE
feat: set storage

### DIFF
--- a/cairo/ethereum/cancun/fork_types.cairo
+++ b/cairo/ethereum/cancun/fork_types.cairo
@@ -4,6 +4,7 @@ from ethereum_types.bytes import Bytes20, Bytes32, Bytes256, Bytes, BytesStruct,
 from ethereum.utils.bytes import Bytes__eq__
 from ethereum_types.numeric import Uint, U256, U256Struct, bool
 from ethereum.crypto.hash import Hash32
+from ethereum.utils.numeric import is_zero
 
 using Address = Bytes20;
 
@@ -126,6 +127,16 @@ func EMPTY_ACCOUNT() -> Account {
 }
 
 func Account__eq__(a: Account, b: Account) -> bool {
+    if (cast(a.value, felt) == 0) {
+        let b_is_none = is_zero(cast(b.value, felt));
+        let res = bool(b_is_none);
+        return res;
+    }
+    if (cast(b.value, felt) == 0) {
+        let a_is_none = is_zero(cast(a.value, felt));
+        let res = bool(a_is_none);
+        return res;
+    }
     if (a.value.nonce.value != b.value.nonce.value) {
         tempvar res = bool(0);
         return res;

--- a/cairo/ethereum/cancun/state.cairo
+++ b/cairo/ethereum/cancun/state.cairo
@@ -161,7 +161,7 @@ func get_storage{poseidon_ptr: PoseidonBuiltin*, state: State}(
     let value = trie_get_TrieBytes32U256{poseidon_ptr=poseidon_ptr, trie=storage_trie}(key);
 
     // Rebind the storage trie to the state
-    let new_storage_trie_ptr = cast(storage_trie_ptr, felt);
+    let new_storage_trie_ptr = cast(storage_trie.value, felt);
 
     hashdict_write{poseidon_ptr=poseidon_ptr, dict_ptr=storage_tries_dict_ptr}(
         1, &address.value, new_storage_trie_ptr

--- a/cairo/ethereum/cancun/state.cairo
+++ b/cairo/ethereum/cancun/state.cairo
@@ -218,6 +218,8 @@ func set_storage{poseidon_ptr: PoseidonBuiltin*, state: State}(
     }(1, &address.value);
 
     if (cast(storage_trie_pointer, felt) == 0) {
+        // dict_new expects an initial_dict hint argument.
+        %{ initial_dict = {} %}
         let (new_mapping_dict_ptr) = dict_new();
         tempvar _storage_trie = new TrieBytes32U256Struct(
             secured=bool(1),

--- a/cairo/ethereum/cancun/state.cairo
+++ b/cairo/ethereum/cancun/state.cairo
@@ -203,6 +203,8 @@ func set_storage{poseidon_ptr: PoseidonBuiltin*, state: State}(
     // Assert that the account exists
     let account = get_account_optional(address);
     if (cast(account.value, felt) == 0) {
+        // TODO: think about which cases lead to this error and decide on the correct type of exception to raise
+        // perhaps AssertionError
         with_attr error_message("Cannot set storage on non-existent account") {
             assert 0 = 1;
         }

--- a/cairo/ethereum/cancun/state.cairo
+++ b/cairo/ethereum/cancun/state.cairo
@@ -25,7 +25,7 @@ from ethereum.cancun.trie import (
     TrieBytes32U256Struct,
 )
 from ethereum_types.bytes import Bytes, Bytes32
-from src.utils.dict import hashdict_read, hashdict_write
+from src.utils.dict import hashdict_read, hashdict_write, hashdict_get
 from ethereum_types.numeric import U256, U256Struct
 
 struct AddressTrieBytes32U256DictAccess {
@@ -127,7 +127,7 @@ func get_storage{poseidon_ptr: PoseidonBuiltin*, state: State}(
 
     let storage_tries_dict_ptr = cast(storage_tries.value.dict_ptr, DictAccess*);
 
-    let (pointer) = hashdict_read{poseidon_ptr=poseidon_ptr, dict_ptr=storage_tries_dict_ptr}(
+    let (pointer) = hashdict_get{poseidon_ptr=poseidon_ptr, dict_ptr=storage_tries_dict_ptr}(
         1, &address.value
     );
 
@@ -207,11 +207,10 @@ func set_storage{poseidon_ptr: PoseidonBuiltin*, state: State}(
     }
 
     let storage_tries_dict_ptr = cast(storage_tries.value.dict_ptr, DictAccess*);
-    let (storage_trie_pointer) = hashdict_read{
+    let (storage_trie_pointer) = hashdict_get{
         poseidon_ptr=poseidon_ptr, dict_ptr=storage_tries_dict_ptr
     }(1, &address.value);
 
-    // If the storage trie is not found, create an empty one and store it in the state
     if (cast(storage_trie_pointer, felt) == 0) {
         let (new_mapping_dict_ptr) = dict_new();
         tempvar _storage_trie = new TrieBytes32U256Struct(
@@ -236,7 +235,7 @@ func set_storage{poseidon_ptr: PoseidonBuiltin*, state: State}(
             storage_tries_dict_ptr, AddressTrieBytes32U256DictAccess*
         );
 
-        tempvar storage_tries = MappingAddressTrieBytes32U256(
+        tempvar new_storage_tries = MappingAddressTrieBytes32U256(
             new MappingAddressTrieBytes32U256Struct(
                 dict_ptr_start=storage_tries.value.dict_ptr_start,
                 dict_ptr=new_storage_tries_dict_ptr,

--- a/cairo/ethereum/cancun/state.cairo
+++ b/cairo/ethereum/cancun/state.cairo
@@ -230,7 +230,6 @@ func set_storage{poseidon_ptr: PoseidonBuiltin*, state: State}(
             1, &address.value, new_storage_trie_ptr
         );
 
-        let storage_trie = TrieBytes32U256(_storage_trie);
         let new_storage_tries_dict_ptr = cast(
             storage_tries_dict_ptr, AddressTrieBytes32U256DictAccess*
         );

--- a/cairo/ethereum/cancun/state.cairo
+++ b/cairo/ethereum/cancun/state.cairo
@@ -127,6 +127,8 @@ func get_storage{poseidon_ptr: PoseidonBuiltin*, state: State}(
 
     let storage_tries_dict_ptr = cast(storage_tries.value.dict_ptr, DictAccess*);
 
+    // Use `hashdict_get` instead of `hashdict_read` because `MappingAddressTrieBytes32U256` is not a
+    // `default_dict`. Accessing a key that does not exist in the dict would have panicked for `hashdict_read`.
     let (pointer) = hashdict_get{poseidon_ptr=poseidon_ptr, dict_ptr=storage_tries_dict_ptr}(
         1, &address.value
     );
@@ -207,6 +209,8 @@ func set_storage{poseidon_ptr: PoseidonBuiltin*, state: State}(
     }
 
     let storage_tries_dict_ptr = cast(storage_tries.value.dict_ptr, DictAccess*);
+    // Use `hashdict_get` instead of `hashdict_read` because `MappingAddressTrieBytes32U256` is not a
+    // `default_dict`. Accessing a key that does not exist in the dict would have panicked for `hashdict_read`.
     let (storage_trie_pointer) = hashdict_get{
         poseidon_ptr=poseidon_ptr, dict_ptr=storage_tries_dict_ptr
     }(1, &address.value);

--- a/cairo/ethereum/cancun/trie.cairo
+++ b/cairo/ethereum/cancun/trie.cairo
@@ -447,15 +447,7 @@ func trie_set_TrieAddressAccount{poseidon_ptr: PoseidonBuiltin*, trie: TrieAddre
     let dict_ptr_start = cast(trie.value._data.value.dict_ptr_start, DictAccess*);
     let dict_ptr = cast(trie.value._data.value.dict_ptr, DictAccess*);
 
-    // If the trie's default value is None (i.e. a null pointer), we compare `value` with the null pointer.
-    // As otherwise, Account__eq__ will panic.
-    if (cast(trie.value.default.value, felt) == 0) {
-        let value_is_null = is_zero(cast(value.value, felt));
-        tempvar is_default = bool(value_is_null);
-    } else {
-        let is_default = Account__eq__(value, trie.value.default);
-        tempvar is_default = is_default;
-    }
+    let is_default = Account__eq__(value, trie.value.default);
 
     with dict_ptr_start, dict_ptr {
         let (keys) = alloc();

--- a/cairo/ethereum/cancun/trie.cairo
+++ b/cairo/ethereum/cancun/trie.cairo
@@ -447,7 +447,15 @@ func trie_set_TrieAddressAccount{poseidon_ptr: PoseidonBuiltin*, trie: TrieAddre
     let dict_ptr_start = cast(trie.value._data.value.dict_ptr_start, DictAccess*);
     let dict_ptr = cast(trie.value._data.value.dict_ptr, DictAccess*);
 
-    let is_default = Account__eq__(value, trie.value.default);
+    // If the trie's default value is None (i.e. a null pointer), we compare `value` with the null pointer.
+    // As otherwise, Account__eq__ will panic.
+    if (cast(trie.value.default.value, felt) == 0) {
+        let value_is_null = is_zero(cast(value.value, felt));
+        tempvar is_default = bool(value_is_null);
+    } else {
+        let is_default = Account__eq__(value, trie.value.default);
+        tempvar is_default = is_default;
+    }
 
     with dict_ptr_start, dict_ptr {
         let (keys) = alloc();

--- a/cairo/src/utils/dict.cairo
+++ b/cairo/src/utils/dict.cairo
@@ -83,6 +83,44 @@ func hashdict_read{poseidon_ptr: PoseidonBuiltin*, dict_ptr: DictAccess*}(
     return (value=value);
 }
 
+// A wrapper around dict_read that hashes the key before accessing the dictionary if the key
+// does not fit in a felt.
+// @dev This version returns 0, if the key is not found and the dict is NOT a defaultdict.
+// @param key_len: The readnumber of felt values used to represent the key.
+// @param key: The key to access the dictionary.
+// TODO: write the associated squash function.
+func hashdict_get{poseidon_ptr: PoseidonBuiltin*, dict_ptr: DictAccess*}(
+    key_len: felt, key: felt*
+) -> (value: felt) {
+    alloc_locals;
+    local felt_key;
+    if (key_len == 1) {
+        assert felt_key = key[0];
+        tempvar poseidon_ptr = poseidon_ptr;
+    } else {
+        let (felt_key_) = poseidon_hash_many(key_len, key);
+        assert felt_key = felt_key_;
+        tempvar poseidon_ptr = poseidon_ptr;
+    }
+
+    local value;
+    %{
+        from collections import defaultdict
+        dict_tracker = __dict_manager.get_tracker(ids.dict_ptr)
+        dict_tracker.current_ptr += ids.DictAccess.SIZE
+        preimage = tuple([memory[ids.key + i] for i in range(ids.key_len)])
+        if isinstance(dict_tracker.data, defaultdict):
+            ids.value = dict_tracker.data[preimage]
+        else:
+            ids.value = dict_tracker.data.get(preimage, 0)
+    %}
+    dict_ptr.key = felt_key;
+    dict_ptr.prev_value = value;
+    dict_ptr.new_value = value;
+    let dict_ptr = dict_ptr + DictAccess.SIZE;
+    return (value=value);
+}
+
 // A wrapper around dict_write that hashes the key before accessing the dictionary if the key
 // does not fit in a felt.
 // @param key_len: The number of felt values used to represent the key.
@@ -102,10 +140,14 @@ func hashdict_write{poseidon_ptr: PoseidonBuiltin*, dict_ptr: DictAccess*}(
         tempvar poseidon_ptr = poseidon_ptr;
     }
     %{
+        from collections import defaultdict
         dict_tracker = __dict_manager.get_tracker(ids.dict_ptr)
         dict_tracker.current_ptr += ids.DictAccess.SIZE
         preimage = tuple([memory[ids.key + i] for i in range(ids.key_len)])
-        ids.dict_ptr.prev_value = dict_tracker.data[preimage]
+        if isinstance(dict_tracker.data, defaultdict):
+            ids.dict_ptr.prev_value = dict_tracker.data[preimage]
+        else:
+            ids.dict_ptr.prev_value = 0
         dict_tracker.data[preimage] = ids.new_value
     %}
     dict_ptr.key = felt_key;

--- a/cairo/tests/ethereum/cancun/test_state.py
+++ b/cairo/tests/ethereum/cancun/test_state.py
@@ -24,7 +24,7 @@ def state_and_address_and_key(
     # For address selection, use address_strategy if no keys in state
     address_options = (
         [st.sampled_from(list(state._main_trie._data.keys())), address_strategy]
-        if state._main_trie._data is not None and state._main_trie._data
+        if state._main_trie._data != {}
         else [address_strategy]
     )
     address = draw(st.one_of(*address_options))
@@ -36,7 +36,7 @@ def state_and_address_and_key(
 
     key_options = (
         [st.sampled_from(list(storage._data.keys())), key_strategy]
-        if storage is not None and storage._data
+        if storage is not None and storage._data != {}
         else [key_strategy]
     )
     key = draw(st.one_of(*key_options))

--- a/cairo/tests/ethereum/cancun/test_trie.py
+++ b/cairo/tests/ethereum/cancun/test_trie.py
@@ -174,7 +174,11 @@ class TestTrieOperations:
 
     @given(trie=..., key=..., value=...)
     def test_trie_set_TrieAddressAccount(
-        self, cairo_run, trie: Trie[Address, Account], key: Address, value: Account
+        self,
+        cairo_run,
+        trie: Trie[Address, Optional[Account]],
+        key: Address,
+        value: Account,
     ):
         cairo_trie = cairo_run("trie_set_TrieAddressAccount", trie, key, value)
         trie_set(trie, key, value)

--- a/cairo/tests/test_serde.py
+++ b/cairo/tests/test_serde.py
@@ -234,6 +234,7 @@ class TestSerde:
             Trie[Bytes32, U256],
             Trie[Address, Optional[Account]],
             TransientStorage,
+            Mapping[Address, Trie[Bytes32, U256]],
             State,
             Tuple[
                 Trie[Address, Optional[Account]], Mapping[Address, Trie[Bytes32, U256]]

--- a/cairo/tests/utils/serde.py
+++ b/cairo/tests/utils/serde.py
@@ -516,7 +516,7 @@ class Serde:
                 ]:
                     hashed_key = poseidon_hash_many(key)
                     preimage = b"".join(felt.to_bytes(16, "little") for felt in key)
-                    # Other syntaxes are eagerly evaluated, and thus throw a key error.
+
                     value = dict_segment_data.get(
                         hashed_key
                     ) or serialized_original.get(preimage)

--- a/cairo/tests/utils/serde.py
+++ b/cairo/tests/utils/serde.py
@@ -517,29 +517,29 @@ class Serde:
                     hashed_key = poseidon_hash_many(key)
                     preimage = b"".join(felt.to_bytes(16, "little") for felt in key)
                     # Other syntaxes are eagerly evaluated, and thus throw a key error.
-                    serialized_dict[preimage] = (
-                        dict_segment_data[hashed_key]
-                        if dict_segment_data.get(hashed_key) is not None
-                        else serialized_original[preimage]
-                    )
+                    value = dict_segment_data.get(
+                        hashed_key
+                    ) or serialized_original.get(preimage)
+                    if value is not None:
+                        serialized_dict[preimage] = value
 
                 elif python_key_type == U256:
                     hashed_key = poseidon_hash_many(key)
                     preimage = sum(felt * 2 ** (128 * i) for i, felt in enumerate(key))
-                    serialized_dict[preimage] = (
-                        dict_segment_data[hashed_key]
-                        if dict_segment_data.get(hashed_key) is not None
-                        else serialized_original[preimage]
-                    )
+                    value = dict_segment_data.get(
+                        hashed_key
+                    ) or serialized_original.get(preimage)
+                    if value is not None:
+                        serialized_dict[preimage] = value
 
                 elif python_key_type == Bytes:
                     hashed_key = poseidon_hash_many(key)
                     preimage = bytes(list(key))
-                    serialized_dict[preimage] = (
-                        dict_segment_data[hashed_key]
-                        if dict_segment_data.get(hashed_key) is not None
-                        else serialized_original[preimage]
-                    )
+                    value = dict_segment_data.get(
+                        hashed_key
+                    ) or serialized_original.get(preimage)
+                    if value is not None:
+                        serialized_dict[preimage] = value
                 else:
                     raise ValueError(f"Unsupported key type: {python_key_type}")
 
@@ -574,11 +574,11 @@ class Serde:
                 if is_null_pointer:
                     continue
 
-                serialized_dict[preimage] = (
-                    dict_segment_data.get(preimage)
-                    if dict_segment_data.get(preimage) is not None
-                    else serialized_original[preimage]
+                value = dict_segment_data.get(preimage) or serialized_original.get(
+                    preimage
                 )
+                if value is not None:
+                    serialized_dict[preimage] = value
 
         if origin_cls is set:
             return set(serialized_dict.keys())

--- a/cairo/tests/utils/serde.py
+++ b/cairo/tests/utils/serde.py
@@ -822,7 +822,7 @@ class Serde:
             # encounter an error.
             except UnknownMemoryError:
                 break
-            except Exception as _e:
+            except Exception:
                 # TODO: handle this better as only UnknownMemoryError is expected
                 # when accessing invalid memory
                 break

--- a/cairo/tests/utils/serde.py
+++ b/cairo/tests/utils/serde.py
@@ -520,6 +520,10 @@ class Serde:
                     value = dict_segment_data.get(
                         hashed_key
                     ) or serialized_original.get(preimage)
+
+                    # If `value` is None, it means the dict tracker has more
+                    # data than the corresponding `dict_segment`.
+                    # This can occur when serializing snapshots of dictionaries.
                     if value is not None:
                         serialized_dict[preimage] = value
 

--- a/cairo/tests/utils/serde.py
+++ b/cairo/tests/utils/serde.py
@@ -518,8 +518,8 @@ class Serde:
                     preimage = b"".join(felt.to_bytes(16, "little") for felt in key)
 
                     value = dict_segment_data.get(
-                        hashed_key
-                    ) or serialized_original.get(preimage)
+                        hashed_key, serialized_original.get(preimage)
+                    )
 
                     # If `value` is None, it means the dict tracker has more
                     # data than the corresponding `dict_segment`.
@@ -531,8 +531,8 @@ class Serde:
                     hashed_key = poseidon_hash_many(key)
                     preimage = sum(felt * 2 ** (128 * i) for i, felt in enumerate(key))
                     value = dict_segment_data.get(
-                        hashed_key
-                    ) or serialized_original.get(preimage)
+                        hashed_key, serialized_original.get(preimage)
+                    )
                     if value is not None:
                         serialized_dict[preimage] = value
 
@@ -540,8 +540,8 @@ class Serde:
                     hashed_key = poseidon_hash_many(key)
                     preimage = bytes(list(key))
                     value = dict_segment_data.get(
-                        hashed_key
-                    ) or serialized_original.get(preimage)
+                        hashed_key, serialized_original.get(preimage)
+                    )
                     if value is not None:
                         serialized_dict[preimage] = value
                 else:
@@ -578,9 +578,10 @@ class Serde:
                 if is_null_pointer:
                     continue
 
-                value = dict_segment_data.get(preimage) or serialized_original.get(
-                    preimage
+                value = dict_segment_data.get(
+                    preimage, serialized_original.get(preimage)
                 )
+
                 if value is not None:
                     serialized_dict[preimage] = value
 

--- a/cairo/tests/utils/strategies.py
+++ b/cairo/tests/utils/strategies.py
@@ -326,6 +326,8 @@ state = st.lists(address, min_size=0, max_size=MAX_ADDRESS_SET_SIZE).flatmap(
                     _data=st.dictionaries(
                         keys=bytes32,
                         values=uint256,
+                        # If _data is empty, the trie is not created
+                        min_size=1,
                         max_size=MAX_STORAGE_KEY_SET_SIZE,
                     ),
                 )
@@ -416,3 +418,4 @@ def register_type_strategies():
     st.register_type_strategy(Memory, memory)
     st.register_type_strategy(Evm, evm)
     st.register_type_strategy(tuple, tuple_strategy)
+    st.register_type_strategy(State, state)

--- a/cairo/tests/utils/strategies.py
+++ b/cairo/tests/utils/strategies.py
@@ -1,7 +1,6 @@
 # ruff: noqa: E402
 
 import os
-from collections import defaultdict
 from typing import ForwardRef, Sequence, TypeAlias, Union, get_args, get_origin
 from unittest.mock import patch
 
@@ -110,7 +109,11 @@ def trie_strategy(thing):
     default_strategy = (
         st.none()
         if value_type_origin is Union and get_args(value_type)[1] is type(None)
-        else st.from_type(value_type)
+        else (
+            st.just(value_type(0))
+            if value_type is U256
+            else st.nothing()  # No other type is accepted
+        )
     )
 
     # Create a strategy for non-default values
@@ -319,24 +322,12 @@ state = st.lists(address, min_size=0, max_size=MAX_ADDRESS_SET_SIZE).flatmap(
         ),
         _storage_tries=st.fixed_dictionaries(
             {
-                address: st.builds(
-                    Trie[Bytes32, U256],
-                    secured=st.just(True),
-                    default=st.just(U256(0)),
-                    _data=st.dictionaries(
-                        keys=bytes32,
-                        values=uint256,
-                        # If _data is empty, the trie is not created
-                        min_size=1,
-                        max_size=MAX_STORAGE_KEY_SET_SIZE,
-                    ),
+                address: trie_strategy(Trie[Bytes32, U256]).filter(
+                    lambda t: bool(t._data)
                 )
                 for address in addresses
             }
-            # In case the dict is empty, we use 0 as the default value
-            # To avoid panic in the dict.cairo:hashdict_read hint
-            # `ids.value = dict_tracker.data.get(preimage, dict_tracker.data.default_factory())`
-        ).map(lambda d: defaultdict(lambda: 0, d)),
+        ),
         _snapshots=st.just([]),
         created_accounts=st.just(set()),
     )

--- a/cairo/tests/utils/strategies.py
+++ b/cairo/tests/utils/strategies.py
@@ -1,7 +1,15 @@
 # ruff: noqa: E402
 
 import os
-from typing import ForwardRef, Sequence, TypeAlias, Union, get_args, get_origin
+from typing import (
+    ForwardRef,
+    Optional,
+    Sequence,
+    TypeAlias,
+    Union,
+    get_args,
+    get_origin,
+)
 from unittest.mock import patch
 
 from eth_keys.datatypes import PrivateKey
@@ -313,7 +321,7 @@ state = st.lists(address, min_size=0, max_size=MAX_ADDRESS_SET_SIZE).flatmap(
     lambda addresses: st.builds(
         State,
         _main_trie=st.builds(
-            Trie[Address, Account],
+            Trie[Address, Optional[Account]],
             secured=st.just(True),
             default=st.none(),
             _data=st.fixed_dictionaries(


### PR DESCRIPTION
Setting to draft as tests cannot pass until we skip serialization of nested dictionaries that are filled with default_values in serde.py, as seen in https://github.com/ethereum/execution-specs/blob/master/src/ethereum/cancun/state.py#L318

closes #409 