### PR TITLE
feat: signing hash utils

### DIFF
--- a/cairo/ethereum/cancun/transactions.cairo
+++ b/cairo/ethereum/cancun/transactions.cairo
@@ -26,11 +26,11 @@ from ethereum.cancun.transactions_types import (
 
 from ethereum.crypto.hash import keccak256, Hash32
 from ethereum_rlp.rlp import (
-    encode_legacy_transaction,
-    encode_eip155_transaction,
-    encode_access_list_transaction,
-    encode_fee_market_transaction,
-    encode_blob_transaction,
+    encode_legacy_transaction_for_signing,
+    encode_eip155_transaction_for_signing,
+    encode_access_list_transaction_for_signing,
+    encode_fee_market_transaction_for_signing,
+    encode_blob_transaction_for_signing,
 )
 
 from ethereum.cancun.utils.constants import MAX_CODE_SIZE
@@ -179,7 +179,7 @@ func validate_transaction{range_check_ptr}(tx: Transaction) -> bool {
 func signing_hash_pre155{range_check_ptr, bitwise_ptr: BitwiseBuiltin*, keccak_ptr: KeccakBuiltin*}(
     tx: LegacyTransaction
 ) -> Hash32 {
-    let encoded_tx = encode_legacy_transaction(tx);
+    let encoded_tx = encode_legacy_transaction_for_signing(tx);
     let hash = keccak256(encoded_tx);
     return hash;
 }
@@ -187,7 +187,7 @@ func signing_hash_pre155{range_check_ptr, bitwise_ptr: BitwiseBuiltin*, keccak_p
 func signing_hash_155{range_check_ptr, bitwise_ptr: BitwiseBuiltin*, keccak_ptr: KeccakBuiltin*}(
     tx: LegacyTransaction, chain_id: U64
 ) -> Hash32 {
-    let encoded_tx = encode_eip155_transaction(tx, chain_id);
+    let encoded_tx = encode_eip155_transaction_for_signing(tx, chain_id);
     let hash = keccak256(encoded_tx);
     return hash;
 }
@@ -195,7 +195,7 @@ func signing_hash_155{range_check_ptr, bitwise_ptr: BitwiseBuiltin*, keccak_ptr:
 func signing_hash_2930{range_check_ptr, bitwise_ptr: BitwiseBuiltin*, keccak_ptr: KeccakBuiltin*}(
     tx: AccessListTransaction
 ) -> Hash32 {
-    let encoded_tx = encode_access_list_transaction(tx);
+    let encoded_tx = encode_access_list_transaction_for_signing(tx);
     let hash = keccak256(encoded_tx);
     return hash;
 }
@@ -203,7 +203,7 @@ func signing_hash_2930{range_check_ptr, bitwise_ptr: BitwiseBuiltin*, keccak_ptr
 func signing_hash_1559{range_check_ptr, bitwise_ptr: BitwiseBuiltin*, keccak_ptr: KeccakBuiltin*}(
     tx: FeeMarketTransaction
 ) -> Hash32 {
-    let encoded_tx = encode_fee_market_transaction(tx);
+    let encoded_tx = encode_fee_market_transaction_for_signing(tx);
     let hash = keccak256(encoded_tx);
     return hash;
 }
@@ -211,7 +211,7 @@ func signing_hash_1559{range_check_ptr, bitwise_ptr: BitwiseBuiltin*, keccak_ptr
 func signing_hash_4844{range_check_ptr, bitwise_ptr: BitwiseBuiltin*, keccak_ptr: KeccakBuiltin*}(
     tx: BlobTransaction
 ) -> Hash32 {
-    let encoded_tx = encode_blob_transaction(tx);
+    let encoded_tx = encode_blob_transaction_for_signing(tx);
     let hash = keccak256(encoded_tx);
     return hash;
 }

--- a/cairo/ethereum/cancun/transactions.cairo
+++ b/cairo/ethereum/cancun/transactions.cairo
@@ -1,12 +1,18 @@
 from starkware.cairo.common.math_cmp import is_le_felt, is_not_zero
 from starkware.cairo.common.bool import FALSE, TRUE
+from starkware.cairo.common.cairo_builtins import KeccakBuiltin
+from starkware.cairo.common.bitwise import BitwiseBuiltin
 
 from ethereum_types.bytes import Bytes, Bytes0
-from ethereum_types.numeric import Uint, bool, U256, U256Struct
+from ethereum_types.numeric import Uint, bool, U256, U256Struct, U64
 from ethereum.cancun.fork_types import Address
 from ethereum.cancun.vm.gas import init_code_cost
 from ethereum.cancun.transactions_types import (
     Transaction,
+    LegacyTransaction,
+    AccessListTransaction,
+    FeeMarketTransaction,
+    BlobTransaction,
     To,
     ToStruct,
     TupleAccessListStruct,
@@ -17,8 +23,17 @@ from ethereum.cancun.transactions_types import (
     TX_ACCESS_LIST_ADDRESS_COST,
     TX_ACCESS_LIST_STORAGE_KEY_COST,
 )
+
+from ethereum.crypto.hash import keccak256, Hash32
+from ethereum_rlp.rlp import (
+    encode_legacy_transaction,
+    encode_eip155_transaction,
+    encode_access_list_transaction,
+    encode_fee_market_transaction,
+    encode_blob_transaction,
+)
+
 from ethereum.cancun.utils.constants import MAX_CODE_SIZE
-from ethereum.utils.numeric import U256_le
 from src.utils.array import count_not_zero
 
 func calculate_intrinsic_cost{range_check_ptr}(tx: Transaction) -> Uint {
@@ -159,4 +174,44 @@ func validate_transaction{range_check_ptr}(tx: Transaction) -> bool {
 
     tempvar res = bool(TRUE);
     return res;
+}
+
+func signing_hash_pre155{range_check_ptr, bitwise_ptr: BitwiseBuiltin*, keccak_ptr: KeccakBuiltin*}(
+    tx: LegacyTransaction
+) -> Hash32 {
+    let encoded_tx = encode_legacy_transaction(tx);
+    let hash = keccak256(encoded_tx);
+    return hash;
+}
+
+func signing_hash_155{range_check_ptr, bitwise_ptr: BitwiseBuiltin*, keccak_ptr: KeccakBuiltin*}(
+    tx: LegacyTransaction, chain_id: U64
+) -> Hash32 {
+    let encoded_tx = encode_eip155_transaction(tx, chain_id);
+    let hash = keccak256(encoded_tx);
+    return hash;
+}
+
+func signing_hash_2930{range_check_ptr, bitwise_ptr: BitwiseBuiltin*, keccak_ptr: KeccakBuiltin*}(
+    tx: AccessListTransaction
+) -> Hash32 {
+    let encoded_tx = encode_access_list_transaction(tx);
+    let hash = keccak256(encoded_tx);
+    return hash;
+}
+
+func signing_hash_1559{range_check_ptr, bitwise_ptr: BitwiseBuiltin*, keccak_ptr: KeccakBuiltin*}(
+    tx: FeeMarketTransaction
+) -> Hash32 {
+    let encoded_tx = encode_fee_market_transaction(tx);
+    let hash = keccak256(encoded_tx);
+    return hash;
+}
+
+func signing_hash_4844{range_check_ptr, bitwise_ptr: BitwiseBuiltin*, keccak_ptr: KeccakBuiltin*}(
+    tx: BlobTransaction
+) -> Hash32 {
+    let encoded_tx = encode_blob_transaction(tx);
+    let hash = keccak256(encoded_tx);
+    return hash;
 }

--- a/cairo/ethereum_rlp/rlp.cairo
+++ b/cairo/ethereum_rlp/rlp.cairo
@@ -21,7 +21,6 @@ from ethereum.cancun.transactions_types import (
     LegacyTransaction,
     To,
     AccessList,
-    AccessListStruct,
     TupleAccessList,
     AccessListTransaction,
     FeeMarketTransaction,

--- a/cairo/tests/ethereum/cancun/test_transactions.py
+++ b/cairo/tests/ethereum/cancun/test_transactions.py
@@ -36,59 +36,25 @@ class TestTransactions:
 
     @given(tx=...)
     def test_signing_hash_pre155(self, cairo_run, tx: LegacyTransaction):
-        """Test pre-EIP155 transaction signing hash computation"""
-        try:
-            cairo_result = cairo_run("signing_hash_pre155", tx)
-        except Exception as cairo_error:
-            with strict_raises(type(cairo_error)):
-                signing_hash_pre155(tx)
-            return
-
+        cairo_result = cairo_run("signing_hash_pre155", tx)
         assert signing_hash_pre155(tx) == cairo_result
 
     @given(tx=..., chain_id=...)
     def test_signing_hash_155(self, cairo_run, tx: LegacyTransaction, chain_id: U64):
-        """Test EIP-155 transaction signing hash computation"""
-        try:
-            cairo_result = cairo_run("signing_hash_155", tx, chain_id)
-        except Exception as cairo_error:
-            with strict_raises(type(cairo_error)):
-                signing_hash_155(tx, chain_id)
-            return
-
+        cairo_result = cairo_run("signing_hash_155", tx, chain_id)
         assert signing_hash_155(tx, chain_id) == cairo_result
 
     @given(tx=...)
     def test_signing_hash_2930(self, cairo_run, tx: AccessListTransaction):
-        """Test EIP-2930 transaction signing hash computation"""
-        try:
-            cairo_result = cairo_run("signing_hash_2930", tx)
-        except Exception as cairo_error:
-            with strict_raises(type(cairo_error)):
-                signing_hash_2930(tx)
-            return
-
+        cairo_result = cairo_run("signing_hash_2930", tx)
         assert signing_hash_2930(tx) == cairo_result
 
     @given(tx=...)
     def test_signing_hash_1559(self, cairo_run, tx: FeeMarketTransaction):
-        """Test EIP-1559 transaction signing hash computation"""
-        try:
-            cairo_result = cairo_run("signing_hash_1559", tx)
-        except Exception as cairo_error:
-            with strict_raises(type(cairo_error)):
-                signing_hash_1559(tx)
-            return
-
+        cairo_result = cairo_run("signing_hash_1559", tx)
         assert signing_hash_1559(tx) == cairo_result
 
     @given(tx=...)
     def test_signing_hash_4844(self, cairo_run, tx: BlobTransaction):
-        """Test EIP-4844 transaction signing hash computation"""
-        try:
-            cairo_result = cairo_run("signing_hash_4844", tx)
-        except Exception as cairo_error:
-            with strict_raises(type(cairo_error)):
-                signing_hash_4844(tx)
-            return
+        cairo_result = cairo_run("signing_hash_4844", tx)
         assert signing_hash_4844(tx) == cairo_result

--- a/cairo/tests/ethereum/cancun/test_transactions.py
+++ b/cairo/tests/ethereum/cancun/test_transactions.py
@@ -1,3 +1,4 @@
+from ethereum_types.numeric import U64
 from hypothesis import given
 
 from ethereum.cancun.transactions import (
@@ -15,7 +16,6 @@ from ethereum.cancun.transactions import (
     validate_transaction,
 )
 from tests.utils.errors import strict_raises
-from ethereum_types.numeric import U64
 
 
 class TestTransactions:

--- a/cairo/tests/ethereum/cancun/test_transactions.py
+++ b/cairo/tests/ethereum/cancun/test_transactions.py
@@ -1,11 +1,21 @@
 from hypothesis import given
 
 from ethereum.cancun.transactions import (
+    AccessListTransaction,
+    BlobTransaction,
+    FeeMarketTransaction,
+    LegacyTransaction,
     Transaction,
     calculate_intrinsic_cost,
+    signing_hash_155,
+    signing_hash_1559,
+    signing_hash_2930,
+    signing_hash_4844,
+    signing_hash_pre155,
     validate_transaction,
 )
 from tests.utils.errors import strict_raises
+from ethereum_types.numeric import U64
 
 
 class TestTransactions:
@@ -23,3 +33,62 @@ class TestTransactions:
             return
 
         assert result_cairo == validate_transaction(tx)
+
+    @given(tx=...)
+    def test_signing_hash_pre155(self, cairo_run, tx: LegacyTransaction):
+        """Test pre-EIP155 transaction signing hash computation"""
+        try:
+            cairo_result = cairo_run("signing_hash_pre155", tx)
+        except Exception as cairo_error:
+            with strict_raises(type(cairo_error)):
+                signing_hash_pre155(tx)
+            return
+
+        assert signing_hash_pre155(tx) == cairo_result
+
+    @given(tx=..., chain_id=...)
+    def test_signing_hash_155(self, cairo_run, tx: LegacyTransaction, chain_id: U64):
+        """Test EIP-155 transaction signing hash computation"""
+        try:
+            cairo_result = cairo_run("signing_hash_155", tx, chain_id)
+        except Exception as cairo_error:
+            with strict_raises(type(cairo_error)):
+                signing_hash_155(tx, chain_id)
+            return
+
+        assert signing_hash_155(tx, chain_id) == cairo_result
+
+    @given(tx=...)
+    def test_signing_hash_2930(self, cairo_run, tx: AccessListTransaction):
+        """Test EIP-2930 transaction signing hash computation"""
+        try:
+            cairo_result = cairo_run("signing_hash_2930", tx)
+        except Exception as cairo_error:
+            with strict_raises(type(cairo_error)):
+                signing_hash_2930(tx)
+            return
+
+        assert signing_hash_2930(tx) == cairo_result
+
+    @given(tx=...)
+    def test_signing_hash_1559(self, cairo_run, tx: FeeMarketTransaction):
+        """Test EIP-1559 transaction signing hash computation"""
+        try:
+            cairo_result = cairo_run("signing_hash_1559", tx)
+        except Exception as cairo_error:
+            with strict_raises(type(cairo_error)):
+                signing_hash_1559(tx)
+            return
+
+        assert signing_hash_1559(tx) == cairo_result
+
+    @given(tx=...)
+    def test_signing_hash_4844(self, cairo_run, tx: BlobTransaction):
+        """Test EIP-4844 transaction signing hash computation"""
+        try:
+            cairo_result = cairo_run("signing_hash_4844", tx)
+        except Exception as cairo_error:
+            with strict_raises(type(cairo_error)):
+                signing_hash_4844(tx)
+            return
+        assert signing_hash_4844(tx) == cairo_result

--- a/cairo/tests/ethereum_rlp/test_rlp.py
+++ b/cairo/tests/ethereum_rlp/test_rlp.py
@@ -171,6 +171,7 @@ class TestRlp:
         def test_encode_legacy_transaction_for_signing(
             self, cairo_run, tx: LegacyTransaction
         ):
+            # <https://github.com/ethereum/execution-specs/blob/master/src/ethereum/cancun/transactions.py#L298>
             result = encode(
                 (
                     tx.nonce,
@@ -187,6 +188,7 @@ class TestRlp:
         def test_encode_eip155_transaction_for_signing(
             self, cairo_run, tx: LegacyTransaction, chain_id: U64
         ):
+            # <https://github.com/ethereum/execution-specs/blob/master/src/ethereum/cancun/transactions.py#L326>
             assert encode(
                 (
                     tx.nonce,
@@ -205,6 +207,7 @@ class TestRlp:
         def test_encode_access_list_transaction_for_signing(
             self, cairo_run, tx: AccessListTransaction
         ):
+            # <https://github.com/ethereum/execution-specs/blob/master/src/ethereum/cancun/transactions.py#L359>
             result = b"\x01" + encode(
                 (
                     tx.chain_id,
@@ -223,6 +226,7 @@ class TestRlp:
         def test_encode_fee_market_transaction_for_signing(
             self, cairo_run, tx: FeeMarketTransaction
         ):
+            # <https://github.com/ethereum/execution-specs/blob/master/src/ethereum/cancun/transactions.py#L390>
             result = b"\x02" + encode(
                 (
                     tx.chain_id,
@@ -242,6 +246,7 @@ class TestRlp:
         def test_encode_blob_transaction_for_signing(
             self, cairo_run, tx: BlobTransaction
         ):
+            # <https://github.com/ethereum/execution-specs/blob/master/src/ethereum/cancun/transactions.py#L422>
             result = b"\x03" + encode(
                 (
                     tx.chain_id,

--- a/uv.lock
+++ b/uv.lock
@@ -416,20 +416,12 @@ dependencies = [
     { name = "garaga" },
 ]
 
-[package.dev-dependencies]
-dev = [
-    { name = "hypothesis" },
-]
-
 [package.metadata]
 requires-dist = [
     { name = "cairo-addons", editable = "python/cairo-addons" },
     { name = "cairo-lang", specifier = ">=0.13.3" },
     { name = "garaga", git = "https://github.com/keep-starknet-strange/garaga.git?rev=hydra_upd" },
 ]
-
-[package.metadata.requires-dev]
-dev = [{ name = "hypothesis", specifier = ">=6.124.3" }]
 
 [[package]]
 name = "cairo-ec"


### PR DESCRIPTION
closes #588 

- added encode utils specifically for signing utils, didn't modify the existing encode utils as they will be used in [`apply_body`](https://github.com/ethereum/execution-specs/blob/d9febcb7332d62194968dcdb7775adf497c93626/src/ethereum/paris/fork.py#L487)
- added tests
- added utils for signing hash