### PR TITLE
feat: get_storage_original

### DIFF
--- a/cairo/ethereum/cancun/state.cairo
+++ b/cairo/ethereum/cancun/state.cairo
@@ -341,7 +341,7 @@ func get_storage_original{range_check_ptr, poseidon_ptr: PoseidonBuiltin*, state
     let new_created_accounts_ptr = cast(created_accounts_ptr, SetAddressDictAccess*);
     tempvar new_created_accounts = SetAddress(
         new SetAddressStruct(
-            dict_ptr_start=state.value.created_accounts.value.dict_ptr,
+            dict_ptr_start=state.value.created_accounts.value.dict_ptr_start,
             dict_ptr=new_created_accounts_ptr,
         ),
     );
@@ -356,7 +356,9 @@ func get_storage_original{range_check_ptr, poseidon_ptr: PoseidonBuiltin*, state
 
     let original_storage_tries = state.value.original_storage_tries;
     let original_storage_tries_ptr = cast(original_storage_tries.value.dict_ptr, DictAccess*);
-    let (original_account_trie_pointer) = hashdict_read{dict_ptr=original_storage_tries_ptr}(
+    // The address might not have an original storage trie - `get` returns 0 (None) if no key is
+    // hit.
+    let (original_account_trie_pointer) = hashdict_get{dict_ptr=original_storage_tries_ptr}(
         1, &address.value
     );
 

--- a/cairo/ethereum/cancun/state.cairo
+++ b/cairo/ethereum/cancun/state.cairo
@@ -17,8 +17,6 @@ from ethereum.cancun.fork_types import (
     MappingBytes32U256Struct,
     Account__eq__,
     Bytes32U256DictAccess,
-    SetAddressDictAccess,
-    SetAddressStruct,
 )
 from ethereum.cancun.trie import (
     TrieBytes32U256,
@@ -437,6 +435,7 @@ func destroy_storage{poseidon_ptr: PoseidonBuiltin*, state: State}(address: Addr
                 _storage_tries=storage_tries,
                 _snapshots=state.value._snapshots,
                 created_accounts=state.value.created_accounts,
+                original_storage_tries=state.value.original_storage_tries,
             ),
         );
         return ();
@@ -461,6 +460,7 @@ func destroy_storage{poseidon_ptr: PoseidonBuiltin*, state: State}(address: Addr
             _storage_tries=new_storage_tries,
             _snapshots=state.value._snapshots,
             created_accounts=state.value.created_accounts,
+            original_storage_tries=state.value.original_storage_tries,
         ),
     );
 

--- a/cairo/ethereum/cancun/state.cairo
+++ b/cairo/ethereum/cancun/state.cairo
@@ -114,6 +114,7 @@ func get_account_optional{poseidon_ptr: PoseidonBuiltin*, state: State}(
             _storage_tries=state.value._storage_tries,
             _snapshots=state.value._snapshots,
             created_accounts=state.value.created_accounts,
+            original_storage_tries=state.value.original_storage_tries,
         ),
     );
 

--- a/cairo/ethereum/cancun/state.cairo
+++ b/cairo/ethereum/cancun/state.cairo
@@ -10,6 +10,8 @@ from ethereum.cancun.fork_types import (
     OptionalAccount,
     MappingAddressAccount,
     SetAddress,
+    SetAddressStruct,
+    SetAddressDictAccess,
     EMPTY_ACCOUNT,
     MappingBytes32U256,
     MappingBytes32U256Struct,
@@ -93,6 +95,7 @@ struct StateStruct {
     _storage_tries: MappingAddressTrieBytes32U256,
     _snapshots: ListTupleTrieAddressOptionalAccountMappingAddressTrieBytes32U256,
     created_accounts: SetAddress,
+    original_storage_tries: MappingAddressTrieBytes32U256,
 }
 
 struct State {
@@ -144,6 +147,7 @@ func set_account{poseidon_ptr: PoseidonBuiltin*, state: State}(
             _storage_tries=state.value._storage_tries,
             _snapshots=state.value._snapshots,
             created_accounts=state.value.created_accounts,
+            original_storage_tries=state.value.original_storage_tries,
         ),
     );
     return ();
@@ -184,6 +188,7 @@ func get_storage{poseidon_ptr: PoseidonBuiltin*, state: State}(
                 _storage_tries=storage_tries,
                 _snapshots=state.value._snapshots,
                 created_accounts=state.value.created_accounts,
+                original_storage_tries=state.value.original_storage_tries,
             ),
         );
 
@@ -218,6 +223,7 @@ func get_storage{poseidon_ptr: PoseidonBuiltin*, state: State}(
             _storage_tries=storage_tries,
             _snapshots=state.value._snapshots,
             created_accounts=state.value.created_accounts,
+            original_storage_tries=state.value.original_storage_tries,
         ),
     );
     return value;
