### PR TITLE
refactor: use ec_add & ec_double from compiled circuits

### DIFF
--- a/python/cairo-ec/src/cairo_ec/ec_ops.cairo
+++ b/python/cairo-ec/src/cairo_ec/ec_ops.cairo
@@ -73,7 +73,6 @@ func ec_add{range_check96_ptr: felt*, add_mod_ptr: ModBuiltin*, mul_mod_ptr: Mod
             return res;
         }
 
-
         let (res_x, res_y) = ec_double(&p.x, &p.y, &a, &modulus);
         let res = G1Point(x=[res_x], y=[res_y]);
         return res;
@@ -82,7 +81,6 @@ func ec_add{range_check96_ptr: felt*, add_mod_ptr: ModBuiltin*, mul_mod_ptr: Mod
     let (res_x, res_y) = ec_add_unchecked(&p.x, &p.y, &q.x, &q.y, &modulus);
     let res = G1Point(x=[res_x], y=[res_y]);
     return res;
-
 }
 
 // Multiply an EC point by a scalar. Doesn't check if the input is on curve nor if it's the point at infinity.

--- a/python/cairo-ec/tests/test_ec_ops.cairo
+++ b/python/cairo-ec/tests/test_ec_ops.cairo
@@ -2,7 +2,7 @@ from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import ModBuiltin, PoseidonBuiltin, UInt384
 from starkware.cairo.common.uint256 import Uint256
 
-from cairo_ec.ec_ops import ec_double, ec_add, try_get_point_from_x, get_random_point
+from cairo_ec.ec_ops import ec_add, try_get_point_from_x, get_random_point
 from cairo_ec.curve.g1_point import G1Point
 
 func test__try_get_point_from_x{
@@ -57,30 +57,6 @@ func test__get_random_point{
         UInt384(point.y.d0, point.y.d1, point.y.d2, point.y.d3),
     );
     return point_ptr;
-}
-
-func test__ec_double{range_check96_ptr: felt*, add_mod_ptr: ModBuiltin*, mul_mod_ptr: ModBuiltin*}(
-    ) -> G1Point* {
-    alloc_locals;
-    let (p_ptr: G1Point*) = alloc();
-
-    let (a_ptr: UInt384*) = alloc();
-    let (g_ptr: UInt384*) = alloc();
-    let (modulus_ptr: UInt384*) = alloc();
-    %{
-        segments.write_arg(ids.p_ptr.address_, program_input["p"])
-        segments.write_arg(ids.a_ptr.address_, program_input["a"])
-        segments.write_arg(ids.g_ptr.address_, program_input["g"])
-        segments.write_arg(ids.modulus_ptr.address_, program_input["modulus"])
-    %}
-
-    let res = ec_double([p_ptr], [g_ptr], [a_ptr], [modulus_ptr]);
-
-    tempvar res_ptr = new G1Point(
-        UInt384(res.x.d0, res.x.d1, res.x.d2, res.x.d3),
-        UInt384(res.y.d0, res.y.d1, res.y.d2, res.y.d3),
-    );
-    return res_ptr;
 }
 
 func test__ec_add{range_check96_ptr: felt*, add_mod_ptr: ModBuiltin*, mul_mod_ptr: ModBuiltin*}(

--- a/python/cairo-ec/tests/test_ec_ops.py
+++ b/python/cairo-ec/tests/test_ec_ops.py
@@ -65,64 +65,6 @@ class TestEcOps:
                 x**3 + curve.A * x + curve.B
             ) % curve.FIELD.PRIME == y**2 % curve.FIELD.PRIME
 
-    class TestEcDouble:
-        @given(seed=felt, curve=curve)
-        def test_ec_double(self, cairo_run, seed, curve):
-            point = cairo_run(
-                "test__get_random_point",
-                seed=seed,
-                a=int_to_uint384(int(curve.A)),
-                b=int_to_uint384(int(curve.B)),
-                g=int_to_uint384(int(curve.G)),
-                p=int_to_uint384(int(curve.FIELD.PRIME)),
-            )
-            x = curve.FIELD(
-                uint384_to_int(
-                    point["x"]["d0"],
-                    point["x"]["d1"],
-                    point["x"]["d2"],
-                    point["x"]["d3"],
-                )
-            )
-            y = curve.FIELD(
-                uint384_to_int(
-                    point["y"]["d0"],
-                    point["y"]["d1"],
-                    point["y"]["d2"],
-                    point["y"]["d3"],
-                )
-            )
-            double = cairo_run(
-                "test__ec_double",
-                p=(
-                    point["x"]["d0"],
-                    point["x"]["d1"],
-                    point["x"]["d2"],
-                    point["x"]["d3"],
-                    point["y"]["d0"],
-                    point["y"]["d1"],
-                    point["y"]["d2"],
-                    point["y"]["d3"],
-                ),
-                a=int_to_uint384(int(curve.A)),
-                g=int_to_uint384(int(curve.G)),
-                modulus=int_to_uint384(int(curve.FIELD.PRIME)),
-            )
-            assert curve(x, y).double() == curve(
-                uint384_to_int(
-                    double["x"]["d0"],
-                    double["x"]["d1"],
-                    double["x"]["d2"],
-                    double["x"]["d3"],
-                ),
-                uint384_to_int(
-                    double["y"]["d0"],
-                    double["y"]["d1"],
-                    double["y"]["d2"],
-                    double["y"]["d3"],
-                ),
-            )
-
     class TestEcAdd:
         @given(curve=curve)
         def test_ec_add(self, cairo_run, curve):

--- a/python/cairo-ec/tests/test_ec_ops.py
+++ b/python/cairo-ec/tests/test_ec_ops.py
@@ -81,3 +81,35 @@ class TestEcOps:
             assert p + q == curve(
                 *[curve.FIELD(uint384_to_int(**i)) for i in res.values()]
             )
+
+        @given(curve=curve)
+        def test_ec_add_equal(self, cairo_run, curve):
+            p = curve.random_point()
+            q = curve(p.x, p.y)
+            res = cairo_run(
+                "test__ec_add",
+                p=[*int_to_uint384(int(p.x)), *int_to_uint384(int(p.y))],
+                q=[*int_to_uint384(int(q.x)), *int_to_uint384(int(q.y))],
+                a=int_to_uint384(int(curve.A)),
+                g=int_to_uint384(int(curve.G)),
+                modulus=int_to_uint384(int(curve.FIELD.PRIME)),
+            )
+            assert p + q == curve(
+                *[curve.FIELD(uint384_to_int(**i)) for i in res.values()]
+            )
+
+        @given(curve=curve)
+        def test_ec_add_opposite(self, cairo_run, curve):
+            p = curve.random_point()
+            q = curve(p.x, -p.y)
+            res = cairo_run(
+                "test__ec_add",
+                p=[*int_to_uint384(int(p.x)), *int_to_uint384(int(p.y))],
+                q=[*int_to_uint384(int(q.x)), *int_to_uint384(int(q.y))],
+                a=int_to_uint384(int(curve.A)),
+                g=int_to_uint384(int(curve.G)),
+                modulus=int_to_uint384(int(curve.FIELD.PRIME)),
+            )
+            assert p + q == curve(
+                *[curve.FIELD(uint384_to_int(**i)) for i in res.values()]
+            )


### PR DESCRIPTION
Closes #707 

I've added 2 test cases to cover the checks of `ec_add` when Q = P and Q = -P