### PR TITLE
fix: process-transaction src & strategy

### DIFF
--- a/cairo/ethereum/cancun/utils/message.cairo
+++ b/cairo/ethereum/cancun/utils/message.cairo
@@ -20,7 +20,7 @@ from starkware.cairo.common.registers import get_fp_and_pc, get_label_location
 from starkware.cairo.common.memcpy import memcpy
 from starkware.cairo.common.dict_access import DictAccess
 
-from src.utils.dict import dict_new_empty, hashdict_write
+from src.utils.dict import hashdict_write
 
 const PRECOMPILED_ADDRESSES_SIZE = 10;
 

--- a/cairo/ethereum/cancun/vm/interpreter.cairo
+++ b/cairo/ethereum/cancun/vm/interpreter.cairo
@@ -59,7 +59,7 @@ from ethereum.cancun.state import (
     touch_account,
 )
 
-from src.utils.dict import dict_new_empty, hashdict_write, dict_squash
+from src.utils.dict import hashdict_write, dict_squash
 
 struct MessageCallOutput {
     value: MessageCallOutputStruct*,

--- a/cairo/tests/ethereum/cancun/test_fork.py
+++ b/cairo/tests/ethereum/cancun/test_fork.py
@@ -132,19 +132,15 @@ def tx_with_sender_in_state(
 def env_with_valid_gas_price(draw):
     env = draw(st.from_type(Environment))
     if env.gas_price < env.base_fee_per_gas:
-        env = replace(
-            env,
-            # env.gas_price >= env.base_fee_per_gas is validated in `check_transaction`
-            gas_price=draw(
-                st.integers(
-                    min_value=int(env.base_fee_per_gas), max_value=2**64 - 1
-                ).map(Uint)
-            ),
-            # Values too high would cause taylor_exponential to run indefinitely.
-            excess_blob_gas=draw(
-                st.integers(0, 10 * int(TARGET_BLOB_GAS_PER_BLOCK)).map(U64)
-            ),
+        env.gas_price = draw(
+            st.integers(min_value=int(env.base_fee_per_gas), max_value=2**64 - 1).map(
+                Uint
+            )
         )
+    # Values too high would cause taylor_exponential to run indefinitely.
+    env.excess_blob_gas = draw(
+        st.integers(0, 10 * int(TARGET_BLOB_GAS_PER_BLOCK)).map(U64)
+    )
     return env
 
 

--- a/cairo/tests/ethereum/cancun/vm/test_gas.py
+++ b/cairo/tests/ethereum/cancun/vm/test_gas.py
@@ -126,13 +126,19 @@ class TestGas:
 
     @given(excess_blob_gas=excess_blob_gas)
     def test_calculate_blob_gas_price(self, cairo_run, excess_blob_gas):
-        assert calculate_blob_gas_price(excess_blob_gas) == cairo_run(
+        """Saturates at 2**64 - 1"""
+        blob_gas_price_py = min(
+            calculate_blob_gas_price(excess_blob_gas), Uint(2**64 - 1)
+        )
+        assert blob_gas_price_py == cairo_run(
             "calculate_blob_gas_price", excess_blob_gas
         )
 
     @given(excess_blob_gas=excess_blob_gas, tx=...)
     def test_calculate_data_fee(self, cairo_run, excess_blob_gas, tx: BlobTransaction):
+        """Saturates at (2**64 - 1)**2"""
         assume(len(tx.blob_versioned_hashes) > 0)
-        assert calculate_data_fee(excess_blob_gas, tx) == cairo_run(
-            "calculate_data_fee", excess_blob_gas, tx
+        data_fee_py = min(
+            calculate_data_fee(excess_blob_gas, tx), Uint((2**64 - 1) ** 2)
         )
+        assert data_fee_py == cairo_run("calculate_data_fee", excess_blob_gas, tx)

--- a/python/cairo-addons/src/cairo_addons/hints/dict.py
+++ b/python/cairo-addons/src/cairo_addons/hints/dict.py
@@ -87,9 +87,6 @@ def copy_dict_segment(
 def merge_dict_tracker_with_parent(
     dict_manager: DictManager,
     ids: VmConsts,
-    segments: MemorySegmentManager,
-    memory: MemoryDict,
-    ap: RelocatableValue,
 ):
     current_dict_tracker = dict_manager.get_tracker(ids.dict_ptr)
     parent_dict_tracker = dict_manager.get_tracker(ids.parent_dict_end)
@@ -100,9 +97,6 @@ def merge_dict_tracker_with_parent(
 def update_dict_tracker(
     dict_manager: DictManager,
     ids: VmConsts,
-    segments: MemorySegmentManager,
-    memory: MemoryDict,
-    ap: RelocatableValue,
 ):
     dict_tracker = dict_manager.get_tracker(ids.current_tracker_ptr)
     dict_tracker.current_ptr = ids.new_tracker_ptr.address_

--- a/python/cairo-addons/src/cairo_addons/hints/hashdict.py
+++ b/python/cairo-addons/src/cairo_addons/hints/hashdict.py
@@ -42,9 +42,9 @@ def hashdict_write(dict_manager: DictManager, ids: VmConsts, memory: MemoryDict)
     preimage = tuple([memory[ids.key + i] for i in range(ids.key_len)])
     prev_value = dict_tracker.data.get(preimage)
     if prev_value:
-        ids.prev_value = prev_value
+        ids.dict_ptr.prev_value = prev_value
     else:
-        ids.prev_value = dict_tracker.data.default_factory()
+        ids.dict_ptr.prev_value = dict_tracker.data.default_factory()
     dict_tracker.data[preimage] = ids.new_value
 
 


### PR DESCRIPTION
- fixes the strategy of process_transaction to only generate valid gas values regarding basefee
- fixes the preaccessed addresses & keys to be instanciated with a default dict with default 0
- fixes the state used in reads post-execution to be the updated on from the env
- saturate blob gas / gas price values to 2**64
- stop early taylor exponentiation when accumulated numerator is > 2**128
- limit excess_blob_gas to 10*target in strategy, to avoid the pythonic taylor exponentiation to run forever.
- fix the assertions made in `process_transaction` to handle raises AND exceptions in return values