@@ -317,9 +323,87 @@ func set_storage{poseidon_ptr: PoseidonBuiltin*, state: State}(
             _storage_tries=new_storage_tries,
             _snapshots=state.value._snapshots,
             created_accounts=state.value.created_accounts,
+            original_storage_tries=state.value.original_storage_tries,
         ),
     );
     return ();
+}
+
+func get_storage_original{range_check_ptr, poseidon_ptr: PoseidonBuiltin*, state: State}(
+    address: Address, key: Bytes32
+) -> U256 {
+    alloc_locals;
+
+    let fp_and_pc = get_fp_and_pc();
+    local __fp__: felt* = fp_and_pc.fp_val;
+
+    let created_accounts_ptr = cast(state.value.created_accounts.value.dict_ptr, DictAccess*);
+    let (is_created) = hashdict_read{dict_ptr=created_accounts_ptr}(1, &address.value);
+    let new_created_accounts_ptr = cast(created_accounts_ptr, SetAddressDictAccess*);
+    tempvar new_created_accounts = SetAddress(
+        new SetAddressStruct(
+            dict_ptr_start=state.value.created_accounts.value.dict_ptr,
+            dict_ptr=new_created_accounts_ptr,
+        ),
+    );
+    StateImpl.set_created_accounts(new_created_accounts);
+
+    // In the transaction where an account is created, its preexisting storage
+    // is ignored.
+    if (is_created == 0) {
+        tempvar res = U256(new U256Struct(0, 0));
+        return res;
+    }
+
+    let original_storage_tries = state.value.original_storage_tries;
+    let original_storage_tries_ptr = cast(original_storage_tries.value.dict_ptr, DictAccess*);
+    let (original_account_trie_pointer) = hashdict_read{dict_ptr=original_storage_tries_ptr}(
+        1, &address.value
+    );
+
+    // If account trie is null, return 0
+    if (cast(original_account_trie_pointer, felt) == 0) {
+        let new_original_storage_tries_ptr = cast(
+            original_storage_tries_ptr, AddressTrieBytes32U256DictAccess*
+        );
+        tempvar new_original_storage_tries = MappingAddressTrieBytes32U256(
+            new MappingAddressTrieBytes32U256Struct(
+                dict_ptr_start=original_storage_tries.value.dict_ptr_start,
+                dict_ptr=new_original_storage_tries_ptr,
+                original_mapping=original_storage_tries.value.original_mapping,
+            ),
+        );
+        StateImpl.set_original_storage_tries(new_original_storage_tries);
+        tempvar res = U256(new U256Struct(0, 0));
+        return res;
+    }
+
+    // Get the value from the account's original storage trie
+    let original_account_trie = TrieBytes32U256(
+        cast(original_account_trie_pointer, TrieBytes32U256Struct*)
+    );
+    let original_value = trie_get_TrieBytes32U256{trie=original_account_trie}(key);
+
+    // Overwrite the original_storage_tries with the updated account's storage trie, post-read.
+    let new_account_storage_trie_ptr = cast(original_account_trie.value, felt);
+    hashdict_write{dict_ptr=original_storage_tries_ptr}(
+        1, &address.value, new_account_storage_trie_ptr
+    );
+
+    // Update state
+    let new_original_storage_tries_ptr = cast(
+        original_storage_tries_ptr, AddressTrieBytes32U256DictAccess*
+    );
+    tempvar new_original_storage_tries = MappingAddressTrieBytes32U256(
+        new MappingAddressTrieBytes32U256Struct(
+            dict_ptr_start=original_storage_tries.value.dict_ptr_start,
+            dict_ptr=new_original_storage_tries_ptr,
+            original_mapping=original_storage_tries.value.original_mapping,
+        ),
+    );
+    StateImpl.set_original_storage_tries(new_original_storage_tries);
+
+    return original_value;
 }
 
 func destroy_storage{poseidon_ptr: PoseidonBuiltin*, state: State}(address: Address) {
@@ -590,6 +674,7 @@ func mark_account_created{poseidon_ptr: PoseidonBuiltin*, state: State}(address:
             _storage_tries=state.value._storage_tries,
             _snapshots=state.value._snapshots,
             created_accounts=new_created_account,
+            original_storage_tries=state.value.original_storage_tries,
         ),
     );
 
