### PR TITLE
Print miss for current file

### DIFF
--- a/python/cairo-addons/src/cairo_addons/testing/fixtures.py
+++ b/python/cairo-addons/src/cairo_addons/testing/fixtures.py
@@ -111,7 +111,7 @@ def coverage(cairo_program: Program, cairo_file: Path, worker_id: str):
             .with_columns(
                 pl.col("filename") + ":" + pl.col("line_number").cast(pl.String)
             )
-            .drop("line_number")
+            .drop("line_number", "count")
         )
     all_coverages = (
         all_coverages.group_by("filename")


### PR DESCRIPTION
Running with `-s` will print the misses for the current file. The IDE lets you then click to the line

<img width="1007" alt="image" src="https://github.com/user-attachments/assets/cb7e5ecc-ab51-4e1a-b55e-a5e4cc09c842" />
