### PR TITLE
fix: spelling issues 

### DIFF
--- a/cairo/ethereum/cancun/utils/message.cairo
+++ b/cairo/ethereum/cancun/utils/message.cairo
@@ -85,7 +85,7 @@ func prepare_message{
     let state = env.value.state;
     if (cast(target.value.bytes0, felt) != 0) {
         let caller_account = get_account{state=state}(caller);
-        // wont't underflow: the nonce of the caller is always incremented by 1 before `prepare_message`.
+        // won't underflow: the nonce of the caller is always incremented by 1 before `prepare_message`.
         let nonce = Uint(caller_account.value.nonce.value - 1);
         let current_target = compute_contract_address(caller, nonce);
 

--- a/cairo/ethereum/cancun/vm/instructions/system.cairo
+++ b/cairo/ethereum/cancun/vm/instructions/system.cairo
@@ -1509,7 +1509,7 @@ func selfdestruct{
     // Add additional gas cost if beneficiary not alive and originator has balance
     let is_new_account = (1 - beneficiary_is_alive.value) * (1 - originator_balance_zero);
     if (is_new_account != 0) {
-        // Wont't overflow as all components are < 25k
+        // Won't overflow as all components are < 25k
         tempvar final_gas_cost = Uint(gas_cost.value + GasConstants.GAS_SELF_DESTRUCT_NEW_ACCOUNT);
     } else {
         tempvar final_gas_cost = gas_cost;

--- a/cairo/ethereum/cancun/vm/precompiled_contracts/ripemd160.cairo
+++ b/cairo/ethereum/cancun/vm/precompiled_contracts/ripemd160.cairo
@@ -60,7 +60,7 @@ func ripemd160{
     let (local buf: felt*) = alloc();
     let (local arr_x: felt*) = alloc();
 
-    // Before starting fill arr_x with 0s to align on 32 bytes (hash length is 20bytes so 12 bytes to fill)
+    // Before starting fill arr_x with 0s to align on 32 bytes (hash length is 20 bytes so 12 bytes to fill)
     memset(arr_x, 0, 12);
     let arr_x: felt* = arr_x + 12;
 


### PR DESCRIPTION
cairo/ethereum/cancun/utils/message.cairo
wont't - `fix error`

cairo/ethereum/cancun/vm/instructions/system.cairo
Wont't - Won't - `fix error`

cairo/ethereum/cancun/vm/precompiled_contracts/ripemd160.cairo
20bytes - 20 bytes `fix missing space `