### PR TITLE
Fix Typos and Improve Readability in Documentation and Code Comments

### DIFF
--- a/.cursor/rules/common_patterns.mdc
+++ b/.cursor/rules/common_patterns.mdc
@@ -26,7 +26,7 @@ struct BytesStruct {
 
 ## OOP Features
 - We use a rust-like approach where we define a type (e.g. `Evm`) and an "impl" (e.g. EvmImpl)
-- The "impl" is simply a `namespace EvmImpl` with a collections of functions associated to the type.
+- The "impl" is simply a `namespace EvmImpl` with a collection of functions associated to the type.
 - Avoid manipulating low-level Cairo: Use methods and types as much as possible
 
 Example in @evm_impl.cairo:

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ directory.
 uv run pytest <optional pytest args>
 ```
 
-Some tests require to compile solidity code, which requires `forge` to be
+Some tests require compile solidity code, which requires `forge` to be
 installed, and `foundry` to be in the path, and to run `forge build`.
 
 #### Ethereum Foundation Tests
@@ -118,7 +118,7 @@ uv run --reinstall <command>
 ```
 
 Forgetting the `--reinstall` flag will not re-build the python package and
-consequentially not use any changes to the rust code.
+consequently not use any changes to the rust code.
 
 ## Status
 


### PR DESCRIPTION
Typo Fix: "a collections" → "a collection"

Before: The "impl" is simply a namespace EvmImpl with a collections of functions associated to the type.
After: The "impl" is simply a namespace EvmImpl with a collection of functions associated to the type.
Reason: "Collections" is a plural noun, but the sentence structure requires the singular form "collection."
Grammar Fix: "require to compile" → "require compile"

Before: Some tests require to compile Solidity code, which requires forge to be installed.
After: Some tests require compile Solidity code, which requires forge to be installed.
Reason: The verb "require" should be followed by a noun phrase (i.e., "require compilation") or a bare infinitive verb (i.e., "require compile").
Word Choice Fix: "consequentially" → "consequently"

Before: Forgetting the --reinstall flag will not re-build the Python package and consequentially not use any changes to the Rust code.
After: Forgetting the --reinstall flag will not re-build the Python package and consequently not use any changes to the Rust code.
Reason: "Consequentially" means "in a way that is a consequence of something," whereas "consequently" means "as a result." The latter is correct in this context.
