### PR TITLE
fix: iterate on squashed storage tries in storage roots computation

### DIFF
--- a/cairo/ethereum/cancun/state.cairo
+++ b/cairo/ethereum/cancun/state.cairo
@@ -970,8 +970,8 @@ func storage_roots{
     );
 
     build_map_addr_storage_trie{
-        map_addr_storage=map_addr_storage, storage_tries_ptr_end=storage_tries_end
-    }(storage_tries_start);
+        map_addr_storage=map_addr_storage, storage_tries_ptr_end=squashed_storage_tries_end
+    }(squashed_storage_tries_start);
 
     // Squash the Mapping[address, trie[bytes32, u256]] to iterate over each address
     let (squashed_map_addr_storage_start, squashed_map_addr_storage_end) = dict_squash(
@@ -1090,6 +1090,12 @@ func build_map_addr_storage_trie{
 
     if (storage_tries_ptr == storage_tries_ptr_end) {
         return ();
+    }
+
+    // Skip all None values, which are deleted trie entries. We don't need them to compute
+    // the storage roots.
+    if (cast(storage_tries_ptr.new_value, felt) == 0) {
+        return build_map_addr_storage_trie(storage_tries_ptr + DictAccess.SIZE);
     }
 
     let tup_address_b32 = get_tuple_address_bytes32_preimage_for_key(

--- a/cairo/ethereum/cancun/trie.cairo
+++ b/cairo/ethereum/cancun/trie.cairo
@@ -1148,6 +1148,8 @@ func _prepare_trie_inner_storage{
     }
 
     // Skip all None values, which are deleted trie entries
+    // Note: Considering that the given trie was built from the state._storage_tries of type
+    // Trie[Tuple[Address, Bytes32], U256], there should not be any None values remaining.
     if (dict_ptr.new_value.value == 0) {
         return _prepare_trie_inner_storage(
             trie, dict_ptr + Bytes32U256DictAccess.SIZE, mapping_ptr_end


### PR DESCRIPTION
The iteration was done on the the unsquashed tries, meaning that multiple entries would appear for the same address.