### PR TITLE
feat: enable proof mode in Rust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ data
 
 *.trace
 *.air_public_input.json
+*.air_private_input.json
+*.memory

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ cairo/tests/ef_tests/fixtures/
 
 # zk-pig default output directory
 data
+
+*.trace
+*.air_public_input.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,6 +623,7 @@ dependencies = [
 [[package]]
 name = "cairo-vm"
 version = "2.0.0"
+source = "git+https://github.com/kkrt-labs/cairo-vm?rev=af22b7189f3ebf0f225711d58be133d217b0a3d8#af22b7189f3ebf0f225711d58be133d217b0a3d8"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,8 +622,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-vm"
-version = "2.0.0-rc5"
-source = "git+https://github.com/kkrt-labs/cairo-vm?rev=016fc91e5c45f2baa7250e908593588f8bd900c2#016fc91e5c45f2baa7250e908593588f8bd900c2"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -657,6 +656,7 @@ dependencies = [
 name = "cairo_addons"
 version = "0.1.0"
 dependencies = [
+ "bincode",
  "cairo-vm",
  "garaga_rs",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,10 +56,5 @@ cairo-vm = { git = "https://github.com/lambdaclass/cairo-vm.git", tag = "v2.0.0-
   "mod_builtin",
 ] }
 
-# cairo-vm = { path = "../../deps/cairo-vm/vm", features = [
-#   "test_utils",
-#   "mod_builtin",
-# ] }
-
 [patch."https://github.com/lambdaclass/cairo-vm.git"]
 cairo-vm = { git = "https://github.com/kkrt-labs/cairo-vm", rev = "af22b7189f3ebf0f225711d58be133d217b0a3d8" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,15 +51,15 @@ thiserror = "1.0"
 url = "2.5"
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 
-# cairo-vm = { git = "https://github.com/lambdaclass/cairo-vm.git", tag = "v2.0.0-rc5", features = [
-#   "test_utils",
-#   "mod_builtin",
-# ] }
-
-cairo-vm = { path = "../../deps/cairo-vm/vm", features = [
+cairo-vm = { git = "https://github.com/lambdaclass/cairo-vm.git", tag = "v2.0.0-rc5", features = [
   "test_utils",
   "mod_builtin",
 ] }
 
-# [patch."https://github.com/lambdaclass/cairo-vm.git"]
-# cairo-vm = { git = "https://github.com/kkrt-labs/cairo-vm", rev = "016fc91e5c45f2baa7250e908593588f8bd900c2" }
+# cairo-vm = { path = "../../deps/cairo-vm/vm", features = [
+#   "test_utils",
+#   "mod_builtin",
+# ] }
+
+[patch."https://github.com/lambdaclass/cairo-vm.git"]
+cairo-vm = { git = "https://github.com/kkrt-labs/cairo-vm", rev = "af22b7189f3ebf0f225711d58be133d217b0a3d8" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,11 +51,15 @@ thiserror = "1.0"
 url = "2.5"
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 
-cairo-vm = { git = "https://github.com/lambdaclass/cairo-vm.git", tag = "v2.0.0-rc5", features = [
+# cairo-vm = { git = "https://github.com/lambdaclass/cairo-vm.git", tag = "v2.0.0-rc5", features = [
+#   "test_utils",
+#   "mod_builtin",
+# ] }
+
+cairo-vm = { path = "../../deps/cairo-vm/vm", features = [
   "test_utils",
   "mod_builtin",
 ] }
 
-
-[patch."https://github.com/lambdaclass/cairo-vm.git"]
-cairo-vm = { git = "https://github.com/kkrt-labs/cairo-vm", rev = "016fc91e5c45f2baa7250e908593588f8bd900c2" }
+# [patch."https://github.com/lambdaclass/cairo-vm.git"]
+# cairo-vm = { git = "https://github.com/kkrt-labs/cairo-vm", rev = "016fc91e5c45f2baa7250e908593588f8bd900c2" }

--- a/cairo/tests/ethereum/cancun/vm/test_runtime.cairo
+++ b/cairo/tests/ethereum/cancun/vm/test_runtime.cairo
@@ -10,7 +10,7 @@ from ethereum.cancun.vm.runtime import (
 )
 from legacy.utils.dict import dict_squash
 
-func test__get_valid_jump_destinations{range_check_ptr}(output_ptr: felt*) {
+func test__get_valid_jump_destinations{range_check_ptr}() -> felt* {
     alloc_locals;
 
     tempvar bytecode_len;
@@ -26,9 +26,10 @@ func test__get_valid_jump_destinations{range_check_ptr}(output_ptr: felt*) {
     let valid_jumpdests = get_valid_jump_destinations(code);
     let valid_jumpdests_ptr = valid_jumpdests.value.dict_ptr;
 
-    %{ segments.write_arg(ids.output_ptr, {k[0]: v for k, v in __dict_manager.get_dict(ids.valid_jumpdests_ptr).items()}) %}
+    let (output) = alloc();
+    %{ segments.write_arg(ids.output, {k[0]: v for k, v in __dict_manager.get_dict(ids.valid_jumpdests_ptr).items()}) %}
 
-    return ();
+    return output;
 }
 
 func test__finalize_jumpdests{range_check_ptr}() {

--- a/cairo/tests/legacy/utils/test_array.cairo
+++ b/cairo/tests/legacy/utils/test_array.cairo
@@ -5,29 +5,16 @@ from starkware.cairo.common.uint256 import Uint256
 from starkware.cairo.common.alloc import alloc
 
 from legacy.utils.array import reverse, count_not_zero
+from cairo_core.bytes import Bytes
 
-func test__reverse(output_ptr: felt*) {
+func test__reverse(data: Bytes) -> felt* {
     alloc_locals;
-    tempvar arr_len: felt;
-    let (arr) = alloc();
-    %{
-        ids.arr_len = len(program_input["arr"])
-        segments.write_arg(ids.arr, program_input["arr"])
-    %}
-
-    reverse(output_ptr, arr_len, arr);
-    return ();
+    let (output) = alloc();
+    reverse(output, data.value.len, data.value.data);
+    return output;
 }
 
-func test__count_not_zero(output_ptr: felt*) {
-    tempvar arr_len: felt;
-    let (arr) = alloc();
-    %{
-        ids.arr_len = len(program_input["arr"])
-        segments.write_arg(ids.arr, program_input["arr"])
-    %}
-
-    let count = count_not_zero(arr_len, arr);
-    assert [output_ptr] = count;
-    return ();
+func test__count_not_zero(data: Bytes) -> felt {
+    let count = count_not_zero(data.value.len, data.value.data);
+    return count;
 }

--- a/cairo/tests/legacy/utils/test_array.py
+++ b/cairo/tests/legacy/utils/test_array.py
@@ -1,7 +1,5 @@
 import pytest
 
-pytestmark = pytest.mark.python_vm
-
 
 class TestArray:
     class TestReverse:
@@ -17,7 +15,7 @@ class TestArray:
             ],
         )
         def test_should_return_reversed_array(self, cairo_run, arr):
-            output = cairo_run("test__reverse", arr=arr)
+            output = cairo_run("test__reverse", data=bytes(arr))
             assert arr[::-1] == (output if isinstance(output, list) else [output])
 
     class TestCountNotZero:
@@ -33,5 +31,5 @@ class TestArray:
             ],
         )
         def test_should_return_count_of_non_zero_elements(self, cairo_run, arr):
-            output = cairo_run("test__count_not_zero", arr=arr)
+            output = cairo_run("test__count_not_zero", data=bytes(arr))
             assert len(arr) - arr.count(0) == output

--- a/cairo/tests/legacy/utils/test_bytes_legacy.cairo
+++ b/cairo/tests/legacy/utils/test_bytes_legacy.cairo
@@ -3,6 +3,9 @@
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.uint256 import Uint256
 
+from cairo_core.numeric import U256
+from cairo_core.bytes import Bytes
+
 from legacy.utils.bytes import (
     felt_to_bytes_little,
     felt_to_bytes,
@@ -14,95 +17,58 @@ from legacy.utils.bytes import (
     bytes_to_felt_le,
 )
 
-func test__felt_to_bytes_little{range_check_ptr}() -> felt* {
+func test__felt_to_bytes_little{range_check_ptr}(n: felt) -> felt* {
     alloc_locals;
-    tempvar n: felt;
-    %{ ids.n = program_input["n"] %}
 
     let (output) = alloc();
     felt_to_bytes_little(output, n);
     return output;
 }
 
-func test__felt_to_bytes{range_check_ptr}(output_ptr: felt*) {
+func test__felt_to_bytes{range_check_ptr}(n: felt) -> felt* {
     alloc_locals;
-    tempvar n: felt;
-    %{ ids.n = program_input["n"] %}
-
-    felt_to_bytes(output_ptr, n);
-    return ();
+    let (output) = alloc();
+    felt_to_bytes(output, n);
+    return output;
 }
 
-func test__uint256_to_bytes_little{range_check_ptr}(output_ptr: felt*) {
+func test__uint256_to_bytes_little{range_check_ptr}(n: U256) -> felt* {
     alloc_locals;
-    tempvar n: Uint256;
-    %{
-        ids.n.low = program_input["n"][0]
-        ids.n.high = program_input["n"][1]
-    %}
-
-    uint256_to_bytes_little(output_ptr, n);
-    return ();
+    let (output) = alloc();
+    uint256_to_bytes_little(output, [n.value]);
+    return output;
 }
 
-func test__uint256_to_bytes{range_check_ptr}(output_ptr: felt*) {
+func test__uint256_to_bytes{range_check_ptr}(n: U256) -> felt* {
     alloc_locals;
-    tempvar n: Uint256;
-    %{
-        ids.n.low = program_input["n"][0]
-        ids.n.high = program_input["n"][1]
-    %}
-
-    uint256_to_bytes(output_ptr, n);
-    return ();
+    let (output) = alloc();
+    uint256_to_bytes(output, [n.value]);
+    return output;
 }
 
-func test__uint256_to_bytes32{range_check_ptr}(output_ptr: felt*) {
+func test__uint256_to_bytes32{range_check_ptr}(n: U256) -> felt* {
     alloc_locals;
-    tempvar n: Uint256;
-    %{
-        ids.n.low = program_input["n"][0]
-        ids.n.high = program_input["n"][1]
-    %}
-
-    uint256_to_bytes32(output_ptr, n);
-    return ();
+    let (output) = alloc();
+    uint256_to_bytes32(output, [n.value]);
+    return output;
 }
 
-func test__bytes_to_bytes8_little_endian{range_check_ptr}() -> felt* {
+func test__bytes_to_bytes8_little_endian{range_check_ptr}(bytes: Bytes) -> felt* {
     alloc_locals;
-    tempvar bytes_len: felt;
-    let (bytes) = alloc();
-    %{
-        ids.bytes_len = len(program_input["bytes"])
-        segments.write_arg(ids.bytes, program_input["bytes"])
-    %}
-
     let (bytes8) = alloc();
-    bytes_to_bytes8_little_endian(bytes8, bytes_len, bytes);
+    bytes_to_bytes8_little_endian(bytes8, bytes.value.len, bytes.value.data);
 
     return bytes8;
 }
 
-func test__bytes_to_felt() -> felt {
-    tempvar len;
-    let (ptr) = alloc();
-    %{
-        ids.len = len(program_input["data"])
-        segments.write_arg(ids.ptr, program_input["data"])
-    %}
-    let res = bytes_to_felt(len, ptr);
+func test__bytes_to_felt(bytes: Bytes) -> felt {
+    alloc_locals;
+    let res = bytes_to_felt(bytes.value.len, bytes.value.data);
     return res;
 }
 
-func test__bytes_to_felt_le() -> felt {
+func test__bytes_to_felt_le(bytes: Bytes) -> felt {
     alloc_locals;
-    tempvar len;
-    let (ptr) = alloc();
-    %{
-        ids.len = len(program_input["data"])
-        segments.write_arg(ids.ptr, program_input["data"])
-    %}
-    let res = bytes_to_felt_le(len, ptr);
+    let res = bytes_to_felt_le(bytes.value.len, bytes.value.data);
     return res;
 }

--- a/cairo/tests/legacy/utils/test_utils.cairo
+++ b/cairo/tests/legacy/utils/test_utils.cairo
@@ -20,14 +20,7 @@ func test__bytes_to_uint256{range_check_ptr}() -> Uint256 {
     return res;
 }
 
-func test__bytes_used_128{range_check_ptr}(output_ptr: felt*) {
-    tempvar word;
-    %{ ids.word = program_input["word"] %}
-
-    // When
+func test__bytes_used_128{range_check_ptr}(word: felt) -> felt {
     let bytes_used = Helpers.bytes_used_128(word);
-
-    // Then
-    assert [output_ptr] = bytes_used;
-    return ();
+    return bytes_used;
 }

--- a/crates/cairo-addons/Cargo.toml
+++ b/crates/cairo-addons/Cargo.toml
@@ -34,6 +34,7 @@ pyo3-polars = "0.20.0"
 thiserror = "2.0"
 bincode = { version = "2.0.0-rc.3", default-features = false, features = [
   "serde",
+  "alloc",
 ] }
 
 [build-dependencies]

--- a/crates/cairo-addons/Cargo.toml
+++ b/crates/cairo-addons/Cargo.toml
@@ -34,7 +34,6 @@ pyo3-polars = "0.20.0"
 thiserror = "2.0"
 bincode = { version = "2.0.0-rc.3", default-features = false, features = [
   "serde",
-  "alloc",
 ] }
 
 [build-dependencies]

--- a/crates/cairo-addons/Cargo.toml
+++ b/crates/cairo-addons/Cargo.toml
@@ -32,6 +32,9 @@ garaga_rs = { git = "https://github.com/keep-starknet-strange/garaga.git", tag =
 polars = { version = "0.46" }
 pyo3-polars = "0.20.0"
 thiserror = "2.0"
+bincode = { version = "2.0.0-rc.3", default-features = false, features = [
+  "serde",
+] }
 
 [build-dependencies]
 pyo3-build-config = "0.23.3" # Should match pyo3 version

--- a/crates/cairo-addons/src/vm/program.rs
+++ b/crates/cairo-addons/src/vm/program.rs
@@ -7,8 +7,6 @@ use pyo3::prelude::*;
 
 use crate::vm::builtins::PyBuiltinList;
 
-use super::maybe_relocatable::PyMaybeRelocatable;
-
 #[pyclass(name = "Program")]
 pub struct PyProgram {
     pub(crate) inner: RustProgram,
@@ -45,15 +43,5 @@ impl PyProgram {
             .into_builtin_names()
             .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
         Ok(())
-    }
-
-    #[getter]
-    fn data_length(&self) -> usize {
-        self.inner.shared_program_data.data.len()
-    }
-
-    #[getter]
-    fn data(&self) -> Vec<PyMaybeRelocatable> {
-        self.inner.shared_program_data.data.iter().map(|x| x.clone().into()).collect()
     }
 }

--- a/crates/cairo-addons/src/vm/program.rs
+++ b/crates/cairo-addons/src/vm/program.rs
@@ -7,6 +7,8 @@ use pyo3::prelude::*;
 
 use crate::vm::builtins::PyBuiltinList;
 
+use super::maybe_relocatable::PyMaybeRelocatable;
+
 #[pyclass(name = "Program")]
 pub struct PyProgram {
     pub(crate) inner: RustProgram,
@@ -43,5 +45,15 @@ impl PyProgram {
             .into_builtin_names()
             .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
         Ok(())
+    }
+
+    #[getter]
+    fn data_length(&self) -> usize {
+        self.inner.shared_program_data.data.len()
+    }
+
+    #[getter]
+    fn data(&self) -> Vec<PyMaybeRelocatable> {
+        self.inner.shared_program_data.data.iter().map(|x| x.clone().into()).collect()
     }
 }

--- a/crates/cairo-addons/src/vm/runner.rs
+++ b/crates/cairo-addons/src/vm/runner.rs
@@ -1,13 +1,14 @@
-use std::{cell::RefCell, collections::HashMap, rc::Rc};
-
+use super::{
+    dict_manager::PyDictManager, hints::HintProcessor, memory_segments::PyMemorySegmentManager,
+};
 use crate::vm::{
     layout::PyLayout, maybe_relocatable::PyMaybeRelocatable, program::PyProgram,
     relocatable::PyRelocatable, relocated_trace::PyRelocatedTraceEntry,
     run_resources::PyRunResources,
 };
-use bincode::enc::write::SliceWriter;
+use bincode::enc::write::Writer;
 use cairo_vm::{
-    cairo_run::write_encoded_trace,
+    cairo_run::{write_encoded_memory, write_encoded_trace},
     hint_processor::builtin_hint_processor::dict_manager::DictManager,
     serde::deserialize_program::Identifier,
     types::{
@@ -15,7 +16,7 @@ use cairo_vm::{
         relocatable::{MaybeRelocatable, Relocatable},
     },
     vm::{
-        errors::{runner_errors::RunnerError, vm_exception::VmException},
+        errors::vm_exception::VmException,
         runners::{builtin_runner::BuiltinRunner, cairo_runner::CairoRunner as RustCairoRunner},
         security::verify_secure_runner,
     },
@@ -27,10 +28,13 @@ use pyo3::{
     types::{IntoPyDict, PyDict},
 };
 use pyo3_polars::PyDataFrame;
-use std::ffi::CString;
-
-use super::{
-    dict_manager::PyDictManager, hints::HintProcessor, memory_segments::PyMemorySegmentManager,
+use std::{
+    cell::RefCell,
+    collections::HashMap,
+    ffi::CString,
+    io::{self, Write},
+    path::PathBuf,
+    rc::Rc,
 };
 
 #[pyclass(name = "CairoRunner", unsendable)]
@@ -154,57 +158,51 @@ except Exception as e:
     }
 
     /// Initialize the runner with the given stack and entrypoint offset.
-    #[pyo3(signature = (stack, entrypoint, ordered_builtins=None))]
+    #[pyo3(signature = (stack, entrypoint))]
     pub fn initialize_vm(
         &mut self,
         stack: Vec<PyMaybeRelocatable>,
         entrypoint: usize,
-        ordered_builtins: Option<Vec<String>>,
-    ) -> PyResult<PyRelocatable> {
-        let initial_stack = self.builtins_stack(ordered_builtins)?;
-        let stack: Vec<MaybeRelocatable> = initial_stack
-            .into_iter()
-            .chain(stack.into_iter().map(|x| x.into()))
-            .collect::<Vec<_>>();
+    ) -> PyResult<()> {
+        // let stack: Vec<MaybeRelocatable> = stack.into_iter().map(|x| x.into()).collect();
 
-        // canonical offset should be 2 for Cairo 0
-        let target_offset: usize = 2;
-        let execution_base = self.inner.execution_base.ok_or(RunnerError::NoExecBase).unwrap();
-        let return_fp = Into::<MaybeRelocatable>::into((execution_base + target_offset).unwrap());
-        let end = ((self.inner.program_base.unwrap() +
-            self.inner.get_program().shared_program_data.data.len())
-        .unwrap() -
-            2)
-        .unwrap();
-        println!("end: {:?}", end);
-        // stack = [return_fp, end] + stack + [return_fp, end]
-        let mut stack_with_prefix = vec![return_fp.clone(), end.into()];
-        stack_with_prefix.extend(stack.clone());
-        stack_with_prefix.extend(vec![return_fp, end.into()]);
-        self.inner.execution_public_memory = Some(Vec::from_iter(0..stack_with_prefix.len()));
-        println!("stack_with_prefix: {:?}", stack_with_prefix);
+        // // canonical offset for proof mode in cairo 0
+        // let target_offset: usize = 2;
+        // let execution_base = self
+        //     .inner
+        //     .execution_base
+        //     .ok_or(RunnerError::NoExecBase)
+        //     .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+        // let return_fp = (execution_base + target_offset).unwrap();
+        // let end = ((self.inner.program_base.unwrap() +
+        //     self.inner.get_program().shared_program_data.data.len())
+        // .unwrap() -
+        //     target_offset)
+        //     .unwrap();
 
-        self.inner.initial_pc = Some((self.inner.program_base.unwrap() + entrypoint).unwrap());
-        //TODO: cloning here is bad but i don't know how to do it otherwise
-        let program = self.inner.get_program().shared_program_data.data.clone();
-        self.inner.vm.load_data(self.inner.program_base.unwrap(), &program).unwrap();
-        // // Mark all addresses from the program segment as accessed
-        // for i in 0..self.inner.get_program().shared_program_data.data.len() {
-        //     self.inner.vm.segments.memory.mark_as_accessed((self.inner.program_base.unwrap() +
-        // i).unwrap()); }
+        // let mut stack_with_prefix: Vec<MaybeRelocatable> =
+        //     vec![return_fp.clone().into(), end.into()];
+        // stack_with_prefix.extend(stack);
+        // stack_with_prefix.extend(vec![return_fp.clone().into(), end.into()]);
+        // self.inner.execution_public_memory = Some(Vec::from_iter(0..stack_with_prefix.len()));
 
-        self.inner.vm.load_data(self.inner.execution_base.unwrap(), &stack_with_prefix).unwrap();
+        // self.inner.initial_pc = Some((self.inner.program_base.unwrap() + entrypoint).unwrap());
+        // let program = self.inner.get_program().shared_program_data.data.clone();
+        // self.inner
+        //     .vm
+        //     .load_data(self.inner.program_base.unwrap(), &program)
+        //     .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+        // // // Mark all addresses from the program segment as accessed
+        // // for i in 0..self.inner.get_program().shared_program_data.data.len() {
+        // //     self.inner.vm.segments.memory.mark_as_accessed((self.inner.program_base.unwrap() +
+        // // i).unwrap()); }
+        // self.inner
+        //     .vm
+        //     .load_data(self.inner.execution_base.unwrap(), &stack_with_prefix)
+        //     .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
 
-        self.inner.initial_fp =
-            Some((self.inner.execution_base.unwrap() + stack_with_prefix.len()).unwrap());
-        self.inner.initial_ap = self.inner.initial_fp;
-        // self.inner.final_pc = Some(end);
-
-        println!(
-            "initial ap, pc, fp: {:?}, {:?}, {:?}",
-            self.inner.initial_ap, self.inner.initial_pc, self.inner.initial_fp
-        );
-        println!("final pc: {:?}", self.inner.final_pc);
+        // self.inner.initial_fp = Some((execution_base + stack_with_prefix.len()).unwrap());
+        // self.inner.initial_ap = self.inner.initial_fp;
 
         for builtin_runner in self.inner.vm.builtin_runners.iter_mut() {
             if let BuiltinRunner::Mod(runner) = builtin_runner {
@@ -215,7 +213,37 @@ except Exception as e:
             .initialize_vm()
             .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
 
-        Ok(PyRelocatable { inner: end })
+        Ok(())
+    }
+
+    #[getter]
+    fn initial_pc(&self) -> Option<PyRelocatable> {
+        self.inner.initial_pc.map(|x| PyRelocatable { inner: x })
+    }
+
+    #[setter]
+    fn set_initial_pc(&mut self, value: Option<PyRelocatable>) {
+        self.inner.initial_pc = value.map(|x| x.inner);
+    }
+
+    #[getter]
+    fn initial_ap(&self) -> Option<PyRelocatable> {
+        self.inner.initial_ap.map(|x| PyRelocatable { inner: x })
+    }
+
+    #[setter]
+    fn set_initial_ap(&mut self, value: Option<PyRelocatable>) {
+        self.inner.initial_ap = value.map(|x| x.inner);
+    }
+
+    #[getter]
+    fn initial_fp(&self) -> Option<PyRelocatable> {
+        self.inner.initial_fp.map(|x| PyRelocatable { inner: x })
+    }
+
+    #[setter]
+    fn set_initial_fp(&mut self, value: Option<PyRelocatable>) {
+        self.inner.initial_fp = value.map(|x| x.inner);
     }
 
     #[getter]
@@ -223,33 +251,65 @@ except Exception as e:
         self.inner.program_base.map(|x| PyRelocatable { inner: x })
     }
 
+    #[setter]
+    fn set_program_base(&mut self, value: Option<PyRelocatable>) {
+        self.inner.program_base = value.map(|x| x.inner);
+    }
+
     #[getter]
     fn execution_base(&self) -> Option<PyRelocatable> {
-        // execution_base is not stored but we know it's created right after program_base
-        // during initialize_segments(None), so we can derive it by incrementing the segment_index
-        self.inner.program_base.map(|x| PyRelocatable {
-            inner: Relocatable { segment_index: x.segment_index + 1, offset: 0 },
-        })
+        self.inner.execution_base.map(|x| PyRelocatable { inner: x })
+    }
+
+    #[setter]
+    fn set_execution_base(&mut self, value: Option<PyRelocatable>) {
+        self.inner.execution_base = value.map(|x| x.inner);
     }
 
     #[getter]
-    fn ap(&self) -> PyRelocatable {
-        PyRelocatable { inner: self.inner.vm.get_ap() }
+    fn execution_public_memory(&self) -> Option<Vec<usize>> {
+        self.inner.execution_public_memory.clone()
     }
 
-    #[getter]
-    fn fp(&self) -> PyRelocatable {
-        PyRelocatable { inner: self.inner.vm.get_fp() }
-    }
-
-    #[getter]
-    fn pc(&self) -> PyRelocatable {
-        PyRelocatable { inner: self.inner.vm.get_pc() }
+    #[setter]
+    fn set_execution_public_memory(&mut self, value: Option<Vec<usize>>) {
+        self.inner.execution_public_memory = value;
     }
 
     #[getter]
     fn segments(&mut self) -> PyMemorySegmentManager {
         PyMemorySegmentManager { vm: &mut self.inner.vm }
+    }
+
+    fn load_data(&mut self, base: PyRelocatable, data: Vec<PyMaybeRelocatable>) -> PyResult<()> {
+        let data: Vec<MaybeRelocatable> = data.into_iter().map(|x| x.into()).collect();
+        self.inner
+            .vm
+            .load_data(base.inner, &data)
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+        Ok(())
+    }
+
+    fn load_program_data(&mut self, base: PyRelocatable) -> PyResult<()> {
+        // Avoid borrow-checker issues by using a raw pointer to the data.
+        let program = self.inner.get_program();
+        let data_ptr = &program.shared_program_data.data as *const Vec<_>; // Raw pointer to data
+        let data = unsafe { &*data_ptr }; // Dereference as immutable reference (no mutation yet)
+        self.inner
+            .vm
+            .load_data(base.inner, data)
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+        Ok(())
+    }
+
+    #[getter]
+    fn program_len(&self) -> usize {
+        self.inner.get_program().shared_program_data.data.len()
+    }
+
+    #[getter]
+    fn program(&self) -> PyResult<PyProgram> {
+        Ok(PyProgram { inner: self.inner.get_program().clone() })
     }
 
     #[getter]
@@ -261,7 +321,44 @@ except Exception as e:
             .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
         Ok(PyDictManager { inner: dict_manager })
     }
+    #[getter]
+    fn builtin_runners(&mut self) -> PyResult<PyObject> {
+        let ap = self.inner.vm.get_ap();
+        Python::with_gil(|py| {
+            let dict = PyDict::new(py);
+            for builtin_runner in self.inner.vm.builtin_runners.iter_mut() {
+                let name = builtin_runner.name().to_string();
+                let included = builtin_runner.included();
+                let initial_stack: Vec<PyRelocatable> = builtin_runner
+                    .initial_stack()
+                    .into_iter()
+                    .map(|x| PyRelocatable { inner: x.try_into().unwrap() })
+                    .collect();
+                let final_stack: Vec<PyRelocatable> = if !included {
+                    builtin_runner
+                        .final_stack(&self.inner.vm.segments, ap)
+                        .into_iter()
+                        .map(|x| PyRelocatable { inner: x })
+                        .collect()
+                } else {
+                    vec![]
+                };
+                let base = PyRelocatable {
+                    inner: Relocatable { segment_index: builtin_runner.base() as isize, offset: 0 },
+                };
+                let runner_dict = PyDict::new(py);
+                runner_dict.set_item("included", included)?;
+                runner_dict.set_item("base", base)?;
+                runner_dict.set_item("name", name.clone())?;
+                runner_dict.set_item("initial_stack", initial_stack)?;
+                runner_dict.set_item("final_stack", final_stack)?;
+                dict.set_item(name, runner_dict)?;
+            }
+            Ok(dict.into())
+        })
+    }
 
+    // Existing run_until_pc (unchanged)
     #[pyo3(signature = (address, resources))]
     fn run_until_pc(&mut self, address: PyRelocatable, resources: PyRunResources) -> PyResult<()> {
         let mut hint_processor = if self.enable_pythonic_hints {
@@ -272,43 +369,33 @@ except Exception as e:
         } else {
             HintProcessor::default().with_run_resources(resources.inner).build()
         };
-
         self.inner
             .run_until_pc(address.inner, &mut hint_processor)
             .map_err(|e| VmException::from_vm_error(&self.inner, e))
             .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
-
         self.inner
             .end_run(false, false, &mut hint_processor)
             .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
         Ok(())
     }
 
+    // New methods for post-run processing
     fn verify_auto_deductions(&mut self) -> PyResult<()> {
         self.inner
             .vm
             .verify_auto_deductions()
             .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
-
         Ok(())
     }
 
     fn read_return_values(&mut self, offset: usize) -> PyResult<PyRelocatable> {
-        PyResult::Ok(PyRelocatable { inner: self._read_return_values(offset)? })
+        let pointer = self._read_return_values(offset)?;
+        Ok(PyRelocatable { inner: pointer })
     }
 
     fn verify_secure_runner(&mut self) -> PyResult<()> {
         verify_secure_runner(&self.inner, true, None)
             .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
-
-        Ok(())
-    }
-
-    fn verify_and_relocate(&mut self, offset: usize) -> PyResult<()> {
-        self.verify_auto_deductions()?;
-        self.read_return_values(offset)?;
-        self.verify_secure_runner()?;
-        self.relocate()?;
         Ok(())
     }
 
@@ -316,7 +403,6 @@ except Exception as e:
         self.inner
             .relocate(true)
             .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
-
         Ok(())
     }
 
@@ -348,8 +434,12 @@ except Exception as e:
 
         let df = df!("pc" => pc_values, "ap" => ap_values, "fp" => fp_values)
             .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
-
         Ok(PyDataFrame(df))
+    }
+
+    #[getter]
+    fn ap(&self) -> PyRelocatable {
+        PyRelocatable { inner: self.inner.vm.get_ap() }
     }
 
     #[pyo3(signature = (pointer, first_return_data_offset))]
@@ -361,13 +451,9 @@ except Exception as e:
         let exec_base = self.inner.execution_base.ok_or_else(|| {
             PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("No execution base available")
         })?;
-
-        // Calculate the range to add to execution_public_memory
         let begin = pointer.inner.offset - exec_base.offset;
         let ap = self.inner.vm.get_ap();
         let end = ap.offset - first_return_data_offset;
-
-        // Extend execution_public_memory with this range
         self.inner
             .execution_public_memory
             .as_mut()
@@ -377,22 +463,27 @@ except Exception as e:
                 )
             })?
             .extend(begin..end);
-
         Ok(())
     }
 
-    #[pyo3(signature = (file_path))]
-    fn write_binary_trace(&self, file_path: String) -> PyResult<()> {
-        if let Some(relocated_trace) = &self.inner.relocated_trace {
-            use std::{fs::File, io::Write};
+    fn finalize_segments(&mut self) -> PyResult<()> {
+        self.inner
+            .finalize_segments()
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+        Ok(())
+    }
 
-            let mut buffer = Vec::new();
-            let mut writer = SliceWriter::new(&mut buffer);
-            write_encoded_trace(relocated_trace, &mut writer)
-                .map_err(|e| PyErr::new::<pyo3::exceptions::PyIOError, _>(e.to_string()))?;
-            let mut file = File::create(file_path)
-                .map_err(|e| PyErr::new::<pyo3::exceptions::PyIOError, _>(e.to_string()))?;
-            file.write_all(&buffer)
+    // def write_binary_trace(trace_file: IO[bytes], trace: List[TraceEntry[int]]):
+    // for trace_entry in trace:
+    //     trace_file.write(trace_entry.serialize())
+    // trace_file.flush()
+    fn write_binary_trace(&self, file_path: String) -> PyResult<()> {
+        if let Some(trace_entries) = &self.inner.relocated_trace {
+            let trace_file = std::fs::File::create(file_path)?;
+            let mut trace_writer =
+                FileWriter::new(io::BufWriter::with_capacity(3 * 1024 * 1024, trace_file));
+
+            write_encoded_trace(trace_entries, &mut trace_writer)
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyIOError, _>(e.to_string()))?;
             Ok(())
         } else {
@@ -400,68 +491,117 @@ except Exception as e:
         }
     }
 
-    #[getter]
-    fn builtin_runners(&self) -> PyResult<PyObject> {
-        Python::with_gil(|py| {
-            let dict = PyDict::new(py);
+    fn write_binary_memory(&self, file_path: String, capacity: usize) -> PyResult<()> {
+        let memory_file = std::fs::File::create(file_path)?;
+        let mut memory_writer =
+            FileWriter::new(io::BufWriter::with_capacity(capacity, memory_file));
 
-            for builtin_runner in self.inner.vm.builtin_runners.iter() {
-                let name = builtin_runner.name().to_string();
-                let included = builtin_runner.included();
-                let base = PyRelocatable {
-                    inner: Relocatable { segment_index: builtin_runner.base() as isize, offset: 0 },
-                };
-
-                let runner_dict = PyDict::new(py);
-                runner_dict.set_item("included", included)?;
-                runner_dict.set_item("base", base)?;
-                runner_dict.set_item("name", name.clone())?;
-
-                dict.set_item(name, runner_dict)?;
-            }
-
-            Ok(dict.into())
-        })
+        write_encoded_memory(&self.inner.relocated_memory, &mut memory_writer)
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyIOError, _>(e.to_string()))?;
+        memory_writer
+            .flush()
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyIOError, _>(e.to_string()))?;
+        Ok(())
     }
+
+    fn write_binary_air_public_input(&self, file_path: String) -> PyResult<()> {
+        let json = self
+            .inner
+            .get_air_public_input()
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?
+            .serialize_json()
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+        std::fs::write(file_path, json)
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyIOError, _>(e.to_string()))?;
+        Ok(())
+    }
+
+    fn write_binary_air_private_input(
+        &self,
+        trace_path: PathBuf,
+        memory_path: PathBuf,
+        file_path: String,
+    ) -> PyResult<()> {
+        // Get absolute paths of trace_file & memory_file
+        let trace_path = trace_path
+            .as_path()
+            .canonicalize()
+            .unwrap_or(trace_path.clone())
+            .to_string_lossy()
+            .to_string();
+        let memory_path = memory_path
+            .as_path()
+            .canonicalize()
+            .unwrap_or(memory_path.clone())
+            .to_string_lossy()
+            .to_string();
+
+        let json = self
+            .inner
+            .get_air_private_input()
+            .to_serializable(trace_path, memory_path)
+            .serialize_json()
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+        std::fs::write(file_path, json)
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyIOError, _>(e.to_string()))?;
+        Ok(())
+    }
+
+    // fn get_perm_range_check_limits(&self) -> PyResult<(i128, i128)> {
+    //     let (rc_min, rc_max) = self
+    //         .inner
+    //         .get_perm_range_check_limits()
+    //         .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+    //     Ok((rc_min, rc_max))
+    // }
+
+    // #[getter]
+    // fn relocated_memory(&self) -> PyResult<HashMap<usize, PyMaybeRelocatable>> {
+    //     let memory = self.inner.relocated_memory.as_ref().ok_or_else(|| {
+    //         PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("No relocated memory available")
+    //     })?;
+    //     let result =
+    //         memory.iter().map(|(k, v)| (k.clone(),
+    // PyMaybeRelocatable::from(v.clone()))).collect();     Ok(result)
+    // }
+
+    // fn get_public_memory_addresses(&self) -> PyResult<Vec<usize>> {
+    //     let offsets = self
+    //         .inner
+    //         .get_segment_offsets()
+    //         .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+    //     let addresses = self
+    //         .inner
+    //         .segments
+    //         .get_public_memory_addresses(&offsets)
+    //         .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+    //     Ok(addresses)
+    // }
+
+    // fn get_memory_segment_addresses(&self) -> PyResult<HashMap<usize, (usize, usize)>> {
+    //     let addresses = self
+    //         .inner
+    //         .get_memory_segment_addresses()
+    //         .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+    //     Ok(addresses)
+    // }
+
+    // fn get_air_private_input(&self) -> PyResult<HashMap<String, PyObject>> {
+    //     let private_input = self
+    //         .inner
+    //         .get_air_private_input()
+    //         .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+    //     Python::with_gil(|py| {
+    //         let dict = PyDict::new(py);
+    //         for (k, v) in private_input.into_iter() {
+    //             dict.set_item(k, v.to_object(py))?;
+    //         }
+    //         Ok(dict.into())
+    //     })
+    // }
 }
 
 impl PyCairoRunner {
-    fn builtins_stack(
-        &mut self,
-        ordered_builtins: Option<Vec<String>>,
-    ) -> PyResult<Vec<MaybeRelocatable>> {
-        let ordered_builtins = ordered_builtins.unwrap_or_default();
-
-        let mut stack = Vec::new();
-        let mut used_builtins_acc = Vec::new();
-
-        // # If we're in proof mode, all builtins are enabled by default. However, we don't use them
-        // in the entrypoint, nor do we return them at the end of the execution.
-        // # Because they're unused, we can simply put them in the stack (no impact on program
-        // execution), which is dumped into the execution public memory. # Note: if we tried
-        // to pass an included builtin here, it would fail, because we would try to access ptr-1
-        // which is an invalid address. (see final_stack)
-        for builtin_runner in self.inner.vm.builtin_runners.iter_mut() {
-            let runner_base =
-                Relocatable { segment_index: builtin_runner.base() as isize, offset: 0 };
-            let is_included =
-                ordered_builtins.contains(&builtin_runner.name().to_str_with_suffix().to_string());
-            if !is_included {
-                let final_pointer =
-                    builtin_runner.final_stack(&self.inner.vm.segments, runner_base).unwrap();
-                stack.push(final_pointer.into());
-            } else {
-                used_builtins_acc.push(builtin_runner);
-            }
-        }
-
-        for builtin_runner in used_builtins_acc.iter() {
-            stack.append(&mut builtin_runner.initial_stack());
-        }
-
-        Ok(stack)
-    }
-
     /// Mainly like `CairoRunner::read_return_values` but with an `offset` parameter and some checks
     /// that I needed to remove.
     fn _read_return_values(&mut self, offset: usize) -> PyResult<Relocatable> {
@@ -470,20 +610,17 @@ impl PyCairoRunner {
             if let Some(builtin_runner) =
                 self.inner.vm.builtin_runners.iter_mut().find(|b| b.name() == *builtin_name)
             {
-                let new_pointer =
+                pointer =
                     builtin_runner.final_stack(&self.inner.vm.segments, pointer).map_err(|e| {
                         PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string())
                     })?;
-                pointer = new_pointer;
+            } else if !self.allow_missing_builtins {
+                return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
+                    "Missing builtin: {}",
+                    builtin_name
+                )));
             } else {
-                if !self.allow_missing_builtins {
-                    return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                        "Missing builtin: {}",
-                        builtin_name
-                    )));
-                }
                 pointer.offset = pointer.offset.saturating_sub(1);
-
                 if !self
                     .inner
                     .vm
@@ -499,5 +636,33 @@ impl PyCairoRunner {
             }
         }
         Ok(pointer)
+    }
+}
+
+// From <https://github.com/lambdaclass/cairo-vm/blob/5d7c20880785e1f9edbd73d0d46aeb58d8bced4e/cairo-vm-cli/src/main.rs#L109-L140>
+struct FileWriter {
+    buf_writer: io::BufWriter<std::fs::File>,
+    bytes_written: usize,
+}
+
+impl Writer for FileWriter {
+    fn write(&mut self, bytes: &[u8]) -> Result<(), bincode::error::EncodeError> {
+        self.buf_writer
+            .write_all(bytes)
+            .map_err(|e| bincode::error::EncodeError::Io { inner: e, index: self.bytes_written })?;
+
+        self.bytes_written += bytes.len();
+
+        Ok(())
+    }
+}
+
+impl FileWriter {
+    fn new(buf_writer: io::BufWriter<std::fs::File>) -> Self {
+        Self { buf_writer, bytes_written: 0 }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.buf_writer.flush()
     }
 }

--- a/python/cairo-addons/src/cairo_addons/testing/runner.py
+++ b/python/cairo-addons/src/cairo_addons/testing/runner.py
@@ -666,7 +666,17 @@ def run_rust_vm(
         if coverage is not None:
             coverage(runner.trace_df, PROGRAM_BASE)
 
-        displayed_args = json.dumps(kwargs) if kwargs else ""
+        # Create a unique output stem for the given test by using the test file name, the entrypoint and the kwargs
+        displayed_args = ""
+        if kwargs:
+            try:
+                displayed_args = json.dumps(kwargs)
+            except TypeError as e:
+                logger.debug(f"Failed to serialize kwargs: {e}")
+        output_stem = str(
+            request.node.path.parent
+            / f"{request.node.path.stem}_{entrypoint}_{displayed_args}"
+        )
         output_stem = str(
             request.node.path.parent
             / f"{request.node.path.stem}_{entrypoint}_{displayed_args}"

--- a/python/cairo-addons/src/cairo_addons/testing/runner.py
+++ b/python/cairo-addons/src/cairo_addons/testing/runner.py
@@ -291,14 +291,6 @@ def run_python_vm(
             stack
         )  # Set the initial frame pointer and argument pointer to the end of the stack
         runner.initialize_zero_segment()
-        # Print all attributes of runner
-        print(f"stack: {stack}")
-        print(f"runner.initial_pc: {runner.initial_pc}")
-        print(f"runner.initial_ap: {runner.initial_ap}")
-        print(f"runner.initial_fp: {runner.initial_fp}")
-        print(f"runner.program_base: {runner.program_base}")
-        print(f"runner.execution_base: {runner.execution_base}")
-        print(f"end: {end}")
 
         # ============================================================================
         # STEP 5: CONFIGURE VM AND EXECUTE PROGRAM
@@ -618,23 +610,12 @@ def run_rust_vm(
             entrypoint
         )  # Start the run at the offset of the entrypoint
         runner.load_program_data(runner.program_base)  # Load the program into memory
-        # runner.load_data(runner.program_base, cairo_program.data)  # Load the stack into memory
         runner.load_data(runner.execution_base, stack)  # Load the stack into memory
         runner.initial_fp = runner.initial_ap = runner.execution_base + len(
             stack
         )  # Set the initial frame pointer and argument pointer to the end of the stack
 
-        runner.initialize_vm(stack, cairo_program.get_label(entrypoint))
-        # runner.initialize_zero_segment()
-
-        # Print all attributes of runner
-        print(f"stack: {stack}")
-        print(f"runner.initial_pc: {runner.initial_pc}")
-        print(f"runner.initial_ap: {runner.initial_ap}")
-        print(f"runner.initial_fp: {runner.initial_fp}")
-        print(f"runner.program_base: {runner.program_base}")
-        print(f"runner.execution_base: {runner.execution_base}")
-        print(f"end: {end}")
+        runner.initialize_vm()
 
         # ============================================================================
         # STEP 5: CONFIGURE VM AND EXECUTE PROGRAM
@@ -673,6 +654,7 @@ def run_rust_vm(
         if proof_mode:
             runner.update_execution_public_memory(pointer, first_return_data_offset)
             runner.finalize_segments()
+
         runner.verify_secure_runner()
         runner.relocate()
 

--- a/python/cairo-addons/tests/test_runner.py
+++ b/python/cairo-addons/tests/test_runner.py
@@ -14,43 +14,31 @@ class TestRunner:
     def test_initialize(self, sw_program, rust_program):
         runner = CairoRunner(rust_program, layout="all_cairo")
         runner.initialize_segments()
-        runner.initialize_vm(stack=[], entrypoint=sw_program.get_label("os"))
 
     def test_program_base(self, sw_program, rust_program):
         runner = CairoRunner(rust_program, layout="all_cairo")
         runner.initialize_segments()
-        runner.initialize_vm(stack=[], entrypoint=sw_program.get_label("os"))
         runner.program_base
 
     def test_execution_base(self, sw_program, rust_program):
         runner = CairoRunner(rust_program, layout="all_cairo")
         runner.initialize_segments()
-        runner.initialize_vm(stack=[], entrypoint=sw_program.get_label("os"))
         runner.execution_base
 
     def test_ap(self, sw_program, rust_program):
         runner = CairoRunner(rust_program, layout="all_cairo")
         runner.initialize_segments()
-        runner.initialize_vm(stack=[], entrypoint=sw_program.get_label("os"))
         runner.ap
 
     def test_fp(self, sw_program, rust_program):
         runner = CairoRunner(rust_program, layout="all_cairo")
         runner.initialize_segments()
-        runner.initialize_vm(stack=[], entrypoint=sw_program.get_label("os"))
         runner.fp
 
     def test_pc(self, sw_program, rust_program):
         runner = CairoRunner(rust_program, layout="all_cairo")
         runner.initialize_segments()
-        runner.initialize_vm(stack=[], entrypoint=sw_program.get_label("os"))
         runner.pc
-
-    def test_relocated_trace(self, sw_program, rust_program):
-        runner = CairoRunner(rust_program, layout="all_cairo")
-        runner.initialize_segments()
-        runner.initialize_vm(stack=[], entrypoint=sw_program.get_label("os"))
-        runner.relocated_trace
 
     def test_get_maybe_relocatable(self, rust_program):
         runner = CairoRunner(rust_program, layout="all_cairo")


### PR DESCRIPTION
### PR: Integrate Rust Cairo VM Runner with Proof Mode into Python Testing Framework

Closes https://github.com/kkrt-labs/keth/issues/952
Closes #960

#### Overview
This pull request further pushed the functional parity between the Rust-based Cairo VM runner (`PyCairoRunner`) and the existing Python VM runner (`run_python_vm`) by adding support for **Proof Mode**.

Key changes include a refactored `runner.py` file with an 8-step structure, mirrored in both vm runs, extended Rust bindings in `runner.rs`. 

#### Changes

1. **Refactored `run_rust_vm` in `runner.py`**
   - **Objective**: Mirror the 8-step structure of `run_python_vm` for consistency and maintainability.
   - **Details**:
     - **Step 1**: Program selection and entrypoint metadata extraction using `build_entrypoint`.
     - **Step 2**: Runner initialization with `RustCairoRunner`, supporting proof mode and layout configuration.
     - **Step 3**: Stack construction with builtins and arguments, integrating `gen_arg_builder` for type conversion.
     - **Step 4**: VM setup done in python rather than in Rust
     - **Step 5**: Execution via `run_until_pc` with exception handling and coverage support.
     - **Step 6**: Return value processing with `read_return_values`, proof mode updates, and security verification.
     - **Step 7**: Output file generation (trace, memory) using Rust methods, with proof mode leveraging the Rust approach (e.g., `write_binary_trace`, `write_binary_memory`).
     - **Step 8**: Output serialization via `Serde`, matching Python VM behavior.
   - **Impact**: Ensures a modular, debuggable flow aligned with `run_python_vm`, while respecting Rust’s proof mode handling. Both `jmp rel 0` "hacks" are applied to both vm runs.

2. **Enhanced `PyCairoRunner` in `runner.rs`**
   - **Objective**: Extend Rust bindings to support all execution phases and proof mode outputs.
   - **Details**:
     - Modified `initialize_vm` to __not__ handle stack setup, which is now handled in python.
     - Implemented execution methods: `run_until_pc`, `verify_auto_deductions`, `read_return_values`, `verify_secure_runner`, `relocate`, to be closer from the python vm runner
     - Added getters for state inspection: `initial_pc`, `initial_ap`, `initial_fp`, `program_base`, `execution_base`, `ap`, `relocated_trace`, `trace_df`.
     - Introduced proof mode output methods: `finalize_segments`, `write_binary_trace`, `write_binary_memory`, `update_execution_public_memory`.
     - Kept `write_binary_air_public_input` and `write_binary_air_private_input` for Rust-native AIR file generation (per your decision to retain the Rust approach).
   - **Impact**: Provides a robust Rust API for Python to control execution and generate proof mode artifacts natively.

#### Rationale
- **Parity**: The 8-step structure ensures `run_rust_vm` behaves like `run_python_vm`, easing contributor onboarding and maintenance by clearly defining the rational behind each step.
- **Constraints**: Retained existing Rust APIs (e.g., `write_binary_air_*`) per project limitations, delegating AIR file details to Rust where applicable.

#### Testing
- Verified execution parity with `run_python_vm` on sample Cairo programs. `(test_rlp.py)`
- Verified execution was working in proof mode for EF-Tests 
- **DID NOT** Try to verify a produced proof.
