### PR TITLE
fix: mutable object strategy generation

### DIFF
--- a/cairo/tests/ethereum/cancun/vm/instructions/test_environment.py
+++ b/cairo/tests/ethereum/cancun/vm/instructions/test_environment.py
@@ -45,7 +45,7 @@ from tests.utils.strategies import (
 environment_empty_state = st.builds(
     Environment,
     caller=...,
-    block_hashes=st.just([]),
+    block_hashes=st.builds(list, st.just([])),
     origin=...,
     coinbase=...,
     number=...,

--- a/cairo/tests/utils/evm_builder.py
+++ b/cairo/tests/utils/evm_builder.py
@@ -29,7 +29,7 @@ from tests.utils.strategies import (
 empty_environment = st.builds(
     Environment,
     caller=st.just(address_zero),
-    block_hashes=st.just([]),
+    block_hashes=st.builds(list, st.just([])),
     origin=st.just(address_zero),
     coinbase=st.just(address_zero),
     number=st.just(Uint(0)),
@@ -51,23 +51,23 @@ class EvmBuilder:
 
     def __init__(self):
         self._pc = st.just(Uint(0))
-        self._stack = st.just([])
+        self._stack = st.builds(list, st.just([]))
         self._memory = st.just(Memory(b""))
         self._code = st.just(b"")
         self._gas_left = st.just(Uint(0))
         self._env = empty_environment
-        self._valid_jump_destinations = st.just(set())
+        self._valid_jump_destinations = st.builds(set, st.just(set()))
         self._logs = st.just(())
         self._refund_counter = st.just(0)
         self._running = st.just(True)
         self._message = MessageBuilder().build()  # empty message
         self._output = st.just(b"")
-        self._accounts_to_delete = st.just(set())
-        self._touched_accounts = st.just(set())
+        self._accounts_to_delete = st.builds(set, st.just(set()))
+        self._touched_accounts = st.builds(set, st.just(set()))
         self._return_data = st.just(b"")
         self._error = st.none() | st.from_type(EthereumException)
-        self._accessed_addresses = st.just(set())
-        self._accessed_storage_keys = st.just(set())
+        self._accessed_addresses = st.builds(set, st.just(set()))
+        self._accessed_storage_keys = st.builds(set, st.just(set()))
 
     def with_pc(self, strategy=uint):
         self._pc = strategy


### PR DESCRIPTION
We had an issue in the way we were generating strategies. 
Closes #581 
> 
> ## Description
> When using Hypothesis with nested dataclasses containing mutable objects (like dictionaries), mutations to these objects can persist between test runs, leading to unexpected state and potential test failures.
> 
> ## Minimal Reproducible Example
> 
> ```
> from hypothesis import strategies as st
> @dataclass
> class InnerDicts:
>     field0: Dict[int, int]
>     field1: Dict[int, Dict[bytes, bytes]]
> 
> empty_inner_dicts = st.builds(InnerDicts, field0=st.just({}), field1=st.just({}))
> 
> @dataclass
> class OuterClass:
>     state: InnerDicts
>     field1: int
>     field2: int
> 
> outer_class_strategy = st.builds(OuterClass, state=empty_inner_dicts, field1=st.integers(), field2=st.integers())
> 
> @given(outer_class=outer_class_strategy)
> def test_mre_outer_class(outer_class: OuterClass):
>     assert outer_class.state.field0 == {}
>     assert outer_class.state.field1 == {}
>     mutate_state(outer_class)
> 
> 
> def mutate_state(outer_class: OuterClass):
>     random_key = random.randint(0, 1000000)
>     random_value = random.randint(0, 1000000)
>     outer_class.state.field0[random_key] = random_value
>     random_bytes = random.randbytes(10)
>     outer_class.state.field1[random_key] = {random_bytes: random_bytes}
> 
> ```
> 
> 
> ## Expected Behavior
> Each test run should start with empty dictionaries (`field0` and `field1`), as specified in the strategy.
> 
> ## Actual Behavior
> The dictionaries retain mutations from previous test runs. This happens because Hypothesis is reusing the same dictionary objects between test runs rather than creating fresh instances.
> 

> ## Root Cause
> Hypothesis's `st.just()` strategy returns the same object reference each time. When used with mutable objects like dictionaries, this means all test runs share the same underlying object. Any mutations to this object persist across test runs.
> 
> ## Solutions
> 1. Use `st.builds()` with `st.dictionaries()` instead of `st.just({})` to get fresh dictionaries each time