### PR TITLE
fix: missing stack rebind returndatacopy

### DIFF
--- a/cairo/ethereum/cancun/vm/instructions/environment.cairo
+++ b/cairo/ethereum/cancun/vm/instructions/environment.cairo
@@ -405,6 +405,7 @@ func returndatacopy{
         }
     }
     if (size.value.high != 0) {
+        EvmImpl.set_stack(stack);
         tempvar err = new EthereumException(OutOfGasError);
         return err;
     }


### PR DESCRIPTION
missing stack rebind on returndatacopy upon early return.