@@ -629,4 +714,34 @@ func is_account_alive{poseidon_ptr: PoseidonBuiltin*, state: State}(address: Add
 
     tempvar res = bool(0);
     return res;
+}
+
+namespace StateImpl {
+    func set_created_accounts{state: State}(new_created_accounts: SetAddress) {
+        tempvar state = State(
+            new StateStruct(
+                _main_trie=state.value._main_trie,
+                _storage_tries=state.value._storage_tries,
+                _snapshots=state.value._snapshots,
+                created_accounts=new_created_accounts,
+                original_storage_tries=state.value.original_storage_tries,
+            ),
+        );
+        return ();
+    }
+
+    func set_original_storage_tries{state: State}(
+        new_original_storage_tries: MappingAddressTrieBytes32U256
+    ) {
+        tempvar state = State(
+            new StateStruct(
+                _main_trie=state.value._main_trie,
+                _storage_tries=state.value._storage_tries,
+                _snapshots=state.value._snapshots,
+                created_accounts=state.value.created_accounts,
+                original_storage_tries=new_original_storage_tries,
+            ),
+        );
+        return ();
+    }
 }

--- a/cairo/tests/ethereum/cancun/test_state.py
+++ b/cairo/tests/ethereum/cancun/test_state.py
@@ -38,12 +38,14 @@ def state_and_address_and_optional_key(
 ):
     state = draw(state_strategy)
 
-    # For address selection, use address_strategy if no keys in state
-    address_options = (
-        [st.sampled_from(list(state._main_trie._data.keys())), address_strategy]
-        if state._main_trie._data != {}
-        else [address_strategy]
-    )
+    # For address selection, shuffle from one of the following strategies
+    address_options = []
+    if state._main_trie._data:
+        address_options.append(st.sampled_from(list(state._main_trie._data.keys())))
+    if state.created_accounts:
+        address_options.append(st.sampled_from(list(state.created_accounts)))
+    address_options.append(address_strategy)
+
     address = draw(st.one_of(*address_options))
 
     # For key selection, use key_strategy if no storage keys for this address

