### PR TITLE
dev: remove useless assertion on stack depth in process_message

### DIFF
--- a/cairo/tests/ethereum/cancun/vm/test_interpreter.py
+++ b/cairo/tests/ethereum/cancun/vm/test_interpreter.py
@@ -25,6 +25,7 @@ message_without_precompile = (
     .with_value()
     .with_data()
     .with_code_address()
+    .with_depth()
     .with_code(
         strategy=st.just(Bytes(bytes.fromhex("6060")))
     )  # TODO: generate code with random opcodes

--- a/cairo/tests/utils/message_builder.py
+++ b/cairo/tests/utils/message_builder.py
@@ -10,7 +10,6 @@ from tests.utils.strategies import (
     code,
     gas_left,
     small_bytes,
-    uint,
 )
 
 
@@ -64,7 +63,10 @@ class MessageBuilder:
         self._code = strategy
         return self
 
-    def with_depth(self, strategy=uint):
+    # Restricted to 0-1023 because EELS has an extra, unrequired check on the stack depth
+    # in `process_message` which cannot trigger, because `generic_call` and `generic_create`
+    # check the stack depth limit before calling `process_message`.
+    def with_depth(self, strategy=st.integers(min_value=0, max_value=1023).map(Uint)):
         self._depth = strategy
         return self
 


### PR DESCRIPTION
see:

> edit: actually BEFORE calling process_message_create we ensure that the message depth is < STACK_DEPTH_LIMIT, so you can disregard my message. I think the following case is just never triggered and the assertion is never triggered

> I also have an unresolved question about what happens when doing a CREATE opcode that hits the message stack limit:

> Let's say i'm executing a simple CREATE opcode, starting from process_message

> `process_message(begin_transaction:1) -> execute_code -> CREATE -> generic_create -> process_create_message (begin_transaction: 2) -> process_message❌ fails because stack too deep

> This error is caught in the execute_code, which fills the evm.error, then returns to process_message in which we rollback_transaction, which brings our amount of snapshots back to 1 and not zero