### PR TITLE
fix: fix incorrect field name in HeaderStruct in blocks.cairo

### DIFF
--- a/cairo/ethereum/cancun/blocks.cairo
+++ b/cairo/ethereum/cancun/blocks.cairo
@@ -29,7 +29,7 @@ struct HeaderStruct {
     coinbase: Address,
     state_root: Root,
     transactions_root: Root,
-    receipt_root: Root,
+    receipts_root: Root,
     bloom: Bloom,
     difficulty: Uint,
     number: Uint,


### PR DESCRIPTION
I noticed that the field `receipt_root` in `HeaderStruct` is incorrect.
The proper name should be `receipts_root` (with an "s" at the end).
