### PR TITLE
tests: stricter error assertions

### DIFF
--- a/cairo/tests/ethereum/cancun/vm/instructions/test_arithmetic.py
+++ b/cairo/tests/ethereum/cancun/vm/instructions/test_arithmetic.py
@@ -1,4 +1,3 @@
-import pytest
 from hypothesis import given
 
 from ethereum.cancun.vm.instructions.arithmetic import (
@@ -15,6 +14,7 @@ from ethereum.cancun.vm.instructions.arithmetic import (
     sub,
 )
 from tests.utils.args_gen import Evm
+from tests.utils.errors import assert_raises_exactly
 from tests.utils.evm_builder import EvmBuilder
 
 arithmetic_tests_strategy = EvmBuilder().with_stack().with_gas_left().build()
@@ -26,7 +26,7 @@ class TestArithmetic:
         try:
             cairo_result = cairo_run("add", evm)
         except Exception as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 add(evm)
             return
 
@@ -38,7 +38,7 @@ class TestArithmetic:
         try:
             cairo_result = cairo_run("sub", evm)
         except Exception as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 sub(evm)
             return
 
@@ -50,7 +50,7 @@ class TestArithmetic:
         try:
             cairo_result = cairo_run("mul", evm)
         except Exception as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 mul(evm)
             return
 
@@ -63,7 +63,7 @@ class TestArithmetic:
         try:
             cairo_result = cairo_run("div", evm)
         except Exception as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 div(evm)
             return
 
@@ -75,7 +75,7 @@ class TestArithmetic:
         try:
             cairo_result = cairo_run("sdiv", evm)
         except Exception as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 sdiv(evm)
             return
 
@@ -87,7 +87,7 @@ class TestArithmetic:
         try:
             cairo_result = cairo_run("mod", evm)
         except Exception as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 mod(evm)
             return
 
@@ -99,7 +99,7 @@ class TestArithmetic:
         try:
             cairo_result = cairo_run("smod", evm)
         except Exception as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 smod(evm)
             return
 
@@ -111,7 +111,7 @@ class TestArithmetic:
         try:
             cairo_result = cairo_run("addmod", evm)
         except Exception as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 addmod(evm)
             return
 
@@ -123,7 +123,7 @@ class TestArithmetic:
         try:
             cairo_result = cairo_run("mulmod", evm)
         except Exception as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 mulmod(evm)
             return
 
@@ -135,7 +135,7 @@ class TestArithmetic:
         try:
             cairo_result = cairo_run("exp", evm)
         except Exception as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 exp(evm)
             return
 
@@ -147,7 +147,7 @@ class TestArithmetic:
         try:
             cairo_result = cairo_run("signextend", evm)
         except Exception as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 signextend(evm)
             return
 

--- a/cairo/tests/ethereum/cancun/vm/instructions/test_arithmetic.py
+++ b/cairo/tests/ethereum/cancun/vm/instructions/test_arithmetic.py
@@ -14,7 +14,7 @@ from ethereum.cancun.vm.instructions.arithmetic import (
     sub,
 )
 from tests.utils.args_gen import Evm
-from tests.utils.errors import assert_raises_exactly
+from tests.utils.errors import strict_raises
 from tests.utils.evm_builder import EvmBuilder
 
 arithmetic_tests_strategy = EvmBuilder().with_stack().with_gas_left().build()
@@ -26,7 +26,7 @@ class TestArithmetic:
         try:
             cairo_result = cairo_run("add", evm)
         except Exception as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 add(evm)
             return
 
@@ -38,7 +38,7 @@ class TestArithmetic:
         try:
             cairo_result = cairo_run("sub", evm)
         except Exception as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 sub(evm)
             return
 
@@ -50,7 +50,7 @@ class TestArithmetic:
         try:
             cairo_result = cairo_run("mul", evm)
         except Exception as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 mul(evm)
             return
 
@@ -63,7 +63,7 @@ class TestArithmetic:
         try:
             cairo_result = cairo_run("div", evm)
         except Exception as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 div(evm)
             return
 
@@ -75,7 +75,7 @@ class TestArithmetic:
         try:
             cairo_result = cairo_run("sdiv", evm)
         except Exception as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 sdiv(evm)
             return
 
@@ -87,7 +87,7 @@ class TestArithmetic:
         try:
             cairo_result = cairo_run("mod", evm)
         except Exception as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 mod(evm)
             return
 
@@ -99,7 +99,7 @@ class TestArithmetic:
         try:
             cairo_result = cairo_run("smod", evm)
         except Exception as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 smod(evm)
             return
 
@@ -111,7 +111,7 @@ class TestArithmetic:
         try:
             cairo_result = cairo_run("addmod", evm)
         except Exception as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 addmod(evm)
             return
 
@@ -123,7 +123,7 @@ class TestArithmetic:
         try:
             cairo_result = cairo_run("mulmod", evm)
         except Exception as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 mulmod(evm)
             return
 
@@ -135,7 +135,7 @@ class TestArithmetic:
         try:
             cairo_result = cairo_run("exp", evm)
         except Exception as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 exp(evm)
             return
 
@@ -147,7 +147,7 @@ class TestArithmetic:
         try:
             cairo_result = cairo_run("signextend", evm)
         except Exception as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 signextend(evm)
             return
 

--- a/cairo/tests/ethereum/cancun/vm/instructions/test_bitwise.py
+++ b/cairo/tests/ethereum/cancun/vm/instructions/test_bitwise.py
@@ -1,4 +1,3 @@
-import pytest
 from hypothesis import given
 
 from ethereum.cancun.vm.exceptions import ExceptionalHalt
@@ -13,6 +12,7 @@ from ethereum.cancun.vm.instructions.bitwise import (
     get_byte,
 )
 from tests.utils.args_gen import Evm
+from tests.utils.errors import assert_raises_exactly
 from tests.utils.evm_builder import EvmBuilder
 
 bitwise_tests_strategy = EvmBuilder().with_stack().with_gas_left().build()
@@ -24,7 +24,7 @@ class TestBitwise:
         try:
             cairo_result = cairo_run("bitwise_and", evm)
         except ExceptionalHalt as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 bitwise_and(evm)
             return
 
@@ -36,7 +36,7 @@ class TestBitwise:
         try:
             cairo_result = cairo_run("bitwise_or", evm)
         except ExceptionalHalt as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 bitwise_or(evm)
             return
 
@@ -48,7 +48,7 @@ class TestBitwise:
         try:
             cairo_result = cairo_run("bitwise_xor", evm)
         except ExceptionalHalt as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 bitwise_xor(evm)
             return
 
@@ -60,7 +60,7 @@ class TestBitwise:
         try:
             cairo_result = cairo_run("bitwise_not", evm)
         except ExceptionalHalt as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 bitwise_not(evm)
             return
 
@@ -72,7 +72,7 @@ class TestBitwise:
         try:
             cairo_result = cairo_run("get_byte", evm)
         except ExceptionalHalt as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 get_byte(evm)
             return
 
@@ -84,7 +84,7 @@ class TestBitwise:
         try:
             cairo_result = cairo_run("bitwise_shl", evm)
         except ExceptionalHalt as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 bitwise_shl(evm)
             return
 
@@ -96,7 +96,7 @@ class TestBitwise:
         try:
             cairo_result = cairo_run("bitwise_shr", evm)
         except ExceptionalHalt as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 bitwise_shr(evm)
             return
 
@@ -108,7 +108,7 @@ class TestBitwise:
         try:
             cairo_result = cairo_run("bitwise_sar", evm)
         except ExceptionalHalt as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 bitwise_sar(evm)
             return
 

--- a/cairo/tests/ethereum/cancun/vm/instructions/test_bitwise.py
+++ b/cairo/tests/ethereum/cancun/vm/instructions/test_bitwise.py
@@ -12,7 +12,7 @@ from ethereum.cancun.vm.instructions.bitwise import (
     get_byte,
 )
 from tests.utils.args_gen import Evm
-from tests.utils.errors import assert_raises_exactly
+from tests.utils.errors import strict_raises
 from tests.utils.evm_builder import EvmBuilder
 
 bitwise_tests_strategy = EvmBuilder().with_stack().with_gas_left().build()
@@ -24,7 +24,7 @@ class TestBitwise:
         try:
             cairo_result = cairo_run("bitwise_and", evm)
         except ExceptionalHalt as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 bitwise_and(evm)
             return
 
@@ -36,7 +36,7 @@ class TestBitwise:
         try:
             cairo_result = cairo_run("bitwise_or", evm)
         except ExceptionalHalt as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 bitwise_or(evm)
             return
 
@@ -48,7 +48,7 @@ class TestBitwise:
         try:
             cairo_result = cairo_run("bitwise_xor", evm)
         except ExceptionalHalt as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 bitwise_xor(evm)
             return
 
@@ -60,7 +60,7 @@ class TestBitwise:
         try:
             cairo_result = cairo_run("bitwise_not", evm)
         except ExceptionalHalt as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 bitwise_not(evm)
             return
 
@@ -72,7 +72,7 @@ class TestBitwise:
         try:
             cairo_result = cairo_run("get_byte", evm)
         except ExceptionalHalt as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 get_byte(evm)
             return
 
@@ -84,7 +84,7 @@ class TestBitwise:
         try:
             cairo_result = cairo_run("bitwise_shl", evm)
         except ExceptionalHalt as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 bitwise_shl(evm)
             return
 
@@ -96,7 +96,7 @@ class TestBitwise:
         try:
             cairo_result = cairo_run("bitwise_shr", evm)
         except ExceptionalHalt as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 bitwise_shr(evm)
             return
 
@@ -108,7 +108,7 @@ class TestBitwise:
         try:
             cairo_result = cairo_run("bitwise_sar", evm)
         except ExceptionalHalt as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 bitwise_sar(evm)
             return
 

--- a/cairo/tests/ethereum/cancun/vm/instructions/test_block.py
+++ b/cairo/tests/ethereum/cancun/vm/instructions/test_block.py
@@ -13,7 +13,7 @@ from ethereum.cancun.vm.instructions.block import (
     timestamp,
 )
 from tests.utils.args_gen import Environment, Evm, TransientStorage
-from tests.utils.errors import assert_raises_exactly
+from tests.utils.errors import strict_raises
 from tests.utils.evm_builder import EvmBuilder, address_zero
 from tests.utils.strategies import (
     BLOCK_HASHES_LIST,
@@ -73,7 +73,7 @@ class TestBlock:
         try:
             cairo_result = cairo_run("block_hash", evm)
         except ExceptionalHalt as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 block_hash(evm)
             return
 
@@ -85,7 +85,7 @@ class TestBlock:
         try:
             cairo_result = cairo_run("coinbase", evm)
         except ExceptionalHalt as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 coinbase(evm)
             return
 
@@ -97,7 +97,7 @@ class TestBlock:
         try:
             cairo_result = cairo_run("timestamp", evm)
         except ExceptionalHalt as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 timestamp(evm)
             return
 
@@ -109,7 +109,7 @@ class TestBlock:
         try:
             cairo_result = cairo_run("number", evm)
         except ExceptionalHalt as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 number(evm)
             return
 
@@ -121,7 +121,7 @@ class TestBlock:
         try:
             cairo_result = cairo_run("prev_randao", evm)
         except ExceptionalHalt as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 prev_randao(evm)
             return
 
@@ -133,7 +133,7 @@ class TestBlock:
         try:
             cairo_result = cairo_run("gas_limit", evm)
         except ExceptionalHalt as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 gas_limit(evm)
             return
 
@@ -145,7 +145,7 @@ class TestBlock:
         try:
             cairo_result = cairo_run("chain_id", evm)
         except ExceptionalHalt as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 chain_id(evm)
             return
 

--- a/cairo/tests/ethereum/cancun/vm/instructions/test_block.py
+++ b/cairo/tests/ethereum/cancun/vm/instructions/test_block.py
@@ -1,4 +1,3 @@
-import pytest
 from ethereum_types.numeric import U64, Uint
 from hypothesis import given
 from hypothesis import strategies as st
@@ -14,6 +13,7 @@ from ethereum.cancun.vm.instructions.block import (
     timestamp,
 )
 from tests.utils.args_gen import Environment, Evm, TransientStorage
+from tests.utils.errors import assert_raises_exactly
 from tests.utils.evm_builder import EvmBuilder, address_zero
 from tests.utils.strategies import (
     BLOCK_HASHES_LIST,
@@ -73,7 +73,7 @@ class TestBlock:
         try:
             cairo_result = cairo_run("block_hash", evm)
         except ExceptionalHalt as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 block_hash(evm)
             return
 
@@ -85,7 +85,7 @@ class TestBlock:
         try:
             cairo_result = cairo_run("coinbase", evm)
         except ExceptionalHalt as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 coinbase(evm)
             return
 
@@ -97,7 +97,7 @@ class TestBlock:
         try:
             cairo_result = cairo_run("timestamp", evm)
         except ExceptionalHalt as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 timestamp(evm)
             return
 
@@ -109,7 +109,7 @@ class TestBlock:
         try:
             cairo_result = cairo_run("number", evm)
         except ExceptionalHalt as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 number(evm)
             return
 
@@ -121,7 +121,7 @@ class TestBlock:
         try:
             cairo_result = cairo_run("prev_randao", evm)
         except ExceptionalHalt as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 prev_randao(evm)
             return
 
@@ -133,7 +133,7 @@ class TestBlock:
         try:
             cairo_result = cairo_run("gas_limit", evm)
         except ExceptionalHalt as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 gas_limit(evm)
             return
 
@@ -145,7 +145,7 @@ class TestBlock:
         try:
             cairo_result = cairo_run("chain_id", evm)
         except ExceptionalHalt as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 chain_id(evm)
             return
 

--- a/cairo/tests/ethereum/cancun/vm/instructions/test_comparison.py
+++ b/cairo/tests/ethereum/cancun/vm/instructions/test_comparison.py
@@ -1,4 +1,3 @@
-import pytest
 from hypothesis import given
 
 from ethereum.cancun.vm.exceptions import ExceptionalHalt
@@ -11,6 +10,7 @@ from ethereum.cancun.vm.instructions.comparison import (
     signed_less_than,
 )
 from tests.utils.args_gen import Evm
+from tests.utils.errors import assert_raises_exactly
 from tests.utils.evm_builder import EvmBuilder
 
 comparison_tests_strategy = EvmBuilder().with_stack().with_gas_left().build()
@@ -22,7 +22,7 @@ class TestComparison:
         try:
             cairo_result = cairo_run("less_than", evm)
         except ExceptionalHalt as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 less_than(evm)
             return
 
@@ -34,7 +34,7 @@ class TestComparison:
         try:
             cairo_result = cairo_run("greater_than", evm)
         except ExceptionalHalt as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 greater_than(evm)
             return
 
@@ -46,7 +46,7 @@ class TestComparison:
         try:
             cairo_result = cairo_run("signed_less_than", evm)
         except ExceptionalHalt as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 signed_less_than(evm)
             return
 
@@ -58,7 +58,7 @@ class TestComparison:
         try:
             cairo_result = cairo_run("signed_greater_than", evm)
         except ExceptionalHalt as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 signed_greater_than(evm)
             return
 
@@ -70,7 +70,7 @@ class TestComparison:
         try:
             cairo_result = cairo_run("equal", evm)
         except ExceptionalHalt as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 equal(evm)
             return
 
@@ -82,7 +82,7 @@ class TestComparison:
         try:
             cairo_result = cairo_run("is_zero", evm)
         except ExceptionalHalt as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 is_zero(evm)
             return
 

--- a/cairo/tests/ethereum/cancun/vm/instructions/test_comparison.py
+++ b/cairo/tests/ethereum/cancun/vm/instructions/test_comparison.py
@@ -10,7 +10,7 @@ from ethereum.cancun.vm.instructions.comparison import (
     signed_less_than,
 )
 from tests.utils.args_gen import Evm
-from tests.utils.errors import assert_raises_exactly
+from tests.utils.errors import strict_raises
 from tests.utils.evm_builder import EvmBuilder
 
 comparison_tests_strategy = EvmBuilder().with_stack().with_gas_left().build()
@@ -22,7 +22,7 @@ class TestComparison:
         try:
             cairo_result = cairo_run("less_than", evm)
         except ExceptionalHalt as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 less_than(evm)
             return
 
@@ -34,7 +34,7 @@ class TestComparison:
         try:
             cairo_result = cairo_run("greater_than", evm)
         except ExceptionalHalt as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 greater_than(evm)
             return
 
@@ -46,7 +46,7 @@ class TestComparison:
         try:
             cairo_result = cairo_run("signed_less_than", evm)
         except ExceptionalHalt as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 signed_less_than(evm)
             return
 
@@ -58,7 +58,7 @@ class TestComparison:
         try:
             cairo_result = cairo_run("signed_greater_than", evm)
         except ExceptionalHalt as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 signed_greater_than(evm)
             return
 
@@ -70,7 +70,7 @@ class TestComparison:
         try:
             cairo_result = cairo_run("equal", evm)
         except ExceptionalHalt as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 equal(evm)
             return
 
@@ -82,7 +82,7 @@ class TestComparison:
         try:
             cairo_result = cairo_run("is_zero", evm)
         except ExceptionalHalt as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 is_zero(evm)
             return
 

--- a/cairo/tests/ethereum/cancun/vm/instructions/test_control_flow.py
+++ b/cairo/tests/ethereum/cancun/vm/instructions/test_control_flow.py
@@ -12,7 +12,7 @@ from ethereum.cancun.vm.instructions.control_flow import (
 )
 from ethereum.cancun.vm.stack import push
 from tests.utils.args_gen import Evm
-from tests.utils.errors import assert_raises_exactly
+from tests.utils.errors import strict_raises
 from tests.utils.evm_builder import EvmBuilder
 
 
@@ -22,7 +22,7 @@ class TestControlFlow:
         try:
             cairo_result = cairo_run("stop", evm)
         except ExceptionalHalt as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 stop(evm)
             return
 
@@ -49,7 +49,7 @@ class TestControlFlow:
         try:
             cairo_result = cairo_run("jump", evm)
         except ExceptionalHalt as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 jump(evm)
             return
 
@@ -84,7 +84,7 @@ class TestControlFlow:
         try:
             cairo_result = cairo_run("jumpi", evm)
         except ExceptionalHalt as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 jumpi(evm)
             return
 
@@ -96,7 +96,7 @@ class TestControlFlow:
         try:
             cairo_result = cairo_run("pc", evm)
         except ExceptionalHalt as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 pc(evm)
             return
 
@@ -108,7 +108,7 @@ class TestControlFlow:
         try:
             cairo_result = cairo_run("gas_left", evm)
         except ExceptionalHalt as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 gas_left(evm)
             return
 
@@ -120,7 +120,7 @@ class TestControlFlow:
         try:
             cairo_result = cairo_run("jumpdest", evm)
         except ExceptionalHalt as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 jumpdest(evm)
             return
 

--- a/cairo/tests/ethereum/cancun/vm/instructions/test_control_flow.py
+++ b/cairo/tests/ethereum/cancun/vm/instructions/test_control_flow.py
@@ -1,4 +1,3 @@
-import pytest
 from ethereum_types.numeric import U256
 from hypothesis import given
 
@@ -13,6 +12,7 @@ from ethereum.cancun.vm.instructions.control_flow import (
 )
 from ethereum.cancun.vm.stack import push
 from tests.utils.args_gen import Evm
+from tests.utils.errors import assert_raises_exactly
 from tests.utils.evm_builder import EvmBuilder
 
 
@@ -22,7 +22,7 @@ class TestControlFlow:
         try:
             cairo_result = cairo_run("stop", evm)
         except ExceptionalHalt as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 stop(evm)
             return
 
@@ -49,7 +49,7 @@ class TestControlFlow:
         try:
             cairo_result = cairo_run("jump", evm)
         except ExceptionalHalt as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 jump(evm)
             return
 
@@ -84,7 +84,7 @@ class TestControlFlow:
         try:
             cairo_result = cairo_run("jumpi", evm)
         except ExceptionalHalt as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 jumpi(evm)
             return
 
@@ -96,7 +96,7 @@ class TestControlFlow:
         try:
             cairo_result = cairo_run("pc", evm)
         except ExceptionalHalt as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 pc(evm)
             return
 
@@ -108,7 +108,7 @@ class TestControlFlow:
         try:
             cairo_result = cairo_run("gas_left", evm)
         except ExceptionalHalt as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 gas_left(evm)
             return
 
@@ -120,7 +120,7 @@ class TestControlFlow:
         try:
             cairo_result = cairo_run("jumpdest", evm)
         except ExceptionalHalt as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 jumpdest(evm)
             return
 

--- a/cairo/tests/ethereum/cancun/vm/instructions/test_keccak.py
+++ b/cairo/tests/ethereum/cancun/vm/instructions/test_keccak.py
@@ -1,4 +1,3 @@
-import pytest
 from ethereum_types.numeric import U256
 from hypothesis import given
 
@@ -6,6 +5,7 @@ from ethereum.cancun.vm.exceptions import ExceptionalHalt
 from ethereum.cancun.vm.instructions.keccak import keccak
 from ethereum.cancun.vm.stack import push
 from tests.utils.args_gen import Evm
+from tests.utils.errors import assert_raises_exactly
 from tests.utils.evm_builder import EvmBuilder
 from tests.utils.strategies import memory_lite_access_size, memory_lite_start_position
 
@@ -25,7 +25,7 @@ class TestKeccak:
         try:
             cairo_result = cairo_run("keccak", evm)
         except ExceptionalHalt as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 keccak(evm)
             return
 

--- a/cairo/tests/ethereum/cancun/vm/instructions/test_keccak.py
+++ b/cairo/tests/ethereum/cancun/vm/instructions/test_keccak.py
@@ -5,7 +5,7 @@ from ethereum.cancun.vm.exceptions import ExceptionalHalt
 from ethereum.cancun.vm.instructions.keccak import keccak
 from ethereum.cancun.vm.stack import push
 from tests.utils.args_gen import Evm
-from tests.utils.errors import assert_raises_exactly
+from tests.utils.errors import strict_raises
 from tests.utils.evm_builder import EvmBuilder
 from tests.utils.strategies import memory_lite_access_size, memory_lite_start_position
 
@@ -25,7 +25,7 @@ class TestKeccak:
         try:
             cairo_result = cairo_run("keccak", evm)
         except ExceptionalHalt as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 keccak(evm)
             return
 

--- a/cairo/tests/ethereum/cancun/vm/instructions/test_log.py
+++ b/cairo/tests/ethereum/cancun/vm/instructions/test_log.py
@@ -5,7 +5,7 @@ from ethereum.cancun.vm.exceptions import ExceptionalHalt
 from ethereum.cancun.vm.instructions.log import log0, log1, log2, log3, log4
 from ethereum.cancun.vm.stack import push
 from tests.utils.args_gen import Evm
-from tests.utils.errors import assert_raises_exactly
+from tests.utils.errors import strict_raises
 from tests.utils.evm_builder import EvmBuilder
 from tests.utils.strategies import memory_lite_access_size, memory_lite_start_position
 
@@ -24,7 +24,7 @@ class TestLog:
         try:
             cairo_result = cairo_run("log0", evm)
         except ExceptionalHalt as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 log0(evm)
             return
 
@@ -46,7 +46,7 @@ class TestLog:
         try:
             cairo_result = cairo_run("log1", evm)
         except ExceptionalHalt as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 log1(evm)
             return
 
@@ -76,7 +76,7 @@ class TestLog:
         try:
             cairo_result = cairo_run("log2", evm)
         except ExceptionalHalt as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 log2(evm)
             return
 
@@ -109,7 +109,7 @@ class TestLog:
         try:
             cairo_result = cairo_run("log3", evm)
         except ExceptionalHalt as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 log3(evm)
             return
 
@@ -145,7 +145,7 @@ class TestLog:
         try:
             cairo_result = cairo_run("log4", evm)
         except ExceptionalHalt as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 log4(evm)
             return
 

--- a/cairo/tests/ethereum/cancun/vm/instructions/test_log.py
+++ b/cairo/tests/ethereum/cancun/vm/instructions/test_log.py
@@ -1,4 +1,3 @@
-import pytest
 from ethereum_types.numeric import U256
 from hypothesis import given
 
@@ -6,6 +5,7 @@ from ethereum.cancun.vm.exceptions import ExceptionalHalt
 from ethereum.cancun.vm.instructions.log import log0, log1, log2, log3, log4
 from ethereum.cancun.vm.stack import push
 from tests.utils.args_gen import Evm
+from tests.utils.errors import assert_raises_exactly
 from tests.utils.evm_builder import EvmBuilder
 from tests.utils.strategies import memory_lite_access_size, memory_lite_start_position
 
@@ -24,7 +24,7 @@ class TestLog:
         try:
             cairo_result = cairo_run("log0", evm)
         except ExceptionalHalt as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 log0(evm)
             return
 
@@ -46,7 +46,7 @@ class TestLog:
         try:
             cairo_result = cairo_run("log1", evm)
         except ExceptionalHalt as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 log1(evm)
             return
 
@@ -76,7 +76,7 @@ class TestLog:
         try:
             cairo_result = cairo_run("log2", evm)
         except ExceptionalHalt as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 log2(evm)
             return
 
@@ -109,7 +109,7 @@ class TestLog:
         try:
             cairo_result = cairo_run("log3", evm)
         except ExceptionalHalt as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 log3(evm)
             return
 
@@ -145,7 +145,7 @@ class TestLog:
         try:
             cairo_result = cairo_run("log4", evm)
         except ExceptionalHalt as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 log4(evm)
             return
 

--- a/cairo/tests/ethereum/cancun/vm/instructions/test_memory_instructions.py
+++ b/cairo/tests/ethereum/cancun/vm/instructions/test_memory_instructions.py
@@ -1,4 +1,3 @@
-import pytest
 from ethereum_types.numeric import U256
 from hypothesis import given
 
@@ -6,6 +5,7 @@ from ethereum.cancun.vm.exceptions import ExceptionalHalt
 from ethereum.cancun.vm.instructions.memory import mcopy, mload, msize, mstore, mstore8
 from ethereum.cancun.vm.stack import push
 from tests.utils.args_gen import Evm
+from tests.utils.errors import assert_raises_exactly
 from tests.utils.evm_builder import EvmBuilder
 from tests.utils.strategies import (
     memory_lite_access_size,
@@ -32,7 +32,7 @@ class TestMemory:
         try:
             cairo_result = cairo_run("mstore", evm)
         except ExceptionalHalt as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 mstore(evm)
             return
 
@@ -55,7 +55,7 @@ class TestMemory:
         try:
             cairo_result = cairo_run("mstore8", evm)
         except ExceptionalHalt as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 mstore8(evm)
             return
 
@@ -76,7 +76,7 @@ class TestMemory:
         try:
             cairo_result = cairo_run("mload", evm)
         except ExceptionalHalt as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 mload(evm)
             return
 
@@ -88,7 +88,7 @@ class TestMemory:
         try:
             cairo_result = cairo_run("msize", evm)
         except ExceptionalHalt as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 msize(evm)
             return
 
@@ -118,7 +118,7 @@ class TestMemory:
         try:
             cairo_result = cairo_run("mcopy", evm)
         except ExceptionalHalt as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 mcopy(evm)
             return
 

--- a/cairo/tests/ethereum/cancun/vm/instructions/test_memory_instructions.py
+++ b/cairo/tests/ethereum/cancun/vm/instructions/test_memory_instructions.py
@@ -5,7 +5,7 @@ from ethereum.cancun.vm.exceptions import ExceptionalHalt
 from ethereum.cancun.vm.instructions.memory import mcopy, mload, msize, mstore, mstore8
 from ethereum.cancun.vm.stack import push
 from tests.utils.args_gen import Evm
-from tests.utils.errors import assert_raises_exactly
+from tests.utils.errors import strict_raises
 from tests.utils.evm_builder import EvmBuilder
 from tests.utils.strategies import (
     memory_lite_access_size,
@@ -32,7 +32,7 @@ class TestMemory:
         try:
             cairo_result = cairo_run("mstore", evm)
         except ExceptionalHalt as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 mstore(evm)
             return
 
@@ -55,7 +55,7 @@ class TestMemory:
         try:
             cairo_result = cairo_run("mstore8", evm)
         except ExceptionalHalt as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 mstore8(evm)
             return
 
@@ -76,7 +76,7 @@ class TestMemory:
         try:
             cairo_result = cairo_run("mload", evm)
         except ExceptionalHalt as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 mload(evm)
             return
 
@@ -88,7 +88,7 @@ class TestMemory:
         try:
             cairo_result = cairo_run("msize", evm)
         except ExceptionalHalt as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 msize(evm)
             return
 
@@ -118,7 +118,7 @@ class TestMemory:
         try:
             cairo_result = cairo_run("mcopy", evm)
         except ExceptionalHalt as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 mcopy(evm)
             return
 

--- a/cairo/tests/ethereum/cancun/vm/instructions/test_stack_instructions.py
+++ b/cairo/tests/ethereum/cancun/vm/instructions/test_stack_instructions.py
@@ -4,7 +4,7 @@ from hypothesis import given
 import ethereum.cancun.vm.instructions.stack as stack
 from ethereum.cancun.vm.exceptions import ExceptionalHalt
 from tests.utils.args_gen import Evm
-from tests.utils.errors import assert_raises_exactly
+from tests.utils.errors import strict_raises
 from tests.utils.evm_builder import EvmBuilder
 
 
@@ -17,7 +17,7 @@ class TestPushN:
         try:
             cairo_result = cairo_run(func_name, evm)
         except ExceptionalHalt as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 push_i(evm)
             return
 
@@ -34,7 +34,7 @@ class TestSwapN:
         try:
             cairo_result = cairo_run(func_name, evm)
         except ExceptionalHalt as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 swap_i(evm)
             return
 
@@ -51,7 +51,7 @@ class TestDupN:
         try:
             cairo_result = cairo_run(func_name, evm)
         except ExceptionalHalt as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 dup_i(evm)
             return
         dup_i(evm)

--- a/cairo/tests/ethereum/cancun/vm/instructions/test_stack_instructions.py
+++ b/cairo/tests/ethereum/cancun/vm/instructions/test_stack_instructions.py
@@ -4,6 +4,7 @@ from hypothesis import given
 import ethereum.cancun.vm.instructions.stack as stack
 from ethereum.cancun.vm.exceptions import ExceptionalHalt
 from tests.utils.args_gen import Evm
+from tests.utils.errors import assert_raises_exactly
 from tests.utils.evm_builder import EvmBuilder
 
 
@@ -16,7 +17,7 @@ class TestPushN:
         try:
             cairo_result = cairo_run(func_name, evm)
         except ExceptionalHalt as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 push_i(evm)
             return
 
@@ -33,7 +34,7 @@ class TestSwapN:
         try:
             cairo_result = cairo_run(func_name, evm)
         except ExceptionalHalt as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 swap_i(evm)
             return
 
@@ -50,7 +51,7 @@ class TestDupN:
         try:
             cairo_result = cairo_run(func_name, evm)
         except ExceptionalHalt as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 dup_i(evm)
             return
         dup_i(evm)

--- a/cairo/tests/ethereum/cancun/vm/instructions/test_storage.py
+++ b/cairo/tests/ethereum/cancun/vm/instructions/test_storage.py
@@ -8,7 +8,7 @@ from hypothesis.strategies import composite
 
 from ethereum.cancun.vm.instructions.storage import sload, tload, tstore
 from tests.utils.args_gen import Evm
-from tests.utils.errors import assert_raises_exactly
+from tests.utils.errors import strict_raises
 from tests.utils.evm_builder import EvmBuilder
 from tests.utils.strategies import MAX_STORAGE_KEY_SET_SIZE
 
@@ -38,7 +38,7 @@ class TestStorage:
         try:
             cairo_evm = cairo_run("sload", evm)
         except Exception as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 sload(evm)
             return
 
@@ -50,7 +50,7 @@ class TestStorage:
         try:
             cairo_evm = cairo_run("tload", evm)
         except Exception as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 tload(evm)
             return
 
@@ -62,7 +62,7 @@ class TestStorage:
         try:
             cairo_evm = cairo_run("tstore", evm)
         except Exception as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 tstore(evm)
             return
         tstore(evm)

--- a/cairo/tests/ethereum/cancun/vm/instructions/test_storage.py
+++ b/cairo/tests/ethereum/cancun/vm/instructions/test_storage.py
@@ -1,6 +1,5 @@
 from typing import Tuple
 
-import pytest
 from ethereum_types.bytes import Bytes20, Bytes32
 from ethereum_types.numeric import U256
 from hypothesis import given
@@ -9,6 +8,7 @@ from hypothesis.strategies import composite
 
 from ethereum.cancun.vm.instructions.storage import sload, tload, tstore
 from tests.utils.args_gen import Evm
+from tests.utils.errors import assert_raises_exactly
 from tests.utils.evm_builder import EvmBuilder
 from tests.utils.strategies import MAX_STORAGE_KEY_SET_SIZE
 
@@ -38,7 +38,7 @@ class TestStorage:
         try:
             cairo_evm = cairo_run("sload", evm)
         except Exception as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 sload(evm)
             return
 
@@ -50,7 +50,7 @@ class TestStorage:
         try:
             cairo_evm = cairo_run("tload", evm)
         except Exception as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 tload(evm)
             return
 
@@ -62,7 +62,7 @@ class TestStorage:
         try:
             cairo_evm = cairo_run("tstore", evm)
         except Exception as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 tstore(evm)
             return
         tstore(evm)

--- a/cairo/tests/ethereum/cancun/vm/test_gas.py
+++ b/cairo/tests/ethereum/cancun/vm/test_gas.py
@@ -22,7 +22,7 @@ from ethereum.cancun.vm.gas import (
     max_message_call_gas,
 )
 from tests.utils.args_gen import Evm, Memory
-from tests.utils.errors import assert_raises_exactly
+from tests.utils.errors import strict_raises
 from tests.utils.evm_builder import EvmBuilder
 
 
@@ -40,7 +40,7 @@ class TestGas:
         try:
             cairo_result = cairo_run("charge_gas", evm, amount)
         except Exception as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 charge_gas(evm, amount)
             return
 
@@ -61,7 +61,7 @@ class TestGas:
         try:
             cairo_result = cairo_run("calculate_gas_extend_memory", memory, extensions)
         except ExceptionalHalt as cairo_error:
-            with assert_raises_exactly(type(cairo_error)):
+            with strict_raises(type(cairo_error)):
                 calculate_gas_extend_memory(memory, extensions)
             return
 

--- a/cairo/tests/ethereum/cancun/vm/test_gas.py
+++ b/cairo/tests/ethereum/cancun/vm/test_gas.py
@@ -1,6 +1,5 @@
 from typing import List, Tuple
 
-import pytest
 from ethereum_types.numeric import U256, Uint
 from hypothesis import assume, given
 from hypothesis import strategies as st
@@ -23,6 +22,7 @@ from ethereum.cancun.vm.gas import (
     max_message_call_gas,
 )
 from tests.utils.args_gen import Evm, Memory
+from tests.utils.errors import assert_raises_exactly
 from tests.utils.evm_builder import EvmBuilder
 
 
@@ -40,7 +40,7 @@ class TestGas:
         try:
             cairo_result = cairo_run("charge_gas", evm, amount)
         except Exception as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 charge_gas(evm, amount)
             return
 
@@ -61,7 +61,7 @@ class TestGas:
         try:
             cairo_result = cairo_run("calculate_gas_extend_memory", memory, extensions)
         except ExceptionalHalt as cairo_error:
-            with pytest.raises(type(cairo_error)):
+            with assert_raises_exactly(type(cairo_error)):
                 calculate_gas_extend_memory(memory, extensions)
             return
 

--- a/cairo/tests/utils/errors.py
+++ b/cairo/tests/utils/errors.py
@@ -1,5 +1,6 @@
 import re
 from contextlib import contextmanager
+from typing import Type
 
 import pytest
 
@@ -16,3 +17,35 @@ def cairo_error(message=None):
         assert message in error, f"Expected {message}, got {error}"
     finally:
         pass
+
+
+@contextmanager
+def assert_raises_exactly(expected_exception: Type[Exception], msg: str = None):
+    """
+    Context manager that verifies an exception of exactly the specified type is raised.
+    Unlike pytest.raises, this doesn't allow subclass exceptions to match.
+
+    Args:
+        expected_exception: The exact exception type expected
+        msg: Optional message to include in assertion error
+
+    Example:
+        with assert_raises_exactly(AssertionError):
+            raise AssertionError()  # passes
+
+        with assert_raises_exactly(Exception):
+            raise AssertionError()  # fails - more specific exception
+    """
+    try:
+        yield
+    except Exception as e:
+        if type(e) is not expected_exception:
+            raise AssertionError(
+                msg
+                or f"Expected exactly {expected_exception.__name__}, but got {type(e).__name__}"
+            )
+    else:
+        raise AssertionError(
+            msg
+            or f"Expected {expected_exception.__name__} to be raised, but no exception was raised"
+        )


### PR DESCRIPTION
Closes #438
use a special contextmanager that asserts the error raised is EXACTLY of the expected type.