### PR TITLE
fix: is_zero opcode

### DIFF
--- a/cairo/ethereum/cancun/vm/instructions.cairo
+++ b/cairo/ethereum/cancun/vm/instructions.cairo
@@ -23,6 +23,7 @@ from ethereum.cancun.vm.instructions.comparison import (
     signed_less_than,
     signed_greater_than,
     equal,
+    is_zero_opcode,
 )
 from ethereum.cancun.vm.instructions.bitwise import (
     bitwise_and,
@@ -153,7 +154,6 @@ from ethereum.cancun.vm.instructions.environment import (
     blob_hash,
     blob_base_fee,
 )
-from cairo_core.comparison import is_zero
 
 func op_implementation{
     range_check_ptr,
@@ -220,7 +220,7 @@ func op_implementation{
     ret;
     call equal;  // 0x14 - EQ
     ret;
-    call is_zero;  // 0x15 - ISZERO
+    call is_zero_opcode;  // 0x15 - ISZERO
     ret;
     call bitwise_and;  // 0x16 - AND
     ret;

--- a/cairo/ethereum/cancun/vm/instructions/comparison.cairo
+++ b/cairo/ethereum/cancun/vm/instructions/comparison.cairo
@@ -244,7 +244,7 @@ func equal{
 }
 
 // @notice Checks if the top element is equal to zero
-func is_zero{
+func is_zero_opcode{
     range_check_ptr,
     bitwise_ptr: BitwiseBuiltin*,
     keccak_ptr: KeccakBuiltin*,

--- a/cairo/ethereum/cancun/vm/interpreter.cairo
+++ b/cairo/ethereum/cancun/vm/interpreter.cairo
@@ -368,6 +368,7 @@ func _execute_code{
     if (evm.value.running.value == FALSE) {
         return evm;
     }
+
     let is_pc_ge_code_len = is_nn(evm.value.pc.value - evm.value.code.value.len);
     if (is_pc_ge_code_len != FALSE) {
         return evm;

--- a/cairo/tests/ethereum/cancun/vm/instructions/test_comparison.py
+++ b/cairo/tests/ethereum/cancun/vm/instructions/test_comparison.py
@@ -80,7 +80,7 @@ class TestComparison:
     @given(evm=comparison_tests_strategy)
     def test_is_zero(self, cairo_run, evm: Evm):
         try:
-            cairo_result = cairo_run("is_zero", evm)
+            cairo_result = cairo_run("is_zero_opcode", evm)
         except EthereumException as cairo_error:
             with strict_raises(type(cairo_error)):
                 is_zero(evm)


### PR DESCRIPTION
the jumptable was calling the is_zero cairo instead of the is_zero opcode.