### PR TITLE
feat: validate_transaction

### DIFF
--- a/cairo/ethereum/cancun/transactions.cairo
+++ b/cairo/ethereum/cancun/transactions.cairo
@@ -1,122 +1,162 @@
-from ethereum_types.bytes import BytesStruct, Bytes, Bytes0, TupleBytes32
-from ethereum_types.numeric import Uint, U256, U64
-from ethereum.cancun.fork_types import Address, TupleVersionedHash
+from starkware.cairo.common.math_cmp import is_le_felt, is_not_zero
+from starkware.cairo.common.bool import FALSE, TRUE
 
-const TX_BASE_COST = 21000;
-const TX_DATA_COST_PER_NON_ZERO = 16;
-const TX_DATA_COST_PER_ZERO = 4;
-const TX_CREATE_COST = 32000;
-const TX_ACCESS_LIST_ADDRESS_COST = 2400;
-const TX_ACCESS_LIST_STORAGE_KEY_COST = 1900;
+from ethereum_types.bytes import Bytes, Bytes0
+from ethereum_types.numeric import Uint, bool, U256, U256Struct
+from ethereum.cancun.fork_types import Address
+from ethereum.cancun.vm.gas import init_code_cost
+from ethereum.cancun.transactions_types import (
+    Transaction,
+    To,
+    ToStruct,
+    TupleAccessListStruct,
+    TX_BASE_COST,
+    TX_DATA_COST_PER_NON_ZERO,
+    TX_DATA_COST_PER_ZERO,
+    TX_CREATE_COST,
+    TX_ACCESS_LIST_ADDRESS_COST,
+    TX_ACCESS_LIST_STORAGE_KEY_COST,
+)
+from ethereum.cancun.utils.constants import MAX_CODE_SIZE
+from ethereum.utils.numeric import U256_le
+from src.utils.array import count_not_zero
 