--- a/cairo/tests/ethereum/cancun/test_state.py
+++ b/cairo/tests/ethereum/cancun/test_state.py
@@ -17,6 +17,7 @@ from ethereum.cancun.state import (
     get_account,
     get_account_optional,
     get_storage,
+    get_storage_original,
     get_transient_storage,
     is_account_alive,
     is_account_empty,
@@ -137,6 +138,15 @@ class TestStateAccounts:
 
 
 class TestStateStorage:
+    @given(state_and_address_and_optional_key(key_strategy=bytes32))
+    def test_get_storage_original(self, cairo_run, data):
+        state, address, key = data
+        state_cairo, result_cairo = cairo_run(
+            "get_storage_original", state, address, key
+        )
+        assert result_cairo == get_storage_original(state, address, key)
+        assert state_cairo == state
+
     @given(data=state_and_address_and_optional_key(key_strategy=bytes32))
     def test_get_storage(
         self,

--- a/cairo/tests/utils/args_gen.py
+++ b/cairo/tests/utils/args_gen.py
@@ -615,6 +615,13 @@ def _gen_arg(
             )
             for f in fields(arg_type_origin)
         ]
+
+        if arg_type_origin is State:
+            # In case of a Trie, we need to put the original_storage_tries (trie._snapshots[0]) in a
+            # special field of the State. We want easy access / overrides to this specific snapshot in
+            # Cairo, as each `sstore` performs an update of this original trie.
+            data.append(data[1])
+
         segments.load_data(struct_ptr, data)
 
         if arg_type_origin is Trie:

--- a/cairo/tests/utils/args_gen.py
+++ b/cairo/tests/utils/args_gen.py
@@ -617,7 +617,7 @@ def _gen_arg(
         ]
 
         if arg_type_origin is State:
-            # In case of a Trie, we need to put the original_storage_tries (trie._snapshots[0]) in a
+            # In case of a Trie, we need to put the original_storage_tries (state._snapshots[0][1]) in a
             # special field of the State. We want easy access / overrides to this specific snapshot in
             # Cairo, as each `sstore` performs an update of this original trie.
             data.append(data[1])

--- a/cairo/tests/utils/serde.py
+++ b/cairo/tests/utils/serde.py
@@ -385,10 +385,11 @@ class Serde:
 
                 # Replace snapshot[0]._storage_tries with the original_storage_tries,
                 # and remove the original_storage_tries from the state. It's a pure cairo concept.
-                value["_snapshots"][0] = (
-                    value["_snapshots"][0][0],
-                    value["original_storage_tries"],
-                )
+                if value["_snapshots"]:
+                    value["_snapshots"][0] = (
+                        value["_snapshots"][0][0],
+                        value["original_storage_tries"],
+                    )
                 del value["original_storage_tries"]
 
             if python_cls is TransientStorage:

--- a/cairo/tests/utils/serde.py
+++ b/cairo/tests/utils/serde.py
@@ -383,6 +383,14 @@ class Serde:
                     for k in keys_to_delete:
                         del value["_storage_tries"][k]
 
+                # Replace snapshot[0]._storage_tries with the original_storage_tries,
+                # and remove the original_storage_tries from the state. It's a pure cairo concept.
+                value["_snapshots"][0] = (
+                    value["_snapshots"][0][0],
+                    value["original_storage_tries"],
+                )
+                del value["original_storage_tries"]
+
             if python_cls is TransientStorage:
                 if value["_tries"] is not None and value["_tries"] != {}:
                     # First collect all keys with empty tries

--- a/cairo/tests/utils/strategies.py
+++ b/cairo/tests/utils/strategies.py
@@ -377,6 +377,14 @@ state = st.lists(address, max_size=MAX_ADDRESS_SET_SIZE, unique=True).flatmap(
         ),
         _snapshots=st.just([]),
         created_accounts=st.just(set()),
+    ).map(
+        # Create the original state snapshot using the same tries
+        lambda state: State(
+            _main_trie=state._main_trie,
+            _storage_tries=state._storage_tries,
+            _snapshots=[(state._main_trie, state._storage_tries)],
+            created_accounts=set(),
+        )
     ),
 )
 

--- a/cairo/tests/utils/strategies.py
+++ b/cairo/tests/utils/strategies.py
@@ -389,11 +389,7 @@ state = st.lists(address, max_size=MAX_ADDRESS_SET_SIZE, unique=True).flatmap(
                 (
                     copy_trie(state._main_trie),
                     {
-                        addr: Trie(
-                            secured=trie.secured,
-                            default=trie.default,
-                            _data=dict(trie._data),
-                        )
+                        addr: copy_trie(trie)
                         for addr, trie in state._storage_tries.items()
                     },
                 )

--- a/cairo/tests/utils/strategies.py
+++ b/cairo/tests/utils/strategies.py
@@ -377,7 +377,7 @@ state = st.lists(address, max_size=MAX_ADDRESS_SET_SIZE, unique=True).flatmap(
             )
         ),
         _snapshots=st.just([]),
-        created_accounts=st.just(set()),
+        created_accounts=st.sets(st.from_type(Address), max_size=10),
     ).map(
         # Create the original state snapshot using copies of the tries
         lambda state: State(
@@ -394,7 +394,7 @@ state = st.lists(address, max_size=MAX_ADDRESS_SET_SIZE, unique=True).flatmap(
                     },
                 )
             ],
-            created_accounts=set(),
+            created_accounts=state.created_accounts,
         )
     ),
 )


### PR DESCRIPTION
Closes #440 

Note: introduces a new field in the state that holds the original storage tries. 
Because in sstore, we get the original storage, meaning we need to access the snapshots[0] on each sstore. 
Because a dict_read writes memory data, it would mean we have to override snapshots[0] on each dict_read, which is inconvenient. 
This way, we can only overwrite the `original_storage_tries` field of the State struct.