### PR TITLE
dev: expose `serialize` in RustVM pythonic hints

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -80,5 +80,6 @@
   "python.testing.pytestEnabled": true,
   "jupyter.notebookFileRoot": "${workspaceFolder}/cairo",
   "githubPullRequests.remotes": ["kakarot", "upstream"],
-  "cairols.sourceDir": "cairo"
+  "cairols.sourceDir": "cairo",
+  "rust-analyzer.cargo.features": "all"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4509,9 +4509,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd8dcafa1ca14750d8d7a05aa05988c17aab20886e1f3ae33a40223c58d92ef7"
+checksum = "e0f540e3240398cce6128b64ba83fdbdd86129c16a3aa1a3a252efd66eb3d587"
 dependencies = [
  "getrandom 0.3.1",
 ]

--- a/cairo/tests/conftest.py
+++ b/cairo/tests/conftest.py
@@ -77,6 +77,7 @@ def cairo_run(
     request,
     cairo_programs,
     rust_programs,
+    json_programs,
     cairo_files,
     main_paths,
     coverage,
@@ -116,6 +117,7 @@ def cairo_run(
     return run_rust_vm(
         cairo_programs,
         rust_programs,
+        json_programs,
         cairo_files,
         main_paths,
         request,

--- a/cairo/tests/test_serde.py
+++ b/cairo/tests/test_serde.py
@@ -63,7 +63,7 @@ def dict_manager():
 
 @pytest.fixture(scope="module")
 def serde(cairo_program, segments, dict_manager):
-    return Serde(segments, cairo_program, dict_manager)
+    return Serde(segments, cairo_program.identifiers, dict_manager)
 
 
 @pytest.fixture(scope="module")

--- a/crates/cairo-addons/src/vm/runner.rs
+++ b/crates/cairo-addons/src/vm/runner.rs
@@ -38,9 +38,10 @@ pub struct PyCairoRunner {
 #[pymethods]
 impl PyCairoRunner {
     #[new]
-    #[pyo3(signature = (program, layout=None, proof_mode=false, allow_missing_builtins=false))]
+    #[pyo3(signature = (program, json_program, layout=None, proof_mode=false, allow_missing_builtins=false))]
     fn new(
         program: &PyProgram,
+        json_program: &[u8],
         layout: Option<PyLayout>,
         proof_mode: bool,
         allow_missing_builtins: bool,
@@ -68,6 +69,11 @@ impl PyCairoRunner {
         // Insert the program identifiers in the exec_scopes, so that we're able to pull identifier
         // data when executing hints
         inner.exec_scopes.insert_value("__program_identifiers__", identifiers);
+
+        // Store the program JSON in the exec_scopes, so that we're able to pull pythonic identifier
+        // data when executing hints to instantiate Serde
+        let json_program_bytes: Vec<u8> = json_program.to_vec();
+        inner.exec_scopes.insert_value("__program_json__", json_program_bytes);
 
         Ok(Self {
             inner,

--- a/crates/cairo-addons/src/vm/vm_consts.rs
+++ b/crates/cairo-addons/src/vm/vm_consts.rs
@@ -702,8 +702,9 @@ pub fn create_vm_consts_dict(
                     } else {
                         // Case 3: The variable is a struct. In that case we return a PyVmConst
                         // that will load the struct members lazily when the variable is accessed.
-                        let address = get_ptr_from_var_name(name, vm, ids_data, ap_tracking)
-                            .unwrap_or(var_addr);
+                        let address =
+                            get_relocatable_from_var_name(name, vm, ids_data, ap_tracking)
+                                .unwrap_or(var_addr);
 
                         // Create a CairoVarType based on the type_str
                         let var_type = create_var_type(type_str, identifiers).map_err(|e| {

--- a/crates/cairo-addons/src/vm/vm_consts.rs
+++ b/crates/cairo-addons/src/vm/vm_consts.rs
@@ -420,6 +420,27 @@ impl PyVmConst {
         }
     }
 
+    /// Returns the path to the type of the variable
+    #[getter]
+    pub fn type_path(&self) -> Option<Vec<String>> {
+        match &self.var.var_type {
+            CairoVarType::Struct { name, .. } => {
+                Some(name.clone().split(".").map(|s| s.to_string()).collect())
+            }
+            CairoVarType::Pointer { pointee, .. } => match &**pointee {
+                CairoVarType::Struct { name, .. } => {
+                    Some(name.clone().split(".").map(|s| s.to_string()).collect())
+                }
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    fn is_pointer(&self) -> bool {
+        matches!(self.var.var_type, CairoVarType::Pointer { .. })
+    }
+
     /// Get the type name of the variable
     pub fn type_name(&self) -> String {
         match &self.var.var_type {
@@ -460,10 +481,9 @@ impl PyVmConst {
     /// Repr string
     pub fn __repr__(&self) -> String {
         format!(
-            "VmConst(name='{}', type={}, value={}, address={:?})",
+            "VmConst(name='{}', path={:?}, address={:?})",
             self.var.name,
-            self.type_name(),
-            self.__str__(),
+            self.type_path(),
             self.var.address
         )
     }

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -272,3 +272,4 @@ hasattr
 pathlib
 kwargs
 pythonic
+functools

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -269,3 +269,6 @@ mswlen
 xlen
 Turc
 hasattr
+pathlib
+kwargs
+pythonic

--- a/python/cairo-addons/src/cairo_addons/hints/injected.py
+++ b/python/cairo-addons/src/cairo_addons/hints/injected.py
@@ -1,0 +1,50 @@
+# A module that contains functions "injected" into the execution scope of hints in the Rust VM.
+# The purpose of these functions is to provide a way to serialize Cairo variables using Pythonic Hints running on the Rust VM.
+from typing import Callable
+
+
+def set_identifiers(context: Callable[[], dict]):
+    """Load program identifiers from JSON and store them in the provided context object."""
+    from starkware.cairo.lang.compiler.program import Program
+
+    __program_json__ = context().get("__program_json__")
+    if __program_json__ is None:
+        raise ValueError("__program_json__ must be available in the execution scope")
+
+    program = Program.Schema().loads(__program_json__)
+    context()["py_identifiers"] = program.identifiers
+
+
+def create_serializer(context: Callable[[], dict]):
+    """Create and register the serializer function in the provided context object."""
+
+    def serialize(variable, segments, program_identifiers, dict_manager):
+        """Serialize a Cairo variable using the Serde class."""
+
+        from tests.utils.serde import Serde
+
+        # Create Serde instance
+        serde_cls = Serde(
+            segments=segments,
+            program_identifiers=program_identifiers,
+            dict_manager=dict_manager,
+        )
+        if variable.is_pointer():
+            return serde_cls.serialize_pointers(
+                tuple(variable.type_path), variable.address_
+            )
+        return serde_cls.serialize_type(tuple(variable.type_path), variable.address_)
+
+    context()["serialize"] = serialize
+
+
+def initialize_hint_environment(context: Callable[[], dict]):
+    """Initialize the hint environment with all necessary components.
+
+    Args:
+        context: The context object to store the context variables in.
+    """
+    # First load identifiers
+    set_identifiers(context)
+    # Then create and register serializer
+    create_serializer(context)

--- a/python/cairo-addons/src/cairo_addons/testing/fixtures.py
+++ b/python/cairo-addons/src/cairo_addons/testing/fixtures.py
@@ -76,6 +76,14 @@ def rust_programs(cairo_programs: List[Program], python_vm: bool) -> List[RustPr
 
 
 @pytest.fixture(scope="module")
+def json_programs(cairo_programs: List[Program]) -> List[bytes]:
+    return [
+        json.dumps(cairo_program.Schema().dump(cairo_program)).encode()
+        for cairo_program in cairo_programs
+    ]
+
+
+@pytest.fixture(scope="module")
 def coverage(cairo_programs: List[Program], cairo_files: List[Path], worker_id: str):
     """
     Fixture to collect coverage from all tests, then merge and dump it as a json file for codecov.
@@ -186,6 +194,7 @@ def cairo_run_py(
 def cairo_run(
     cairo_programs,
     rust_programs,
+    json_programs,
     cairo_files,
     main_paths,
     request,
@@ -220,6 +229,7 @@ def cairo_run(
 
     return run_rust_vm(
         cairo_programs,
+        json_programs,
         rust_programs,
         cairo_files,
         main_paths,


### PR DESCRIPTION
Exposes a `serialize` function, available in the scope of all hints, that enables the serialization using `serde` of cairo types, and returns their python representation.

This can be used for the logging / tracing system.

I am welcoming any alternative idea on the currently proposed design - as working with python `globals()` has been quite a hassle.

Also, i'm not sure yet how we can make this entirely transparent with the pythonVM runs. If we realize there's a need for that, we can do it later.