-struct ToStruct {
-    bytes0: Bytes0*,
-    address: Address*,
+func calculate_intrinsic_cost{range_check_ptr}(tx: Transaction) -> Uint {
+    alloc_locals;
+
+    if (tx.value.legacy_transaction.value != 0) {
+        let legacy_tx = tx.value.legacy_transaction;
+        let cost_data_and_create = _calculate_data_and_create_cost(
+            legacy_tx.value.data, legacy_tx.value.to
+        );
+        let cost = Uint(TX_BASE_COST + cost_data_and_create);
+        return cost;
+    }
+
+    if (tx.value.access_list_transaction.value != 0) {
+        let access_list_tx = tx.value.access_list_transaction;
+        let cost_data_and_create = _calculate_data_and_create_cost(
+            access_list_tx.value.data, access_list_tx.value.to
+        );
+        let cost_access_list = _calculate_access_list_cost(
+            [access_list_tx.value.access_list.value]
+        );
+        let cost = Uint(TX_BASE_COST + cost_data_and_create + cost_access_list);
+        return cost;
+    }
+
+    if (tx.value.fee_market_transaction.value != 0) {
+        let fee_market_tx = tx.value.fee_market_transaction;
+        let cost_data_and_create = _calculate_data_and_create_cost(
+            fee_market_tx.value.data, fee_market_tx.value.to
+        );
+        let cost_access_list = _calculate_access_list_cost([fee_market_tx.value.access_list.value]);
+        let cost = Uint(TX_BASE_COST + cost_data_and_create + cost_access_list);
+        return cost;
+    }
+
+    if (tx.value.blob_transaction.value != 0) {
+        let blob_tx = tx.value.blob_transaction;
+        tempvar to = new ToStruct(bytes0=cast(0, Bytes0*), address=&blob_tx.value.to);
+        let cost_data_and_create = _calculate_data_and_create_cost(blob_tx.value.data, To(to));
+        let cost_access_list = _calculate_access_list_cost([blob_tx.value.access_list.value]);
+        let cost = Uint(TX_BASE_COST + cost_data_and_create + cost_access_list);
+        return cost;
+    }
+
+    with_attr error_message("InvalidTransaction") {
+        assert 0 = 1;
+    }
+
+    let cost = Uint(0);
+    return cost;
 }
 
-struct To {
-    value: ToStruct*,
+func _calculate_data_and_create_cost{range_check_ptr}(data: Bytes, to: To) -> felt {
+    alloc_locals;
+    let count = count_not_zero(data.value.len, data.value.data);
+    let zeroes = data.value.len - count;
+    let data_cost = zeroes * TX_DATA_COST_PER_ZERO + count * TX_DATA_COST_PER_NON_ZERO;
+
+    if (cast(to.value.address, felt) != 0) {
+        return data_cost;
+    }
+
+    let cost = init_code_cost(Uint(data.value.len));
+    return data_cost + TX_CREATE_COST + cost.value;
 }
 
-struct LegacyTransactionStruct {
-    nonce: U256,
-    gas_price: Uint,
-    gas: Uint,
-    to: To,
-    value: U256,
-    data: Bytes,
-    v: U256,
-    r: U256,
-    s: U256,
+func _calculate_access_list_cost{range_check_ptr}(access_list: TupleAccessListStruct) -> felt {
+    alloc_locals;
+    if (access_list.len == 0) {
+        return 0;
+    }
+
+    let current_list = access_list.data[access_list.len - 1];
+    let current_cost = TX_ACCESS_LIST_ADDRESS_COST + current_list.value.storage_keys.value.len *
+        TX_ACCESS_LIST_STORAGE_KEY_COST;
+    let access_list = TupleAccessListStruct(data=access_list.data, len=access_list.len - 1);
+    let cum_gas_cost = _calculate_access_list_cost(access_list);
+    let cost = current_cost + cum_gas_cost;
+    return cost;
 }
 
-struct LegacyTransaction {
-    value: LegacyTransactionStruct*,
-}
+func validate_transaction{range_check_ptr}(tx: Transaction) -> bool {
+    alloc_locals;
 
-struct AccessListStruct {
-    address: Address,
-    storage_keys: TupleBytes32,
-}
+    local tx_gas: Uint;
+    local tx_nonce: U256;
+    local tx_data: Bytes;
+    local tx_to_ptr: Address*;
 
-struct AccessList {
-    value: AccessListStruct*,
-}
+    if (tx.value.legacy_transaction.value != 0) {
+        assert tx_gas = tx.value.legacy_transaction.value.gas;
+        assert tx_nonce = tx.value.legacy_transaction.value.nonce;
+        assert tx_data = tx.value.legacy_transaction.value.data;
+        assert tx_to_ptr = tx.value.legacy_transaction.value.to.value.address;
+    }
 
-struct TupleAccessListStruct {
-    data: AccessList*,
-    len: felt,
-}
+    if (tx.value.access_list_transaction.value != 0) {
+        assert tx_gas = tx.value.access_list_transaction.value.gas;
+        assert tx_nonce = tx.value.access_list_transaction.value.nonce;
+        assert tx_data = tx.value.access_list_transaction.value.data;
+        assert tx_to_ptr = tx.value.access_list_transaction.value.to.value.address;
+    }
 
-struct TupleAccessList {
-    value: TupleAccessListStruct*,
-}
+    if (tx.value.fee_market_transaction.value != 0) {
+        assert tx_gas = tx.value.fee_market_transaction.value.gas;
+        assert tx_nonce = tx.value.fee_market_transaction.value.nonce;
+        assert tx_data = tx.value.fee_market_transaction.value.data;
+        assert tx_to_ptr = tx.value.fee_market_transaction.value.to.value.address;
+    }
 
-struct AccessListTransactionStruct {
-    chain_id: U64,
-    nonce: U256,
-    gas_price: Uint,
-    gas: Uint,
-    to: To,
-    value: U256,
-    data: Bytes,
-    access_list: TupleAccessList,
-    y_parity: U256,
-    r: U256,
-    s: U256,
-}
+    if (tx.value.blob_transaction.value != 0) {
+        assert tx_gas = tx.value.blob_transaction.value.gas;
+        assert tx_nonce = tx.value.blob_transaction.value.nonce;
+        assert tx_data = tx.value.blob_transaction.value.data;
+        assert tx_to_ptr = &tx.value.blob_transaction.value.to;
+    }
 
-struct AccessListTransaction {
-    value: AccessListTransactionStruct*,
-}
+    let intrinsic_cost = calculate_intrinsic_cost(tx);
+    let is_gas_insufficient = is_le_felt(tx_gas.value, intrinsic_cost.value - 1);
+    if (is_gas_insufficient != FALSE) {
+        tempvar res = bool(FALSE);
+        return res;
+    }
 
-struct FeeMarketTransactionStruct {
-    chain_id: U64,
-    nonce: U256,
-    max_priority_fee_per_gas: Uint,
-    max_fee_per_gas: Uint,
-    gas: Uint,
-    to: To,
-    value: U256,
-    data: Bytes,
-    access_list: TupleAccessList,
-    y_parity: U256,
-    r: U256,
-    s: U256,
-}
+    let is_nonce_out_of_range = U256_le(U256(new U256Struct(2 ** 64 - 1, 0)), tx_nonce);
+    if (is_nonce_out_of_range.value != FALSE) {
+        tempvar res = bool(FALSE);
+        return res;
+    }
 
-struct FeeMarketTransaction {
-    value: FeeMarketTransactionStruct*,
-}
+    let is_data_not_zero = is_not_zero(tx_data.value.len);
+    let is_data_too_large = is_le_felt(2 * MAX_CODE_SIZE, tx_data.value.len - 1);
+    if (tx_to_ptr == 0 and is_data_not_zero != FALSE and is_data_too_large != FALSE) {
+        tempvar res = bool(FALSE);
+        return res;
+    }
 
-struct BlobTransactionStruct {
-    chain_id: U64,
-    nonce: U256,
-    max_priority_fee_per_gas: Uint,
-    max_fee_per_gas: Uint,
-    gas: Uint,
-    to: Address,
-    value: U256,
-    data: Bytes,
-    access_list: TupleAccessList,
-    max_fee_per_blob_gas: U256,
-    blob_versioned_hashes: TupleVersionedHash,
-    y_parity: U256,
-    r: U256,
-    s: U256,
-}
-
-struct BlobTransaction {
-    value: BlobTransactionStruct*,
-}
-
-struct TransactionStruct {
-    legacy_transaction: LegacyTransaction,
-    access_list_transaction: AccessListTransaction,
-    fee_market_transaction: FeeMarketTransaction,
-    blob_transaction: BlobTransaction,
-}
-
-struct Transaction {
-    value: TransactionStruct*,
+    tempvar res = bool(TRUE);
+    return res;
 }

--- a/cairo/ethereum/cancun/transactions.cairo
+++ b/cairo/ethereum/cancun/transactions.cairo
@@ -144,8 +144,8 @@ func validate_transaction{range_check_ptr}(tx: Transaction) -> bool {
         return res;
     }
 
-    let is_nonce_out_of_range = U256_le(U256(new U256Struct(2 ** 64 - 1, 0)), tx_nonce);
-    if (is_nonce_out_of_range.value != FALSE) {
+    let is_nonce_out_of_range = is_le_felt(2 ** 64 - 1, tx_nonce.value.low);
+    if (is_nonce_out_of_range + tx_nonce.value.high != FALSE) {
         tempvar res = bool(FALSE);
         return res;
     }

--- a/cairo/ethereum/cancun/transactions_types.cairo
+++ b/cairo/ethereum/cancun/transactions_types.cairo
@@ -1,0 +1,122 @@
+from ethereum_types.bytes import Bytes, Bytes0, TupleBytes32
+from ethereum_types.numeric import Uint, U256, U64, bool
+from ethereum.cancun.fork_types import Address, TupleVersionedHash
+
+const TX_BASE_COST = 21000;
+const TX_DATA_COST_PER_NON_ZERO = 16;
+const TX_DATA_COST_PER_ZERO = 4;
+const TX_CREATE_COST = 32000;
+const TX_ACCESS_LIST_ADDRESS_COST = 2400;
+const TX_ACCESS_LIST_STORAGE_KEY_COST = 1900;
+
+struct ToStruct {
+    bytes0: Bytes0*,
+    address: Address*,
+}
+
+struct To {
+    value: ToStruct*,
+}
+
+struct LegacyTransactionStruct {
+    nonce: U256,
+    gas_price: Uint,
+    gas: Uint,
+    to: To,
+    value: U256,
+    data: Bytes,
+    v: U256,
+    r: U256,
+    s: U256,
+}
+
+struct LegacyTransaction {
+    value: LegacyTransactionStruct*,
+}
+
+struct AccessListStruct {
+    address: Address,
+    storage_keys: TupleBytes32,
+}
+
+struct AccessList {
+    value: AccessListStruct*,
+}
+
+struct TupleAccessListStruct {
+    data: AccessList*,
+    len: felt,
+}
+
+struct TupleAccessList {
+    value: TupleAccessListStruct*,
+}
+
+struct AccessListTransactionStruct {
+    chain_id: U64,
+    nonce: U256,
+    gas_price: Uint,
+    gas: Uint,
+    to: To,
+    value: U256,
+    data: Bytes,
+    access_list: TupleAccessList,
+    y_parity: U256,
+    r: U256,
+    s: U256,
+}
+
+struct AccessListTransaction {
+    value: AccessListTransactionStruct*,
+}
+
+struct FeeMarketTransactionStruct {
+    chain_id: U64,
+    nonce: U256,
+    max_priority_fee_per_gas: Uint,
+    max_fee_per_gas: Uint,
+    gas: Uint,
+    to: To,
+    value: U256,
+    data: Bytes,
+    access_list: TupleAccessList,
+    y_parity: U256,
+    r: U256,
+    s: U256,
+}
+
+struct FeeMarketTransaction {
+    value: FeeMarketTransactionStruct*,
+}
+
+struct BlobTransactionStruct {
+    chain_id: U64,
+    nonce: U256,
+    max_priority_fee_per_gas: Uint,
+    max_fee_per_gas: Uint,
+    gas: Uint,
+    to: Address,
+    value: U256,
+    data: Bytes,
+    access_list: TupleAccessList,
+    max_fee_per_blob_gas: U256,
+    blob_versioned_hashes: TupleVersionedHash,
+    y_parity: U256,
+    r: U256,
+    s: U256,
+}
+
+struct BlobTransaction {
+    value: BlobTransactionStruct*,
+}
+
+struct TransactionStruct {
+    legacy_transaction: LegacyTransaction,
+    access_list_transaction: AccessListTransaction,
+    fee_market_transaction: FeeMarketTransaction,
+    blob_transaction: BlobTransaction,
+}
+
+struct Transaction {
+    value: TransactionStruct*,
+}

--- a/cairo/ethereum/cancun/trie.cairo
+++ b/cairo/ethereum/cancun/trie.cairo
@@ -42,7 +42,7 @@ from ethereum.cancun.fork_types import (
     MappingTupleAddressBytes32U256,
     MappingTupleAddressBytes32U256Struct,
 )
-from ethereum.cancun.transactions import LegacyTransaction
+from ethereum.cancun.transactions_types import LegacyTransaction
 from ethereum_rlp.rlp import (
     Extended,
     SequenceExtended,

--- a/cairo/ethereum/cancun/vm.cairo
+++ b/cairo/ethereum/cancun/vm.cairo
@@ -17,7 +17,7 @@ from ethereum.cancun.state import State, TransientStorage
 from ethereum.exceptions import EthereumException
 from ethereum_types.bytes import Bytes, Bytes0, Bytes32
 from ethereum_types.numeric import U64, U256, Uint, bool, SetUint
-from ethereum.cancun.transactions import To
+from ethereum.cancun.transactions_types import To
 from ethereum.cancun.vm.stack import Stack
 from ethereum.cancun.state import account_exists_and_is_empty
 from ethereum.cancun.vm.memory import Memory

--- a/cairo/ethereum/cancun/vm/gas.cairo
+++ b/cairo/ethereum/cancun/vm/gas.cairo
@@ -2,7 +2,7 @@ from ethereum_types.numeric import U256, Uint, U64, U256Struct
 from ethereum.utils.numeric import is_zero, divmod, taylor_exponential, min, ceil32
 from ethereum_types.bytes import BytesStruct
 from ethereum.cancun.blocks import Header
-from ethereum.cancun.transactions import Transaction
+from ethereum.cancun.transactions_types import Transaction
 from ethereum_types.others import ListTupleU256U256, TupleU256U256
 from ethereum.cancun.vm import Evm, EvmStruct, EvmImpl
 from ethereum.exceptions import EthereumException

--- a/cairo/ethereum/cancun/vm/instructions/system.cairo
+++ b/cairo/ethereum/cancun/vm/instructions/system.cairo
@@ -53,7 +53,7 @@ from ethereum.cancun.state import (
     is_account_alive,
 )
 from ethereum_types.bytes import Bytes, BytesStruct, Bytes0
-from ethereum.cancun.transactions import To, ToStruct
+from ethereum.cancun.transactions_types import To, ToStruct
 from ethereum.utils.numeric import (
     is_zero,
     U256_from_be_bytes20,

--- a/cairo/ethereum_rlp/rlp.cairo
+++ b/cairo/ethereum_rlp/rlp.cairo
@@ -16,7 +16,7 @@ from ethereum_types.bytes import (
 )
 from ethereum.cancun.blocks import Log, TupleLog, Receipt, Withdrawal
 from ethereum.cancun.fork_types import Address, Account, Bloom
-from ethereum.cancun.transactions import (
+from ethereum.cancun.transactions_types import (
     LegacyTransaction,
     To,
     AccessList,

--- a/cairo/tests/ethereum/cancun/test_fork.py
+++ b/cairo/tests/ethereum/cancun/test_fork.py
@@ -6,11 +6,9 @@ from ethereum.cancun.blocks import Header
 from ethereum.cancun.fork import (
     GAS_LIMIT_ADJUSTMENT_FACTOR,
     calculate_base_fee_per_gas,
-    calculate_intrinsic_cost,
     check_gas_limit,
     validate_header,
 )
-from ethereum.cancun.transactions import Transaction
 from ethereum.exceptions import InvalidBlock
 from tests.utils.errors import cairo_error
 
@@ -73,10 +71,6 @@ class TestFork:
                 cairo_run("validate_header", header, parent_header)
         else:
             cairo_run("validate_header", header, parent_header)
-
-    @given(tx=...)
-    def test_calculate_intrinsic_cost(self, cairo_run, tx: Transaction):
-        assert calculate_intrinsic_cost(tx) == cairo_run("calculate_intrinsic_cost", tx)
 
     @given(gas_limit=..., parent_gas_limit=...)
     def test_check_gas_limit(self, cairo_run, gas_limit: Uint, parent_gas_limit: Uint):

--- a/cairo/tests/ethereum/cancun/test_transactions.py
+++ b/cairo/tests/ethereum/cancun/test_transactions.py
@@ -1,0 +1,28 @@
+from hypothesis import given
+
+from ethereum.cancun.transactions import (
+    Transaction,
+    calculate_intrinsic_cost,
+    validate_transaction,
+)
+from tests.utils.errors import strict_raises
+
+
+class TestTransactions:
+    @given(tx=...)
+    def test_calculate_intrinsic_cost(self, cairo_run, tx: Transaction):
+        assert calculate_intrinsic_cost(tx) == cairo_run("calculate_intrinsic_cost", tx)
+
+    @given(tx=...)
+    def test_validate_transaction(self, cairo_run_py, tx: Transaction):
+        """
+        Test that transaction validation in Cairo matches Python implementation
+        """
+        try:
+            result_cairo = cairo_run_py("validate_transaction", tx)
+        except Exception as cairo_error:
+            with strict_raises(type(cairo_error)):
+                validate_transaction(tx)
+            return
+
+        assert result_cairo == validate_transaction(tx)

--- a/cairo/tests/src/utils/test_dict.py
+++ b/cairo/tests/src/utils/test_dict.py
@@ -1,7 +1,6 @@
 from collections import defaultdict
 from typing import List, Mapping, Tuple
 
-from cairo_addons.hints.decorator import register_hint
 from ethereum_types.bytes import Bytes32
 from ethereum_types.numeric import U256, Uint
 from hypothesis import given
@@ -12,6 +11,7 @@ from starkware.cairo.lang.vm.memory_segments import MemorySegmentManager
 from starkware.cairo.lang.vm.relocatable import RelocatableValue
 from starkware.cairo.lang.vm.vm_consts import VmConsts
 
+from cairo_addons.hints.decorator import register_hint
 from ethereum.cancun.fork_types import Address
 from tests.utils.strategies import felt
 

--- a/cairo/tests/test_serde.cairo
+++ b/cairo/tests/test_serde.cairo
@@ -32,7 +32,7 @@ from ethereum.cancun.blocks import (
     Receipt,
 )
 
-from ethereum.cancun.transactions import (
+from ethereum.cancun.transactions_types import (
     TupleAccessList,
     Transaction,
     LegacyTransaction,

--- a/cairo/tests/utils/args_gen.py
+++ b/cairo/tests/utils/args_gen.py
@@ -432,7 +432,7 @@ _cairo_struct_to_python_type: Dict[Tuple[str, ...], Any] = {
     ("ethereum", "cancun", "fork_types", "TupleVersionedHash"): Tuple[
         VersionedHash, ...
     ],
-    ("ethereum", "cancun", "transactions", "To"): Union[Bytes0, Address],
+    ("ethereum", "cancun", "transactions_types", "To"): Union[Bytes0, Address],
     ("ethereum", "cancun", "fork_types", "TupleAddressBytes32"): Tuple[
         Address, Bytes32
     ],
@@ -441,25 +441,35 @@ _cairo_struct_to_python_type: Dict[Tuple[str, ...], Any] = {
     ],
     ("ethereum_types", "others", "TupleU256U256"): Tuple[U256, U256],
     ("ethereum_types", "others", "ListTupleU256U256"): List[Tuple[U256, U256]],
-    ("ethereum", "cancun", "transactions", "LegacyTransaction"): LegacyTransaction,
     (
         "ethereum",
         "cancun",
-        "transactions",
+        "transactions_types",
+        "LegacyTransaction",
+    ): LegacyTransaction,
+    (
+        "ethereum",
+        "cancun",
+        "transactions_types",
         "AccessListTransaction",
     ): AccessListTransaction,
     (
         "ethereum",
         "cancun",
-        "transactions",
+        "transactions_types",
         "FeeMarketTransaction",
     ): FeeMarketTransaction,
-    ("ethereum", "cancun", "transactions", "BlobTransaction"): BlobTransaction,
-    ("ethereum", "cancun", "transactions", "Transaction"): Transaction,
-    ("ethereum", "cancun", "transactions", "TupleAccessList"): Tuple[
+    (
+        "ethereum",
+        "cancun",
+        "transactions_types",
+        "BlobTransaction",
+    ): BlobTransaction,
+    ("ethereum", "cancun", "transactions_types", "Transaction"): Transaction,
+    ("ethereum", "cancun", "transactions_types", "TupleAccessList"): Tuple[
         Tuple[Address, Tuple[Bytes32, ...]], ...
     ],
-    ("ethereum", "cancun", "transactions", "AccessList"): Tuple[
+    ("ethereum", "cancun", "transactions_types", "AccessList"): Tuple[
         Address, Tuple[Bytes32, ...]
     ],
     ("ethereum", "cancun", "vm", "gas", "MessageCallGas"): MessageCallGas,

--- a/python/cairo-addons/src/cairo_addons/hints/bytes_hints.py
+++ b/python/cairo-addons/src/cairo_addons/hints/bytes_hints.py
@@ -4,10 +4,11 @@ This file contains hints for the bytes.cairo file.
 Added the _hint suffix to the hints to avoid conflicts with the bytes python object.
 """
 
-from cairo_addons.hints.decorator import register_hint
 from starkware.cairo.lang.vm.memory_dict import MemoryDict
 from starkware.cairo.lang.vm.relocatable import RelocatableValue
 from starkware.cairo.lang.vm.vm_consts import VmConsts
+
+from cairo_addons.hints.decorator import register_hint
 
 
 @register_hint

--- a/python/cairo-addons/src/cairo_addons/hints/dict.py
+++ b/python/cairo-addons/src/cairo_addons/hints/dict.py
@@ -1,9 +1,10 @@
-from cairo_addons.hints.decorator import register_hint
 from starkware.cairo.common.dict import DictManager
 from starkware.cairo.lang.vm.memory_dict import MemoryDict
 from starkware.cairo.lang.vm.memory_segments import MemorySegmentManager
 from starkware.cairo.lang.vm.relocatable import RelocatableValue
 from starkware.cairo.lang.vm.vm_consts import VmConsts
+
+from cairo_addons.hints.decorator import register_hint
 
 
 @register_hint

--- a/python/cairo-addons/src/cairo_addons/hints/hashdict.py
+++ b/python/cairo-addons/src/cairo_addons/hints/hashdict.py
@@ -1,8 +1,9 @@
-from cairo_addons.hints.decorator import register_hint
 from starkware.cairo.common.dict import DictManager, DictTracker
 from starkware.cairo.lang.vm.memory_dict import MemoryDict
 from starkware.cairo.lang.vm.memory_segments import MemorySegmentManager
 from starkware.cairo.lang.vm.vm_consts import VmConsts
+
+from cairo_addons.hints.decorator import register_hint
 
 
 @register_hint

--- a/python/cairo-addons/src/cairo_addons/hints/utils.py
+++ b/python/cairo-addons/src/cairo_addons/hints/utils.py
@@ -1,9 +1,10 @@
-from cairo_addons.hints.decorator import register_hint
 from starkware.cairo.common.dict import DictManager
 from starkware.cairo.lang.vm.memory_dict import MemoryDict
 from starkware.cairo.lang.vm.memory_segments import MemorySegmentManager
 from starkware.cairo.lang.vm.relocatable import RelocatableValue
 from starkware.cairo.lang.vm.vm_consts import VmConsts
+
+from cairo_addons.hints.decorator import register_hint
 
 
 @register_hint

--- a/python/cairo-ec/tests/curve/test_secp256k1.py
+++ b/python/cairo-ec/tests/curve/test_secp256k1.py
@@ -1,9 +1,9 @@
 import pytest
+from ethereum.crypto.elliptic_curve import SECP256K1N, EllipticCurve
+from ethereum.crypto.finite_field import PrimeField
 
 from cairo_addons.utils.uint256 import uint256_to_int
 from cairo_addons.utils.uint384 import uint384_to_int
-from ethereum.crypto.elliptic_curve import SECP256K1N, EllipticCurve
-from ethereum.crypto.finite_field import PrimeField
 
 pytestmark = pytest.mark.python_vm
 

--- a/python/cairo-ec/tests/test_ec_ops.py
+++ b/python/cairo-ec/tests/test_ec_ops.py
@@ -1,14 +1,14 @@
 import hypothesis.strategies as st
 import pytest
+from ethereum.crypto.alt_bn128 import BNF as AltBn128P
+from ethereum.crypto.alt_bn128 import BNP as AltBn128
+from ethereum.crypto.elliptic_curve import EllipticCurve
+from ethereum.crypto.finite_field import PrimeField
 from hypothesis import given
 from sympy import sqrt_mod
 
 from cairo_addons.testing.strategies import felt
 from cairo_addons.utils.uint384 import int_to_uint384, uint384_to_int
-from ethereum.crypto.alt_bn128 import BNF as AltBn128P
-from ethereum.crypto.alt_bn128 import BNP as AltBn128
-from ethereum.crypto.elliptic_curve import EllipticCurve
-from ethereum.crypto.finite_field import PrimeField
 
 pytestmark = pytest.mark.python_vm
 

--- a/python/cairo-ec/tests/test_uint384.py
+++ b/python/cairo-ec/tests/test_uint384.py
@@ -1,11 +1,11 @@
 import pytest
+from ethereum.crypto.elliptic_curve import SECP256K1N
 from hypothesis import assume, given
 from hypothesis import strategies as st
 from starkware.cairo.lang.cairo_constants import DEFAULT_PRIME
 
 from cairo_addons.utils.uint256 import int_to_uint256, uint256_to_int
 from cairo_addons.utils.uint384 import int_to_uint384, uint384_to_int
-from ethereum.crypto.elliptic_curve import SECP256K1N
 
 pytestmark = pytest.mark.python_vm
 


### PR DESCRIPTION
Closes #546 

Creates transactions_types file to avoid circular imports. 
Also move the calculate_intrinsic_cost to transaction.py for the same reason (and to match EELS).