### PR TITLE
fix: hashdict_read hint should not skip zero values

### DIFF
--- a/cairo/ethereum/cancun/trie.cairo
+++ b/cairo/ethereum/cancun/trie.cairo
@@ -631,6 +631,7 @@ func trie_get_TrieBytes32U256{poseidon_ptr: PoseidonBuiltin*, trie: TrieBytes32U
 func trie_get_TrieBytesOptionalUnionBytesLegacyTransaction{
     poseidon_ptr: PoseidonBuiltin*, trie: TrieBytesOptionalUnionBytesLegacyTransaction
 }(key: Bytes) -> OptionalUnionBytesLegacyTransaction {
+    alloc_locals;
     let dict_ptr = cast(trie.value._data.value.dict_ptr, DictAccess*);
 
     let (pointer) = hashdict_read{dict_ptr=dict_ptr}(key.value.len, key.value.data);
@@ -660,6 +661,7 @@ func trie_get_TrieBytesOptionalUnionBytesLegacyTransaction{
 func trie_get_TrieBytesOptionalUnionBytesReceipt{
     poseidon_ptr: PoseidonBuiltin*, trie: TrieBytesOptionalUnionBytesReceipt
 }(key: Bytes) -> OptionalUnionBytesReceipt {
+    alloc_locals;
     let dict_ptr = cast(trie.value._data.value.dict_ptr, DictAccess*);
 
     let (pointer) = hashdict_read{dict_ptr=dict_ptr}(key.value.len, key.value.data);
@@ -687,6 +689,7 @@ func trie_get_TrieBytesOptionalUnionBytesReceipt{
 func trie_get_TrieBytesOptionalUnionBytesWithdrawal{
     poseidon_ptr: PoseidonBuiltin*, trie: TrieBytesOptionalUnionBytesWithdrawal
 }(key: Bytes) -> OptionalUnionBytesWithdrawal {
+    alloc_locals;
     let dict_ptr = cast(trie.value._data.value.dict_ptr, DictAccess*);
 
     let (pointer) = hashdict_read{dict_ptr=dict_ptr}(key.value.len, key.value.data);

--- a/cairo/ethereum/cancun/trie.cairo
+++ b/cairo/ethereum/cancun/trie.cairo
@@ -547,8 +547,11 @@ func trie_get_TrieAddressOptionalAccount{
     let fp_and_pc = get_fp_and_pc();
     local __fp__: felt* = fp_and_pc.fp_val;
 
-    with dict_ptr {
-        let (pointer) = hashdict_read(1, &key.value);
+    let (pointer) = hashdict_read{dict_ptr=dict_ptr}(1, &key.value);
+    if (pointer == 0) {
+        tempvar pointer = cast(trie.value.default.value, felt);
+    } else {
+        tempvar pointer = pointer;
     }
     let new_dict_ptr = cast(dict_ptr, AddressAccountDictAccess*);
     let parent_dict = trie.value._data.value.parent_dict;
@@ -567,6 +570,7 @@ func trie_get_TrieAddressOptionalAccount{
 func trie_get_TrieTupleAddressBytes32U256{
     poseidon_ptr: PoseidonBuiltin*, trie: TrieTupleAddressBytes32U256
 }(address: Address, key: Bytes32) -> U256 {
+    alloc_locals;
     let dict_ptr = cast(trie.value._data.value.dict_ptr, DictAccess*);
 
     let (keys) = alloc();
@@ -574,8 +578,11 @@ func trie_get_TrieTupleAddressBytes32U256{
     assert keys[1] = key.value.low;
     assert keys[2] = key.value.high;
 
-    with dict_ptr {
-        let (pointer) = hashdict_read(3, keys);
+    let (pointer) = hashdict_read{dict_ptr=dict_ptr}(3, keys);
+    if (pointer == 0) {
+        tempvar pointer = cast(trie.value.default.value, felt);
+    } else {
+        tempvar pointer = pointer;
     }
     let new_dict_ptr = cast(dict_ptr, TupleAddressBytes32U256DictAccess*);
     let parent_dict = trie.value._data.value.parent_dict;
@@ -594,14 +601,18 @@ func trie_get_TrieTupleAddressBytes32U256{
 func trie_get_TrieBytes32U256{poseidon_ptr: PoseidonBuiltin*, trie: TrieBytes32U256}(
     key: Bytes32
 ) -> U256 {
+    alloc_locals;
     let dict_ptr = cast(trie.value._data.value.dict_ptr, DictAccess*);
 
     let (keys) = alloc();
     assert keys[0] = key.value.low;
     assert keys[1] = key.value.high;
 
-    with dict_ptr {
-        let (pointer) = hashdict_read(2, keys);
+    let (pointer) = hashdict_read{dict_ptr=dict_ptr}(2, keys);
+    if (pointer == 0) {
+        tempvar pointer = cast(trie.value.default.value, felt);
+    } else {
+        tempvar pointer = pointer;
     }
     let new_dict_ptr = cast(dict_ptr, Bytes32U256DictAccess*);
     let parent_dict = trie.value._data.value.parent_dict;
@@ -622,8 +633,11 @@ func trie_get_TrieBytesOptionalUnionBytesLegacyTransaction{
 }(key: Bytes) -> OptionalUnionBytesLegacyTransaction {
     let dict_ptr = cast(trie.value._data.value.dict_ptr, DictAccess*);
 
-    with dict_ptr {
-        let (pointer) = hashdict_read(key.value.len, key.value.data);
+    let (pointer) = hashdict_read{dict_ptr=dict_ptr}(key.value.len, key.value.data);
+    if (pointer == 0) {
+        tempvar pointer = cast(trie.value.default.value, felt);
+    } else {
+        tempvar pointer = pointer;
     }
     let new_dict_ptr = cast(dict_ptr, BytesOptionalUnionBytesLegacyTransactionDictAccess*);
     let parent_dict = trie.value._data.value.parent_dict;
@@ -649,6 +663,11 @@ func trie_get_TrieBytesOptionalUnionBytesReceipt{
     let dict_ptr = cast(trie.value._data.value.dict_ptr, DictAccess*);
 
     let (pointer) = hashdict_read{dict_ptr=dict_ptr}(key.value.len, key.value.data);
+    if (pointer == 0) {
+        tempvar pointer = cast(trie.value.default.value, felt);
+    } else {
+        tempvar pointer = pointer;
+    }
     let new_dict_ptr = cast(dict_ptr, BytesOptionalUnionBytesReceiptDictAccess*);
     let parent_dict = trie.value._data.value.parent_dict;
     tempvar mapping = MappingBytesOptionalUnionBytesReceipt(
@@ -671,6 +690,11 @@ func trie_get_TrieBytesOptionalUnionBytesWithdrawal{
     let dict_ptr = cast(trie.value._data.value.dict_ptr, DictAccess*);
 
     let (pointer) = hashdict_read{dict_ptr=dict_ptr}(key.value.len, key.value.data);
+    if (pointer == 0) {
+        tempvar pointer = cast(trie.value.default.value, felt);
+    } else {
+        tempvar pointer = pointer;
+    }
     let new_dict_ptr = cast(dict_ptr, BytesOptionalUnionBytesWithdrawalDictAccess*);
     let parent_dict = trie.value._data.value.parent_dict;
     tempvar mapping = MappingBytesOptionalUnionBytesWithdrawal(

--- a/python/cairo-addons/src/cairo_addons/hints/hashdict.py
+++ b/python/cairo-addons/src/cairo_addons/hints/hashdict.py
@@ -13,7 +13,7 @@ def hashdict_read(dict_manager: DictManager, ids: VmConsts, memory: MemoryDict):
     preimage = tuple([memory[ids.key + i] for i in range(ids.key_len)])
     # Not using [] here because it will register the value for that key in the tracker.
     value = dict_tracker.data.get(preimage)
-    if value:
+    if value is not None:
         ids.value = value
     else:
         ids.value = dict_tracker.data.default_factory()
@@ -41,7 +41,7 @@ def hashdict_write(dict_manager: DictManager, ids: VmConsts, memory: MemoryDict)
     dict_tracker.current_ptr += ids.DictAccess.SIZE
     preimage = tuple([memory[ids.key + i] for i in range(ids.key_len)])
     prev_value = dict_tracker.data.get(preimage)
-    if prev_value:
+    if prev_value is not None:
         ids.dict_ptr.prev_value = prev_value
     else:
         ids.dict_ptr.prev_value = dict_tracker.data.default_factory()


### PR DESCRIPTION
The problem is that `if value` would return `False` if `value := 0`. But if we delete the entry in a trie (by writing 0), then the next read on the same (address, key) should be returning `0` as `prev_value`, not `default_factory()`. This caused an issue when squashing the storage_tries when computing the storage roots.