### PR TITLE
fix soundness in to_bytes

### DIFF
--- a/python/cairo-core/src/cairo_core/maths.cairo
+++ b/python/cairo-core/src/cairo_core/maths.cairo
@@ -410,12 +410,13 @@ func felt252_to_bytes_le{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}(
     jmp end if is_done != 0;
 
     with_attr error_message("felt252_to_bytes_le: byte not in bounds") {
-        assert [range_check_ptr] = 255 - output[idx];
+        assert [range_check_ptr] = output[idx];
+        assert [range_check_ptr + 1] = 255 - output[idx];
     }
     let pow256_idx = pow256(idx);
     tempvar current_value = output[idx] * pow256_idx;
 
-    tempvar range_check_ptr = range_check_ptr + 1;
+    tempvar range_check_ptr = range_check_ptr + 2;
     tempvar idx = idx + 1;
     tempvar acc = acc + current_value;
     jmp loop;
@@ -478,12 +479,13 @@ func felt252_to_bytes_be{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}(
     jmp end if is_done != 0;
 
     with_attr error_message("felt252_to_bytes_be: byte not in bounds") {
-        assert [range_check_ptr] = 255 - output[idx];
+        assert [range_check_ptr] = output[idx];
+        assert [range_check_ptr + 1] = 255 - output[idx];
     }
     let pow256_idx = pow256(len - 1 - idx);
     tempvar current_value = output[idx] * pow256_idx;
 
-    tempvar range_check_ptr = range_check_ptr + 1;
+    tempvar range_check_ptr = range_check_ptr + 2;
     tempvar idx = idx + 1;
     tempvar acc = acc + current_value;
     jmp loop;

--- a/python/cairo-core/src/cairo_core/maths.cairo
+++ b/python/cairo-core/src/cairo_core/maths.cairo
@@ -393,14 +393,14 @@ func felt252_to_bytes_le{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}(
         let range_check_ptr = range_check_ptr + 2;
     }
     let output = &dst[0];
-    let base = 256;
-    let bound = 256;
     %{ felt252_to_bytes_le %}
 
+    tempvar range_check_ptr = range_check_ptr;
     tempvar idx = 0;
     tempvar acc = 0;
 
     loop:
+    let range_check_ptr = [ap - 3];
     let idx = [ap - 2];
     let acc = [ap - 1];
     let is_done = is_zero(len - idx);
@@ -409,9 +409,13 @@ func felt252_to_bytes_le{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}(
     static_assert acc == [ap - 5];
     jmp end if is_done != 0;
 
+    with_attr error_message("felt252_to_bytes_le: byte not in bounds") {
+        assert [range_check_ptr] = 255 - output[idx];
+    }
     let pow256_idx = pow256(idx);
     tempvar current_value = output[idx] * pow256_idx;
 
+    tempvar range_check_ptr = range_check_ptr + 1;
     tempvar idx = idx + 1;
     tempvar acc = acc + current_value;
     jmp loop;
@@ -457,14 +461,14 @@ func felt252_to_bytes_be{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}(
         let range_check_ptr = range_check_ptr + 2;
     }
     let output = &dst[0];
-    let base = 256;
-    let bound = 256;
     %{ felt252_to_bytes_be %}
 
+    tempvar range_check_ptr = range_check_ptr;
     tempvar idx = 0;
     tempvar acc = 0;
 
     loop:
+    let range_check_ptr = [ap - 3];
     let idx = [ap - 2];
     let acc = [ap - 1];
     let is_done = is_zero(len - idx);
@@ -473,9 +477,13 @@ func felt252_to_bytes_be{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}(
     static_assert acc == [ap - 5];
     jmp end if is_done != 0;
 
+    with_attr error_message("felt252_to_bytes_be: byte not in bounds") {
+        assert [range_check_ptr] = 255 - output[idx];
+    }
     let pow256_idx = pow256(len - 1 - idx);
     tempvar current_value = output[idx] * pow256_idx;
 
+    tempvar range_check_ptr = range_check_ptr + 1;
     tempvar idx = idx + 1;
     tempvar acc = acc + current_value;
     jmp loop;

--- a/python/cairo-core/tests/src/cairo_core/test_maths.py
+++ b/python/cairo-core/tests/src/cairo_core/test_maths.py
@@ -95,12 +95,10 @@ segments.write_arg(ids.output, [int(b)+1 if b < 255 else 0 for b in truncated_va
         ), cairo_error(message="felt252_to_bytes_le: bad output"):
             cairo_run("test__felt252_to_bytes_le", value=value, len=len_)
 
-    @given(
-        value=st.integers(min_value=256, max_value=2**248 - 1),
-    )
     def test_felt252_to_bytes_le_should_panic_on_wrong_output_noncanonical(
-        self, cairo_program, cairo_run, value
+        self, cairo_program, cairo_run
     ):
+        value = 0xAABB
         len_ = 2
         with patch_hint(
             cairo_program,
@@ -164,12 +162,10 @@ segments.write_arg(ids.output, [int(b) + 1 if b < 255 else 0 for b in truncated_
         ), cairo_error(message="felt252_to_bytes_be: bad output"):
             cairo_run("test__felt252_to_bytes_be", value=value, len=len_)
 
-    @given(
-        value=st.integers(min_value=256, max_value=2**248 - 1),
-    )
     def test_felt252_to_bytes_be_should_panic_on_wrong_output_noncanonical(
-        self, cairo_program, cairo_run, value
+        self, cairo_program, cairo_run
     ):
+        value = 0xAABB
         len_ = 2
         with patch_hint(
             cairo_program,

--- a/python/cairo-core/tests/src/cairo_core/test_maths.py
+++ b/python/cairo-core/tests/src/cairo_core/test_maths.py
@@ -90,14 +90,39 @@ class TestMaths:
             """
 mask = (1 << (ids.len * 8)) - 1
 truncated_value = ids.value & mask
-segments.write_arg(ids.output, [int(b)+1 for b in truncated_value.to_bytes(length=ids.len, byteorder='little')])
+segments.write_arg(ids.output, [int(b)+1 if b < 255 else 0 for b in truncated_value.to_bytes(length=ids.len, byteorder='little')])
             """,
         ), cairo_error(message="felt252_to_bytes_le: bad output"):
             cairo_run("test__felt252_to_bytes_le", value=value, len=len_)
 
     @given(
-        value=st.integers(min_value=0, max_value=2**248 - 1),
-        len_=st.integers(min_value=1, max_value=31),
+        value=st.integers(min_value=256, max_value=2**248 - 1),
+    )
+    def test_felt252_to_bytes_le_should_panic_on_wrong_output_noncanonical(
+        self, cairo_program, cairo_run, value
+    ):
+        len_ = 2
+        with patch_hint(
+            cairo_program,
+            "felt252_to_bytes_le",
+            """
+mask = (1 << (ids.len * 8)) - 1
+truncated_value = ids.value & mask
+canonical = truncated_value.to_bytes(length=ids.len, byteorder='little')
+bad = list(canonical)
+if ids.len > 1 and canonical[1] > 0:
+    # Cheating: adjust the first two "bytes" so that the weighted sum is preserved,
+    # but the output is non-canonical (first byte is >= 256).
+    bad[0] = canonical[0] + 256
+    bad[1] = canonical[1] - 1
+segments.write_arg(ids.output, bad)
+            """,
+        ), cairo_error(message="felt252_to_bytes_le: byte not in bounds"):
+            cairo_run("test__felt252_to_bytes_le", value=value, len=len_)
+
+    @given(
+        value=st.integers(min_value=256, max_value=2**248 - 1),
+        len_=st.integers(min_value=2, max_value=31),
     )
     def test_felt252_to_bytes_be(self, cairo_run, value, len_):
         res = cairo_run("test__felt252_to_bytes_be", value=value, len=len_)
@@ -134,7 +159,32 @@ segments.write_arg(ids.output, [int(b)+1 for b in truncated_value.to_bytes(lengt
             """
 mask = (1 << (ids.len * 8)) - 1
 truncated_value = ids.value & mask
-segments.write_arg(ids.output, [int(b) + 1 for b in truncated_value.to_bytes(length=ids.len, byteorder='big')])
+segments.write_arg(ids.output, [int(b) + 1 if b < 255 else 0 for b in truncated_value.to_bytes(length=ids.len, byteorder='big')])
             """,
         ), cairo_error(message="felt252_to_bytes_be: bad output"):
+            cairo_run("test__felt252_to_bytes_be", value=value, len=len_)
+
+    @given(
+        value=st.integers(min_value=256, max_value=2**248 - 1),
+    )
+    def test_felt252_to_bytes_be_should_panic_on_wrong_output_noncanonical(
+        self, cairo_program, cairo_run, value
+    ):
+        len_ = 2
+        with patch_hint(
+            cairo_program,
+            "felt252_to_bytes_be",
+            """
+mask = (1 << (ids.len * 8)) - 1
+truncated_value = ids.value & mask
+canonical = truncated_value.to_bytes(length=ids.len, byteorder='big')
+bad = list(canonical)
+if ids.len > 1 and canonical[-2] > 0:
+    # Cheating: adjust the last two "bytes" so that the weighted sum remains preserved,
+    # but the output is non-canonical (one byte ends up >= 256).
+    bad[-1] = canonical[-1] + 256
+    bad[-2] = canonical[-2] - 1
+segments.write_arg(ids.output, bad)
+            """,
+        ), cairo_error(message="felt252_to_bytes_be: byte not in bounds"):
             cairo_run("test__felt252_to_bytes_be", value=value, len=len_)


### PR DESCRIPTION
The summation check in the function is necessary (and even quite clever) to verify that if you weight the provided “digits” (or bytes) by the base powers and add them up you get back the original value (or its lower bits). However, **this check by itself is not sufficient to guarantee that the output is the _canonical_ byte‐decomposition of the input**. Here’s why:

1. **Lack of Per‐Digit Range Enforcement:**  
   The reconstruction only checks that

$$
   \[
   \text{acc} = \sum_{i=0}^{\text{len}-1} (\text{output}[i] \times 256^i)
   \]
$$

   equals either the original value (if `len == 31`) or the value “masked” to the lower $\(256^{\text{len}}\)$ bits. This equality would be satisfied by many different choices of the `output` array if there were no constraints on an individual element. In a unique base‑256 representation, each byte must satisfy

$$
   \[
   0 \leq \text{output}[i] < 256
   \]
$$

   However, the code does not explicitly check that each `output[i]` falls in this range. Without this per‑digit range check, you might have a “non‑canonical” decomposition where, for example, one digit is larger than 255 but another digit is adjusted so that the overall weighted sum still equals the original value.

2. **The Bitwise Mask Step Isn’t Enough:**  
   In the branch where `len < 31`, the function computes

   ```cairo
   tempvar mask = pow256(idx) - 1;
   assert bitwise_ptr.x = value;
   assert bitwise_ptr.y = mask;
   tempvar value_masked = bitwise_ptr.x_and_y;
   with_attr error_message("felt252_to_bytes_le: bad output") {
       assert acc = value_masked;
   }
   ```

   This sequence checks that the reconstruction matches the lower `len` bytes of `value` (i.e. `value & (256^len - 1)`). But again, this only tests the aggregate value. It does not, by itself, enforce that the "digits" making up that aggregate were chosen from the unique set of values between 0 and 255.

3. **Canonical Representation Assumption:**  
   The uniqueness of the base‑256 representation (and hence the guarantee that the output is “correct”) relies on the assumption that each digit is already in the canonical range. If for any reason the code (or the hint in the `%{ felt252_to_bytes_le %}` section) does not enforce or assume that each byte is in \([0, 255]\), then the summation check alone does not rule out _alternative_ representations that would produce the same sum.

### Conclusion

To rule out non‑canonical decompositions, you would need explicit assertions like:

```cairo
    with_attr error_message("felt252_to_bytes_be: byte not in bounds") {
        assert [range_check_ptr] = 255 - output[idx];
    }
```

(performed for each index) to fully ensure that the decomposition is unique and correct.
