### PR TITLE
fix: account_has_storage in cases of destroyed storage

### DIFF
--- a/crates/cairo-addons/src/vm/hint_definitions/hashdict.rs
+++ b/crates/cairo-addons/src/vm/hint_definitions/hashdict.rs
@@ -250,17 +250,16 @@ pub fn get_storage_keys_for_address() -> Hint {
                     match key {
                         DictKey::Compound(key_parts) => {
                             // Chain Option methods instead of nested if lets
-                            value
-                                .get_int()
-                                .filter(|&v| v != Zero::zero())
-                                .and_then(|_| {
-                                    // Use if expression instead of if/else with None
-                                    if key_parts.len() >= prefix.len() && key_parts[..prefix.len()] == prefix[..] {
-                                        Some(key_parts)
-                                    } else {
-                                        None
-                                    }
-                                })
+                            value.get_int().filter(|&v| v != Zero::zero()).and_then(|_| {
+                                // Use if expression instead of if/else with None
+                                if key_parts.len() >= prefix.len() &&
+                                    key_parts[..prefix.len()] == prefix[..]
+                                {
+                                    Some(key_parts)
+                                } else {
+                                    None
+                                }
+                            })
                         }
                         _ => None,
                     }

--- a/crates/cairo-addons/src/vm/hint_definitions/hashdict.rs
+++ b/crates/cairo-addons/src/vm/hint_definitions/hashdict.rs
@@ -247,26 +247,22 @@ pub fn get_storage_keys_for_address() -> Hint {
                 .get_dictionary_ref()
                 .iter()
                 .filter_map(|(key, value)| {
-                    if let DictKey::Compound(key_parts) = key {
-                        let value = value.get_int();
-                        if let Some(value) = value {
-                            if value != Zero::zero() {
-                                // Check if values starts with prefix
-                                if key_parts.len() >= prefix.len() &&
-                                    key_parts[..prefix.len()] == prefix[..]
-                                {
-                                    Some(key_parts)
-                                } else {
-                                    None
-                                }
-                            } else {
-                                None
-                            }
-                        } else {
-                            None
+                    match key {
+                        DictKey::Compound(key_parts) => {
+                            // Chain Option methods instead of nested if lets
+                            value
+                                .get_int()
+                                .filter(|&v| v != Zero::zero())
+                                .and_then(|_| {
+                                    // Use if expression instead of if/else with None
+                                    if key_parts.len() >= prefix.len() && key_parts[..prefix.len()] == prefix[..] {
+                                        Some(key_parts)
+                                    } else {
+                                        None
+                                    }
+                                })
                         }
-                    } else {
-                        None
+                        _ => None,
                     }
                 })
                 .collect();

--- a/python/cairo-addons/src/cairo_addons/hints/hashdict.py
+++ b/python/cairo-addons/src/cairo_addons/hints/hashdict.py
@@ -82,6 +82,30 @@ def get_keys_for_address_prefix(
 
 
 @register_hint
+def get_storage_keys_for_address(
+    dict_manager: DictManager,
+    ids: VmConsts,
+    segments: MemorySegmentManager,
+    memory: MemoryDict,
+):
+    dict_tracker = dict_manager.get_tracker(ids.dict_ptr)
+    prefix = tuple([memory[ids.prefix + i] for i in range(ids.prefix_len)])
+    matching_preimages = [
+        key
+        for key, value in dict_tracker.data.items()
+        if key[: len(prefix)] == prefix and value != 0
+    ]
+    base = segments.add()
+    for i, preimage in enumerate(matching_preimages):
+        ptr = segments.add()
+        bytes32_base = segments.add()
+        segments.write_arg(bytes32_base, preimage[1:])
+        segments.write_arg(ptr, [preimage[0], bytes32_base])
+        memory[base + i] = ptr
+    ids.keys_len = len(matching_preimages)
+    ids.keys = base
+
+
 def get_preimage_for_key(
     dict_manager: DictManager, ids: VmConsts, segments: MemorySegmentManager
 ):


### PR DESCRIPTION
This is a rough patch of this issue by adding another hint that filtrates for zero values. This is not the definitive design, which will be refactored to handle proofs of non-inclusion.

This is the same as get_keys_for_address_prefix, only we do not collect zero-values.

Closes #924 