### PR TITLE
feat: enhance pythonic hints

### DIFF
--- a/.github/workflows/nightly_fuzzing.yml
+++ b/.github/workflows/nightly_fuzzing.yml
@@ -39,7 +39,7 @@ jobs:
         id: unit-tests
         continue-on-error: true
         run: |
-          uv run --reinstall pytest -n logical --durations=0 -v -s --log-cli-level=DEBUG --no-skip-cached-tests --ignore-glob=cairo/tests/ef_tests/
+          uv run --reinstall pytest -n logical --durations=0 --disable-pythonic-hints -v -s --log-cli-level=DEBUG --no-skip-cached-tests --ignore-glob=cairo/tests/ef_tests/
 
       - name: Upload coverage
         uses: codecov/codecov-action@v5
@@ -80,7 +80,7 @@ jobs:
         continue-on-error: true
         # Running on 48 cores to avoid out of memory issues
         run: |
-          uv run --reinstall pytest -n 48 -m "not slow" --durations=0 -v -s --log-cli-level=DEBUG cairo/tests/ef_tests/ --ignore-glob='cairo/tests/ef_tests/fixtures/*'
+          uv run --reinstall pytest -n 48 -m "not slow" --disable-pythonic-hints --durations=0 -v -s --log-cli-level=DEBUG cairo/tests/ef_tests/ --ignore-glob='cairo/tests/ef_tests/fixtures/*'
       - name: Notify Slack on Failure
         if: steps.ef-tests.outcome == 'failure'
         uses: slackapi/slack-github-action@v1.24.0

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -44,7 +44,7 @@ jobs:
       # <https://github.com/kkrt-labs/keth/issues/694>
       - name: Run unit tests without caching
         run: |
-          uv run --reinstall pytest -n logical --durations=0 -v -s --log-cli-level=DEBUG --no-skip-cached-tests --ignore-glob=cairo/tests/ef_tests/
+          uv run --reinstall pytest -n logical --durations=0 --disable-pythonic-hints -v -s --log-cli-level=DEBUG --no-skip-cached-tests --ignore-glob=cairo/tests/ef_tests/
 
       - uses: actions/cache/save@v4
         with:
@@ -77,7 +77,7 @@ jobs:
         run: |
           # Runs up to ${{ inputs.max-tests }} tests, randomly sampled using the GITHUB_RUN_ID seed
           # Use only 48 cores to avoid out of memory issues
-          uv run --reinstall pytest -n 48 -m "not slow" --timeout 300 --durations=0 -v -s --log-cli-level=DEBUG --max-tests=${{ inputs.max-tests }} --randomly-seed=$GITHUB_RUN_ID cairo/tests/ef_tests/ --ignore-glob='cairo/tests/ef_tests/fixtures/*'
+          uv run --reinstall pytest -n 48 -m "not slow" --disable-pythonic-hints --timeout 300 --durations=0 -v -s --log-cli-level=DEBUG --max-tests=${{ inputs.max-tests }} --randomly-seed=$GITHUB_RUN_ID cairo/tests/ef_tests/ --ignore-glob='cairo/tests/ef_tests/fixtures/*'
       - name: Upload coverage
         uses: codecov/codecov-action@v5
         with:

--- a/cairo/ethereum/cancun/vm/interpreter.cairo
+++ b/cairo/ethereum/cancun/vm/interpreter.cairo
@@ -421,7 +421,7 @@ func _execute_code{
             opcode=opcode,
         );
         %{
-            if memory[ids.err.address_] == 0:
+            if ids.err.value == 0:
                 logger.trace_cairo(f"OpEnd")
         %}
         if (cast(err, felt) != 0) {

--- a/cairo/tests/test_hint_runner.cairo
+++ b/cairo/tests/test_hint_runner.cairo
@@ -1,4 +1,4 @@
-from ethereum_types.numeric import U256
+from ethereum_types.numeric import U256, U256Struct
 
 func test__ap_accessible() {
     tempvar x = 100;
@@ -35,12 +35,10 @@ func test__assign_local_unassigned_variable() {
     ret;
 }
 
-func test__assign_already_assigned_variable() {
+func test__assign_already_assigned_variable_should_fail() {
     alloc_locals;
     local x = 3;
     %{ ids.x = 100; %}
-
-    assert x = 3;
     ret;
 }
 
@@ -52,7 +50,67 @@ func test__assign_memory() {
     ret;
 }
 
+func test__access_struct_members() {
+    tempvar n = U256Struct(100, 200);
+    %{
+        assert ids.n.low == 100, f"ids.n.low: {ids.n.low}";
+        assert ids.n.high == 200, f"ids.n.high: {ids.n.high}";
+    %}
+    ret;
+}
+
+func test__access_struct_members_pointers() {
+    tempvar n = new U256Struct(100, 200);
+    %{
+        assert ids.n.low == 100, f"ids.n.low: {ids.n.low}";
+        assert ids.n.high == 200, f"ids.n.high: {ids.n.high}";
+    %}
+    ret;
+}
+
+func test_access_nested_structs() {
+    tempvar n = U256(new U256Struct(100, 200));
+    %{
+        assert ids.n.value.low == 100, f"ids.n.value.low: {ids.n.value.low}";
+        assert ids.n.value.high == 200, f"ids.n.value.high: {ids.n.value.high}";
+    %}
+    ret;
+}
+
+func test_access_struct_member_address() {
+    tempvar n = U256(new U256Struct(100, 200));
+    %{
+        assert memory[ids.n.value.address_] == 100, f"memory[ids.n.value.address_]: {memory[ids.n.value.address_]}";
+        assert memory[ids.n.value.address_ + 1] == 200, f"memory[ids.n.value.address_ + 1]: {memory[ids.n.value.address_ + 1]}";
+    %}
+    ret;
+}
+
 func test__serialize(n: U256) {
     %{ assert serialize(ids.n) == 100; %}
+    ret;
+}
+
+func test__gen_arg_pointer(n: U256) {
+    tempvar x: U256Struct*;
+    %{
+        from ethereum_types.numeric import U256
+        ids.x = gen_arg(U256, serialize(ids.n));
+    %}
+
+    assert x.low = n.value.low;
+    assert x.high = n.value.high;
+    ret;
+}
+
+func test__gen_arg_struct(n: U256) {
+    tempvar x: U256;
+    %{
+        from ethereum_types.numeric import U256
+        ids.x = gen_arg(U256, serialize(ids.n));
+    %}
+
+    assert x.value.low = n.value.low;
+    assert x.value.high = n.value.high;
     ret;
 }

--- a/cairo/tests/test_hint_runner.cairo
+++ b/cairo/tests/test_hint_runner.cairo
@@ -1,0 +1,58 @@
+from ethereum_types.numeric import U256
+
+func test__ap_accessible() {
+    tempvar x = 100;
+    %{ assert memory[ap-1] == 100; %}
+    ret;
+}
+
+func test__pc_accessible() {
+    %{ x = pc %}
+    ret;
+}
+
+func test__fp_accessible() {
+    alloc_locals;
+    local x = 100;
+    %{ assert memory[fp] == 100; %}
+    ret;
+}
+
+func test__assign_tempvar_ids_variable() {
+    tempvar x;
+    %{ ids.x = 100; %}
+
+    assert x = 100;
+    ret;
+}
+
+func test__assign_local_unassigned_variable() {
+    alloc_locals;
+    local x: felt;
+    %{ ids.x = 3; %}
+
+    assert x = 3;
+    ret;
+}
+
+func test__assign_already_assigned_variable() {
+    alloc_locals;
+    local x = 3;
+    %{ ids.x = 100; %}
+
+    assert x = 3;
+    ret;
+}
+
+func test__assign_memory() {
+    tempvar x;
+    %{ memory[ap-1] = 100; %}
+
+    assert x = 100;
+    ret;
+}
+
+func test__serialize(n: U256) {
+    %{ assert serialize(ids.n) == 100; %}
+    ret;
+}

--- a/cairo/tests/test_hint_runner.cairo
+++ b/cairo/tests/test_hint_runner.cairo
@@ -1,4 +1,5 @@
 from ethereum_types.numeric import U256, U256Struct
+from starkware.cairo.common.alloc import alloc
 
 func test__ap_accessible() {
     tempvar x = 100;
@@ -112,5 +113,20 @@ func test__gen_arg_struct(n: U256) {
 
     assert x.value.low = n.value.low;
     assert x.value.high = n.value.high;
+    ret;
+}
+
+func test__access_let_felt() {
+    let x = 3;
+    %{ assert ids.x == 3 %}
+    ret;
+}
+
+func test__access_let_relocatable() {
+    let (x) = alloc();
+    %{
+        # simple access
+        ids.x
+    %}
     ret;
 }

--- a/cairo/tests/test_hint_runner.cairo
+++ b/cairo/tests/test_hint_runner.cairo
@@ -2,7 +2,7 @@ from ethereum_types.numeric import U256, U256Struct
 
 func test__ap_accessible() {
     tempvar x = 100;
-    %{ assert memory[ap-1] == 100; %}
+    %{ assert memory[ap-1] == 100 %}
     ret;
 }
 
@@ -14,13 +14,13 @@ func test__pc_accessible() {
 func test__fp_accessible() {
     alloc_locals;
     local x = 100;
-    %{ assert memory[fp] == 100; %}
+    %{ assert memory[fp] == 100 %}
     ret;
 }
 
 func test__assign_tempvar_ids_variable() {
     tempvar x;
-    %{ ids.x = 100; %}
+    %{ ids.x = 100 %}
 
     assert x = 100;
     ret;
@@ -29,7 +29,7 @@ func test__assign_tempvar_ids_variable() {
 func test__assign_local_unassigned_variable() {
     alloc_locals;
     local x: felt;
-    %{ ids.x = 3; %}
+    %{ ids.x = 3 %}
 
     assert x = 3;
     ret;
@@ -38,13 +38,13 @@ func test__assign_local_unassigned_variable() {
 func test__assign_already_assigned_variable_should_fail() {
     alloc_locals;
     local x = 3;
-    %{ ids.x = 100; %}
+    %{ ids.x = 100 %}
     ret;
 }
 
 func test__assign_memory() {
     tempvar x;
-    %{ memory[ap-1] = 100; %}
+    %{ memory[ap-1] = 100 %}
 
     assert x = 100;
     ret;
@@ -87,7 +87,7 @@ func test_access_struct_member_address() {
 }
 
 func test__serialize(n: U256) {
-    %{ assert serialize(ids.n) == 100; %}
+    %{ assert serialize(ids.n) == ids.n.value.low + ids.n.value.high * 2**128 %}
     ret;
 }
 

--- a/cairo/tests/test_hint_runner.py
+++ b/cairo/tests/test_hint_runner.py
@@ -2,7 +2,7 @@ import pytest
 from ethereum_types.numeric import U256
 
 
-class TestRunner:
+class TestRunnerRust:
     def test__ap_accessible(self, cairo_run):
         cairo_run("test__ap_accessible")
 
@@ -18,12 +18,76 @@ class TestRunner:
     def test__should_assign_local_unassigned_variable(self, cairo_run):
         cairo_run("test__assign_local_unassigned_variable")
 
-    def test__should_fail_assign_already_assigned_variable(self, cairo_run):
+    def test__should_fail_assign_already_assigned_variable_should_fail(self, cairo_run):
         with pytest.raises(Exception):
-            cairo_run("test__assign_already_assigned_variable")
+            cairo_run("test__assign_already_assigned_variable_should_fail")
 
     def test__assign_memory(self, cairo_run):
         cairo_run("test__assign_memory")
 
+    def test__access_struct_members(self, cairo_run):
+        cairo_run("test__access_struct_members")
+
+    def test__access_struct_members_pointers(self, cairo_run):
+        cairo_run("test__access_struct_members_pointers")
+
+    def test_access_nested_structs(self, cairo_run):
+        cairo_run("test_access_nested_structs")
+
+    def test_access_struct_member_address(self, cairo_run):
+        cairo_run("test_access_struct_member_address")
+
     def test__serialize(self, cairo_run):
         cairo_run("test__serialize", n=U256(100))
+
+    def test__gen_arg_pointer(self, cairo_run):
+        cairo_run("test__gen_arg_pointer", n=U256(100))
+
+    def test__gen_arg_struct(self, cairo_run):
+        cairo_run("test__gen_arg_struct", n=U256(100))
+
+
+class TestRunnerPython:
+    def test__ap_accessible(self, cairo_run_py):
+        cairo_run_py("test__ap_accessible")
+
+    def test__pc_accessible(self, cairo_run_py):
+        cairo_run_py("test__pc_accessible")
+
+    def test__fp_accessible(self, cairo_run_py):
+        cairo_run_py("test__fp_accessible")
+
+    def test__should_assign_tempvar_ids_variable(self, cairo_run_py):
+        cairo_run_py("test__assign_tempvar_ids_variable")
+
+    def test__should_assign_local_unassigned_variable(self, cairo_run_py):
+        cairo_run_py("test__assign_local_unassigned_variable")
+
+    def test__should_fail_assign_already_assigned_variable_should_fail(
+        self, cairo_run_py
+    ):
+        with pytest.raises(Exception):
+            cairo_run_py("test__assign_already_assigned_variable_should_fail")
+
+    def test__assign_memory(self, cairo_run_py):
+        cairo_run_py("test__assign_memory")
+
+    def test__access_struct_members(self, cairo_run_py):
+        cairo_run_py("test__access_struct_members")
+
+    def test__access_struct_members_pointers(self, cairo_run_py):
+        cairo_run_py("test__access_struct_members_pointers")
+
+    def test_access_nested_structs(self, cairo_run_py):
+        cairo_run_py("test_access_nested_structs")
+
+    def test_access_struct_member_address(self, cairo_run_py):
+        cairo_run_py("test_access_struct_member_address")
+
+    def test__serialize(self, cairo_run_py):
+        cairo_run_py("test__serialize", n=U256(100))
+
+    def test__gen_arg_pointer(self, cairo_run_py):
+        cairo_run_py("test__gen_arg_pointer", n=U256(100))
+
+    # The last one is not available in the Python runner but is a nice addition to the Rust one.

--- a/cairo/tests/test_hint_runner.py
+++ b/cairo/tests/test_hint_runner.py
@@ -62,3 +62,11 @@ class TestRunner:
     def test__gen_arg_struct(self, cairo_run):
         cairo_run("test__gen_arg_struct", n=U256(100))
         # Not possible with the Python runner but is a nice addition to the Rust one.
+
+    def test__access_let_felt(self, cairo_run, cairo_run_py):
+        cairo_run("test__access_let_felt")
+        cairo_run_py("test__access_let_felt")
+
+    def test__access_let_relocatable(self, cairo_run, cairo_run_py):
+        cairo_run("test__access_let_relocatable")
+        cairo_run_py("test__access_let_relocatable")

--- a/cairo/tests/test_hint_runner.py
+++ b/cairo/tests/test_hint_runner.py
@@ -2,92 +2,63 @@ import pytest
 from ethereum_types.numeric import U256
 
 
-class TestRunnerRust:
-    def test__ap_accessible(self, cairo_run):
+class TestRunner:
+    def test__ap_accessible(self, cairo_run, cairo_run_py):
         cairo_run("test__ap_accessible")
-
-    def test__pc_accessible(self, cairo_run):
-        cairo_run("test__pc_accessible")
-
-    def test__fp_accessible(self, cairo_run):
-        cairo_run("test__fp_accessible")
-
-    def test__should_assign_tempvar_ids_variable(self, cairo_run):
-        cairo_run("test__assign_tempvar_ids_variable")
-
-    def test__should_assign_local_unassigned_variable(self, cairo_run):
-        cairo_run("test__assign_local_unassigned_variable")
-
-    def test__should_fail_assign_already_assigned_variable_should_fail(self, cairo_run):
-        with pytest.raises(Exception):
-            cairo_run("test__assign_already_assigned_variable_should_fail")
-
-    def test__assign_memory(self, cairo_run):
-        cairo_run("test__assign_memory")
-
-    def test__access_struct_members(self, cairo_run):
-        cairo_run("test__access_struct_members")
-
-    def test__access_struct_members_pointers(self, cairo_run):
-        cairo_run("test__access_struct_members_pointers")
-
-    def test_access_nested_structs(self, cairo_run):
-        cairo_run("test_access_nested_structs")
-
-    def test_access_struct_member_address(self, cairo_run):
-        cairo_run("test_access_struct_member_address")
-
-    def test__serialize(self, cairo_run):
-        cairo_run("test__serialize", n=U256(100))
-
-    def test__gen_arg_pointer(self, cairo_run):
-        cairo_run("test__gen_arg_pointer", n=U256(100))
-
-    def test__gen_arg_struct(self, cairo_run):
-        cairo_run("test__gen_arg_struct", n=U256(100))
-
-
-class TestRunnerPython:
-    def test__ap_accessible(self, cairo_run_py):
         cairo_run_py("test__ap_accessible")
 
-    def test__pc_accessible(self, cairo_run_py):
+    def test__pc_accessible(self, cairo_run, cairo_run_py):
+        cairo_run("test__pc_accessible")
         cairo_run_py("test__pc_accessible")
 
-    def test__fp_accessible(self, cairo_run_py):
+    def test__fp_accessible(self, cairo_run, cairo_run_py):
+        cairo_run("test__fp_accessible")
         cairo_run_py("test__fp_accessible")
 
-    def test__should_assign_tempvar_ids_variable(self, cairo_run_py):
+    def test__should_assign_tempvar_ids_variable(self, cairo_run, cairo_run_py):
+        cairo_run("test__assign_tempvar_ids_variable")
         cairo_run_py("test__assign_tempvar_ids_variable")
 
-    def test__should_assign_local_unassigned_variable(self, cairo_run_py):
+    def test__should_assign_local_unassigned_variable(self, cairo_run, cairo_run_py):
+        cairo_run("test__assign_local_unassigned_variable")
         cairo_run_py("test__assign_local_unassigned_variable")
 
     def test__should_fail_assign_already_assigned_variable_should_fail(
-        self, cairo_run_py
+        self, cairo_run, cairo_run_py
     ):
+        with pytest.raises(Exception):
+            cairo_run("test__assign_already_assigned_variable_should_fail")
         with pytest.raises(Exception):
             cairo_run_py("test__assign_already_assigned_variable_should_fail")
 
-    def test__assign_memory(self, cairo_run_py):
+    def test__assign_memory(self, cairo_run, cairo_run_py):
+        cairo_run("test__assign_memory")
         cairo_run_py("test__assign_memory")
 
-    def test__access_struct_members(self, cairo_run_py):
+    def test__access_struct_members(self, cairo_run, cairo_run_py):
+        cairo_run("test__access_struct_members")
         cairo_run_py("test__access_struct_members")
 
-    def test__access_struct_members_pointers(self, cairo_run_py):
+    def test__access_struct_members_pointers(self, cairo_run, cairo_run_py):
+        cairo_run("test__access_struct_members_pointers")
         cairo_run_py("test__access_struct_members_pointers")
 
-    def test_access_nested_structs(self, cairo_run_py):
+    def test_access_nested_structs(self, cairo_run, cairo_run_py):
+        cairo_run("test_access_nested_structs")
         cairo_run_py("test_access_nested_structs")
 
-    def test_access_struct_member_address(self, cairo_run_py):
+    def test_access_struct_member_address(self, cairo_run, cairo_run_py):
+        cairo_run("test_access_struct_member_address")
         cairo_run_py("test_access_struct_member_address")
 
-    def test__serialize(self, cairo_run_py):
+    def test__serialize(self, cairo_run, cairo_run_py):
+        cairo_run("test__serialize", n=U256(100))
         cairo_run_py("test__serialize", n=U256(100))
 
-    def test__gen_arg_pointer(self, cairo_run_py):
+    def test__gen_arg_pointer(self, cairo_run, cairo_run_py):
+        cairo_run("test__gen_arg_pointer", n=U256(100))
         cairo_run_py("test__gen_arg_pointer", n=U256(100))
 
-    # The last one is not available in the Python runner but is a nice addition to the Rust one.
+    def test__gen_arg_struct(self, cairo_run):
+        cairo_run("test__gen_arg_struct", n=U256(100))
+        # Not possible with the Python runner but is a nice addition to the Rust one.

--- a/cairo/tests/test_hint_runner.py
+++ b/cairo/tests/test_hint_runner.py
@@ -1,0 +1,29 @@
+import pytest
+from ethereum_types.numeric import U256
+
+
+class TestRunner:
+    def test__ap_accessible(self, cairo_run):
+        cairo_run("test__ap_accessible")
+
+    def test__pc_accessible(self, cairo_run):
+        cairo_run("test__pc_accessible")
+
+    def test__fp_accessible(self, cairo_run):
+        cairo_run("test__fp_accessible")
+
+    def test__should_assign_tempvar_ids_variable(self, cairo_run):
+        cairo_run("test__assign_tempvar_ids_variable")
+
+    def test__should_assign_local_unassigned_variable(self, cairo_run):
+        cairo_run("test__assign_local_unassigned_variable")
+
+    def test__should_fail_assign_already_assigned_variable(self, cairo_run):
+        with pytest.raises(Exception):
+            cairo_run("test__assign_already_assigned_variable")
+
+    def test__assign_memory(self, cairo_run):
+        cairo_run("test__assign_memory")
+
+    def test__serialize(self, cairo_run):
+        cairo_run("test__serialize", n=U256(100))

--- a/cairo/tests/test_hint_runner.py
+++ b/cairo/tests/test_hint_runner.py
@@ -1,6 +1,8 @@
 import pytest
 from ethereum_types.numeric import U256
 
+pytestmark = pytest.mark.enable_pythonic_hints
+
 
 class TestRunner:
     def test__ap_accessible(self, cairo_run, cairo_run_py):

--- a/crates/cairo-addons/src/vm/dict_manager.rs
+++ b/crates/cairo-addons/src/vm/dict_manager.rs
@@ -213,7 +213,10 @@ impl PyDictManager {
         let dict_manager = self.inner.borrow();
         let tracker = dict_manager.trackers.get(&segment_index).unwrap();
         let default_value = tracker.get_default_value().cloned().ok_or_else(|| {
-            PyErr::new::<pyo3::exceptions::PyValueError, _>("Default value not found")
+            PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                "Default value not found for segment index {}",
+                segment_index
+            ))
         })?;
         Ok(default_value.into())
     }

--- a/crates/cairo-addons/src/vm/memory_segments.rs
+++ b/crates/cairo-addons/src/vm/memory_segments.rs
@@ -38,6 +38,20 @@ impl PyMemoryWrapper {
             ))
         })
     }
+
+    fn __setitem__(&self, key: PyRelocatable, value: PyMaybeRelocatable) -> PyResult<()> {
+        let vm = unsafe { &mut *self.vm };
+
+        if let Some(value) = vm.get_maybe(&key.inner) {
+            return Err(PyErr::new::<pyo3::exceptions::PyKeyError, _>(format!(
+                "Memory at key {} already has value: {}",
+                key.inner, value
+            )));
+        }
+        vm.insert_value(key.inner, value)
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+        Ok(())
+    }
 }
 
 #[pymethods]

--- a/crates/cairo-addons/src/vm/pythonic_hint.rs
+++ b/crates/cairo-addons/src/vm/pythonic_hint.rs
@@ -100,6 +100,9 @@ pub enum DynamicHintError {
 
     #[error("Unknown variable type: {0}")]
     UnknownVariableType(String),
+
+    #[error("Memory error: {0}")]
+    MemoryError(String),
 }
 
 impl From<DynamicHintError> for HintError {

--- a/crates/cairo-addons/src/vm/runner.rs
+++ b/crates/cairo-addons/src/vm/runner.rs
@@ -551,7 +551,6 @@ impl PyCairoRunner {
     /// Processes builtin pointers in reverse order and handles missing builtins.
     fn _read_return_values(&mut self, offset: usize) -> PyResult<Relocatable> {
         let mut pointer = (self.inner.vm.get_ap() - offset).unwrap();
-        println!("Ordered builtins: {:?}", self.ordered_builtins);
         for builtin_name in self.ordered_builtins.iter().rev() {
             if let Some(builtin_runner) =
                 self.inner.vm.builtin_runners.iter_mut().find(|b| b.name() == *builtin_name)

--- a/crates/cairo-addons/src/vm/runner.rs
+++ b/crates/cairo-addons/src/vm/runner.rs
@@ -556,7 +556,6 @@ impl PyCairoRunner {
             if let Some(builtin_runner) =
                 self.inner.vm.builtin_runners.iter_mut().find(|b| b.name() == *builtin_name)
             {
-                println!("Getting final stack for {}", builtin_name);
                 pointer =
                     builtin_runner.final_stack(&self.inner.vm.segments, pointer).map_err(|e| {
                         PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string())

--- a/crates/cairo-addons/src/vm/vm_consts.rs
+++ b/crates/cairo-addons/src/vm/vm_consts.rs
@@ -6,31 +6,28 @@
 //! Python implementation of Cairo VM (VmConsts), allowing Python hints to access Cairo variables
 //! with their full type information.
 //!
-//! Upon execution of a hint, the `ids` object is created and populated with the variables defined
-//! in the hint using `create_vm_consts_dict`. The `ids` object is then used to access the variables
-//! in the hint.
+//! ## Overview
 //!
-//! There are four different types of variables:
+//! Upon execution of a hint, an `ids` object is created and populated with variables defined
+//! in the hint using `create_vm_consts_dict`. This object serves as the primary interface
+//! for Python hints to interact with Cairo variables. The system supports four variable types:
 //!
-//! - Felt: Basic numeric values
-//! - Relocatable: Memory addresses
-//! - Struct: Composite types with named members
-//! - Pointer: References to other types
+//! - **Felt**: Basic numeric values (mapped to Python integers)
+//! - **Relocatable**: Memory addresses (wrapped as `PyRelocatable`)
+//! - **Struct**: Composite types with named members (wrapped as `PyVmConst`)
+//! - **Pointer**: References to other types (wrapped as `PyVmConst`)
 //!
-//! Struct and Pointer types can be dereferenced to access their members. The members are lazily
-//! loaded from the program identifiers when the variable is accessed for efficiency.
+//! Structs and pointers support member access and dereferencing, with members lazily loaded
+//! from program identifiers for efficiency.
 //!
 //! ## Key Components
 //!
-//! - `CairoVarType`: Represents the different types of Cairo variables (felt, relocatable, struct,
-//!   pointer)
-//! - `CairoVar`: Holds information about a Cairo variable's name, value, address, and type
-//! - `PyVmConst`: Python-accessible wrapper for Cairo variables with type-aware access
-//! - `PyVmConstsDict`: Dictionary-like object that stores Cairo variables and allows access by name
+//! - **`CairoVarType`**: Enum representing Cairo variable types
+//! - **`CairoVar`**: Struct holding variable metadata (name, value, address, type)
+//! - **`PyVmConst`**: Python-accessible wrapper for complex Cairo variables
+//! - **`PyVmConstsDict`**: Dictionary-like interface for variable access in hints
 //!
-//! ## Usage in Hints
-//!
-//! In Python hints, Cairo variables can be accessed through the `ids` dictionary:
+//! ## Usage in Python Hints
 //!
 //! ```python
 //! # Access a simple felt variable
@@ -39,20 +36,13 @@
 //! # Access a struct member
 //! member_value = ids.my_struct.member_name
 //!
-//! # Access a pointer
+//! # Access a pointer and dereference it
 //! ptr_value = ids.my_pointer
-//!
-//! # Dereference a pointer and access the value it points to
 //! deref_value = ids.my_pointer.value
 //!
-//! # Get the address of a variable
+//! # Get variable address
 //! address = ids.my_var.address_
 //! ```
-//!
-//! ## Limitations
-//!
-//! - Mutation of `ids` variables is not supported
-
 use std::collections::HashMap;
 
 use cairo_vm::{
@@ -66,67 +56,85 @@ use cairo_vm::{
     types::relocatable::{MaybeRelocatable, Relocatable},
     vm::vm_core::VirtualMachine,
 };
-use pyo3::{prelude::*, types::PyList, IntoPyObjectExt};
+use pyo3::{
+    exceptions::{PyAttributeError, PyRuntimeError, PyTypeError},
+    prelude::*,
+    types::PyList,
+    IntoPyObjectExt, PyResult,
+};
 
 use super::{
     maybe_relocatable::PyMaybeRelocatable, pythonic_hint::DynamicHintError,
     relocatable::PyRelocatable,
 };
 
-/// Represents the different types of Cairo variables that can be accessed
+/// Represents the different types of Cairo variables that can be accessed in hints.
 #[derive(Debug, Clone)]
 pub enum CairoVarType {
     Felt,
     Relocatable,
+    /// A composite type with named members.
     Struct {
+        /// Fully qualified name of the struct type.
         name: String,
+        /// Map of member names to their definitions (lazy-loaded).
         members: HashMap<String, Member>,
+        /// Size of the struct in felts.
         size: usize,
     },
-    /// A pointer to another type
+    /// A pointer to another type.
     Pointer {
-        /// The type being pointed to
+        /// The type being pointed to.
         pointee: Box<CairoVarType>,
     },
 }
 
-/// Holds information about a Cairo variable's name, value, and address
+/// Holds metadata about a Cairo variable for use in hints.
 #[derive(Debug, Clone)]
 pub struct CairoVar {
+    /// Name of the variable as used in the hint.
     pub name: String,
+    /// Current value of the variable, if available.
     pub value: Option<MaybeRelocatable>,
+    /// Memory address of the variable, if assigned.
     pub address: Option<Relocatable>,
+    /// Type information for the variable.
     pub var_type: CairoVarType,
 }
 
-/// Extracts struct information from identifiers and returns member details
+/// Extracts struct member information from program identifiers.
+///
+/// # Arguments
+/// - `identifiers`: Map of type names to their definitions.
+/// - `type_name`: Name of the struct type to query.
+///
 /// # Returns
-/// A tuple containing:
-/// - A HashMap of member names to their definitions
-/// - The size of the struct
+/// A tuple of `(members, size)` if successful, or `None` if the type is not found.
 fn get_struct_info_from_identifiers(
     identifiers: &HashMap<String, Identifier>,
     type_name: &str,
 ) -> Option<(HashMap<String, Member>, usize)> {
-    // For pointer types, strip the trailing asterisks to get the base type
     let base_type_name = type_name.trim_end_matches('*');
-
     let identifier = identifiers.get(base_type_name)?;
     let members_map = identifier.members.as_ref()?;
 
-    // Convert members to our format
     let mut members = HashMap::new();
     for (member_name, member_def) in members_map {
         members.insert(member_name.clone(), member_def.clone());
     }
 
-    // Get the struct size or use default
     let size = identifier.size.unwrap_or(1);
-
     Some((members, size))
 }
 
-/// Create a CairoVarType instance based on the type name and identifiers
+/// Creates a `CairoVarType` from a type name and program identifiers.
+///
+/// # Arguments
+/// - `type_name`: String representation of the type (e.g., "felt", "MyStruct", "felt*").
+/// - `identifiers`: Program identifiers for resolving struct definitions.
+///
+/// # Returns
+/// A `Result` containing the constructed type or a `DynamicHintError` if invalid.
 fn create_var_type(
     type_name: &str,
     identifiers: &HashMap<String, Identifier>,
@@ -135,16 +143,12 @@ fn create_var_type(
         return Ok(CairoVarType::Felt);
     }
 
-    // Handle pointer types
     if type_name.ends_with('*') {
         let base_type = type_name.trim_end_matches('*');
         let asterisks_count = type_name.len() - base_type.len();
-
-        // Create the innermost type
         let mut inner_type = if base_type == "felt" {
             CairoVarType::Relocatable
         } else {
-            // For struct pointers, create a struct type
             match get_struct_info_from_identifiers(identifiers, base_type) {
                 Some((members, size)) => {
                     CairoVarType::Struct { name: base_type.to_string(), members, size }
@@ -158,7 +162,7 @@ fn create_var_type(
                             members: HashMap::new(),
                             size: 2,
                         });
-                    };
+                    }
                     return Err(DynamicHintError::UnknownVariableType(format!(
                         "Could not get struct info for type '{}'",
                         base_type
@@ -171,72 +175,67 @@ fn create_var_type(
         for _ in 0..asterisks_count {
             inner_type = CairoVarType::Pointer { pointee: Box::new(inner_type) };
         }
-
         return Ok(inner_type);
     }
 
-    // It's a struct
-    Ok(CairoVarType::Struct {
-        name: type_name.to_string(),
-        members: HashMap::new(), // Empty, will be lazy loaded
-        size: 1,                 // Default size
-    })
+    Ok(CairoVarType::Struct { name: type_name.to_string(), members: HashMap::new(), size: 1 })
 }
 
-/// Python-accessible wrapper for Cairo variables that provides a behavior similar to
-/// the original Python VmConsts implementation
+/// Python-accessible wrapper for Cairo variables, mimicking the original Python `VmConsts`.
 ///
-/// See module-level documentation for usage examples.
+/// Provides attribute access, dereferencing, and type-aware behavior for structs and pointers.
 #[pyclass(name = "VmConst", unsendable)]
 pub struct PyVmConst {
-    /// The variable information
+    /// The underlying Cairo variable data.
     pub(crate) var: CairoVar,
+    /// Pointer to the VM for memory access.
     pub(crate) vm: *mut VirtualMachine,
-    /// Reference to program identifiers for struct member resolution
+    /// Optional pointer to identifiers for lazy member loading.
     pub(crate) identifiers: Option<*const HashMap<String, Identifier>>,
 }
 
-// Non-Python methods
 impl PyVmConst {
-    /// Helper method to lazily load struct members from identifiers if needed
-    /// Returns a new var_type with the loaded members if successful
+    /// Lazily loads struct members from identifiers if not already present.
+    ///
+    /// # Returns
+    /// A new `CairoVarType` with loaded members, or a clone if loading fails.
     fn load_struct_members(&self, var_type: &CairoVarType) -> CairoVarType {
-        // Check if we have identifiers
-        let identifiers_ptr = match self.identifiers {
-            Some(ptr) => ptr,
+        let identifiers = match self.identifiers {
+            Some(ptr) => unsafe { &*ptr },
             None => return var_type.clone(),
         };
 
-        let identifiers = unsafe { &*identifiers_ptr };
-
         match var_type {
-            CairoVarType::Struct { name, members, size } => {
-                // Only try to load if members is empty
-                if members.is_empty() {
-                    if let Some((new_members, new_size)) =
-                        get_struct_info_from_identifiers(identifiers, name)
-                    {
-                        return CairoVarType::Struct {
-                            name: name.clone(),
-                            members: new_members,
-                            size: new_size,
-                        };
+            CairoVarType::Struct { name, members, .. } if members.is_empty() => {
+                if let Some((new_members, new_size)) =
+                    get_struct_info_from_identifiers(identifiers, name)
+                {
+                    CairoVarType::Struct {
+                        name: name.clone(),
+                        members: new_members,
+                        size: new_size,
                     }
+                } else {
+                    var_type.clone()
                 }
-                // Return the original if we couldn't load members
-                CairoVarType::Struct { name: name.clone(), members: members.clone(), size: *size }
             }
             CairoVarType::Pointer { pointee } => {
-                // If it's a pointer to a struct, try to load the struct members
-                let new_pointee = Box::new(self.load_struct_members(pointee));
-                CairoVarType::Pointer { pointee: new_pointee }
+                CairoVarType::Pointer { pointee: Box::new(self.load_struct_members(pointee)) }
             }
-            // For other types, just return a clone
             _ => var_type.clone(),
         }
     }
 
-    /// Create a PyVmConst for a member of a struct
+    /// Creates a `PyVmConst` for a struct member.
+    ///
+    /// # Arguments
+    /// - `parent_name`: Name of the parent struct.
+    /// - `member_name`: Name of the member to access.
+    /// - `member`: Member definition from identifiers.
+    /// - `member_addr`: Memory address of the member.
+    ///
+    /// # Returns
+    /// A Python object representing the member (e.g., int, `PyRelocatable`, or `PyVmConst`).
     fn create_member_var(
         &self,
         parent_name: &str,
@@ -244,159 +243,186 @@ impl PyVmConst {
         member: &Member,
         member_addr: Relocatable,
     ) -> PyResult<PyObject> {
-        // Check if we have identifiers
-        let identifiers_ptr = match self.identifiers {
-            Some(ptr) => ptr,
-            None => {
-                return Err(PyErr::new::<pyo3::exceptions::PyAttributeError, _>(format!(
-                    "Could not get identifiers when creating member '{}'",
-                    member_name
-                )))
-            }
-        };
-
-        let identifiers = unsafe { &*identifiers_ptr };
+        let identifiers = self.identifiers.ok_or_else(|| {
+            PyAttributeError::new_err(format!(
+                "Identifiers missing when accessing member '{}'",
+                member_name
+            ))
+        })?;
+        let identifiers = unsafe { &*identifiers };
 
         Python::with_gil(|py| {
             let vm = unsafe { &mut *self.vm };
+            let value = vm.get_maybe(&member_addr).ok_or_else(|| {
+                PyAttributeError::new_err(format!(
+                    "Member '{}' not found in memory at {}",
+                    member_name, member_addr
+                ))
+            })?;
 
-            // Try to get the value from memory
-            if let Some(value) = vm.get_maybe(&member_addr) {
-                // Get member type from the member definition
-                let member_type = create_var_type(member.cairo_type.as_ref(), identifiers)
-                    .map_err(|e| {
-                        PyErr::new::<pyo3::exceptions::PyAttributeError, _>(e.to_string())
-                    })?;
+            let member_type = create_var_type(member.cairo_type.as_ref(), identifiers)
+                .map_err(|e| PyAttributeError::new_err(format!("Failed to create type: {}", e)))?;
 
-                // Based on the type, return different Python objects
-                match &member_type {
-                    CairoVarType::Felt => {
-                        // For felt types, return a Python int directly
-                        match &value {
-                            MaybeRelocatable::Int(felt) => {
-                                Ok(felt.to_biguint().into_bound_py_any(py)?.into())
-                            }
-                            MaybeRelocatable::RelocatableValue(rel) => {
-                                // If it's a relocatable but type is felt, still return the
-                                // relocatable This can happen for
-                                // range_check_ptr or __temp variables.
-                                let py_rel = PyRelocatable { inner: *rel };
-                                Ok(Py::new(py, py_rel)?.into_bound_py_any(py)?.into())
-                            }
-                        }
+            match member_type {
+                CairoVarType::Felt => match value {
+                    MaybeRelocatable::Int(felt) => {
+                        Ok(felt.to_biguint().into_bound_py_any(py)?.into())
                     }
-                    CairoVarType::Relocatable => {
-                        // For relocatable types, return a PyRelocatable directly
-                        match &value {
-                            MaybeRelocatable::RelocatableValue(rel) => {
-                                let py_rel = PyRelocatable { inner: *rel };
-                                Ok(Py::new(py, py_rel)?.into_bound_py_any(py)?.into())
-                            }
-                            _ => Err(PyErr::new::<pyo3::exceptions::PyAttributeError, _>(format!(
-                                "Expected relocatable value, got {}",
-                                value
-                            ))),
-                        }
+                    MaybeRelocatable::RelocatableValue(rel) => {
+                        // If it's a relocatable but type is felt, still return the
+                        // relocatable This can happen for
+                        // range_check_ptr or __temp variables.
+                        let py_rel = PyRelocatable { inner: rel };
+                        Ok(Py::new(py, py_rel)?.into_bound_py_any(py)?.into())
                     }
-                    _ => {
-                        // For structs and pointers, use PyVmConst
-                        let var = CairoVar {
-                            name: format!("{}.{}", parent_name, member_name),
-                            value: Some(value),
-                            address: Some(member_addr),
-                            var_type: member_type,
-                        };
-                        let py_member =
-                            PyVmConst { var, vm: self.vm, identifiers: self.identifiers };
-                        Ok(Py::new(py, py_member)?.into_bound_py_any(py)?.into())
+                },
+                CairoVarType::Relocatable => match value {
+                    // For relocatable types, return a PyRelocatable directly
+                    MaybeRelocatable::RelocatableValue(rel) => {
+                        let py_rel = PyRelocatable { inner: rel };
+                        Ok(Py::new(py, py_rel)?.into_bound_py_any(py)?.into())
                     }
+                    _ => Err(PyAttributeError::new_err(format!(
+                        "Expected relocatable value, got {}",
+                        value
+                    ))),
+                },
+                _ => {
+                    // For structs and pointers, use PyVmConst
+                    let var = CairoVar {
+                        name: format!("{}.{}", parent_name, member_name),
+                        value: Some(value),
+                        address: Some(member_addr),
+                        var_type: member_type,
+                    };
+                    let py_member = PyVmConst { var, vm: self.vm, identifiers: self.identifiers };
+                    Ok(Py::new(py, py_member)?.into_bound_py_any(py)?.into())
                 }
-            } else {
-                Err(PyErr::new::<pyo3::exceptions::PyAttributeError, _>(format!(
-                    "Member '{}' not found in memory",
-                    member_name
-                )))
             }
         })
     }
 
-    /// Returns the address of the variable, taking into account that if it's a pointer,
-    /// the address returned is the address of its pointee.
-    fn get_address(&self) -> Option<Relocatable> {
+    /// Gets the effective address of the variable, dereferencing pointers if applicable.
+    fn get_address(&self) -> PyResult<Option<Relocatable>> {
+        let vm = unsafe { &mut *self.vm };
         match &self.var.var_type {
             CairoVarType::Pointer { .. } => {
-                let vm = unsafe { &mut *self.vm };
-                vm.get_relocatable(self.var.address.unwrap())
-                    .map_or(Some(self.var.address.unwrap()), Some)
+                let addr = self
+                    .var
+                    .address
+                    .ok_or_else(|| PyAttributeError::new_err("Pointer has no address"))?;
+
+                // Note: when dereferencing a pointer like
+                // ```
+                // tempvar n = new U256Struct(100, 200);
+                // %{
+                //     assert ids.n.low == 100, f"ids.n.low: {ids.n.low}";
+                //     assert ids.n.high == 200, f"ids.n.high: {ids.n.high}";
+                // %}
+                // ```
+                // ids.n.low are located at address `addr`, not `get_relocatable(addr)` - hence the
+                // fallback.
+                Ok(Some(vm.get_relocatable(addr).map_or(addr, |r| r)))
             }
-            _ => self.var.address,
+            _ => Ok(self.var.address),
         }
     }
 }
 
 #[pymethods]
 impl PyVmConst {
-    /// Get the memory address of the variable
-    /// If the variable is a pointer, the rule is that the `.address_` access returns
-    /// the address of its pointee.
+    /// Gets the memory address of the variable as a `PyRelocatable`.
     #[getter]
     pub fn address_(&self, py: Python<'_>) -> PyResult<PyObject> {
-        match self.get_address() {
-            Some(addr) => {
-                let py_addr = PyRelocatable { inner: addr };
-                Ok(Py::new(py, py_addr)?.into_bound_py_any(py)?.into())
-            }
-            None => Err(PyErr::new::<pyo3::exceptions::PyAttributeError, _>(
-                "This variable does not have an address",
-            )),
-        }
+        let addr = self
+            .get_address()?
+            .ok_or_else(|| PyAttributeError::new_err("This variable does not have an address"))?;
+        let py_addr = PyRelocatable { inner: addr };
+        Ok(Py::new(py, py_addr)?.into_bound_py_any(py)?.into())
     }
 
-    /// Get a member of the variable if it's a struct
+    /// Accesses attributes or members of the variable.
     pub fn __getattr__(&self, name: &str, py: Python<'_>) -> PyResult<PyObject> {
         if name == "address_" {
             return self.address_(py);
         }
 
-        // // Create a possibly updated var_type with lazily loaded members
+        // Create a possibly updated var_type with lazily loaded members
         // TODO: come back to this and see whether we can avoid loading the members here - having
         // them already available
         let var_type = self.load_struct_members(&self.var.var_type);
+        let vm = unsafe { &mut *self.vm };
 
-        // Handle different types
-        match &var_type {
+        match var_type {
             CairoVarType::Felt => match &self.var.value {
                 Some(MaybeRelocatable::Int(felt)) => {
                     Ok(felt.to_biguint().into_bound_py_any(py)?.into())
                 }
-                _ => Err(PyErr::new::<pyo3::exceptions::PyAttributeError, _>(format!(
+                _ => Err(PyAttributeError::new_err(format!(
                     "Expected felt value, got {:?}",
                     self.var.value
                 ))),
             },
-
             CairoVarType::Relocatable => match &self.var.value {
                 Some(MaybeRelocatable::RelocatableValue(rel)) => {
-                    Ok(Py::new(py, PyRelocatable { inner: *rel })?.into_bound_py_any(py)?.into())
+                    let py_rel = PyRelocatable { inner: *rel };
+                    Ok(Py::new(py, py_rel)?.into_bound_py_any(py)?.into())
                 }
-                _ => Err(PyErr::new::<pyo3::exceptions::PyAttributeError, _>(format!(
+                _ => Err(PyAttributeError::new_err(format!(
                     "Expected relocatable value, got {:?}",
                     self.var.value
                 ))),
             },
-
             CairoVarType::Struct { members, size, .. } => {
+                if name == "SIZE" {
+                    return Ok(size.into_bound_py_any(py)?.into());
+                }
                 // Check if the member exists and the struct has an address
-                if let (Some(member), Some(addr)) = (members.get(name), self.var.address) {
-                    // Extract offset as a numeric value we can use for address calculation
-                    let offset_value = member.offset;
-                    let member_addr = (addr + offset_value).map_err(|e| {
-                        PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string())
+                let (member, addr) = match (members.get(name), self.var.address) {
+                    (Some(m), Some(a)) => (m, a),
+                    _ => {
+                        return Err(PyAttributeError::new_err(format!(
+                            "Struct has no member '{}' or no address",
+                            name
+                        )))
+                    }
+                };
+                let member_addr = (addr + member.offset).map_err(|e| {
+                    PyRuntimeError::new_err(format!("Address calculation failed: {}", e))
+                })?;
+
+                // Check if the member is a felt* and return a PyRelocatable directly
+                if member.cairo_type.as_str() == "felt*" {
+                    if let Some(MaybeRelocatable::RelocatableValue(rel)) =
+                        vm.get_maybe(&member_addr)
+                    {
+                        let py_rel = PyRelocatable { inner: rel };
+                        return Ok(Py::new(py, py_rel)?.into_bound_py_any(py)?.into());
+                    }
+                }
+                self.create_member_var(&self.var.name, name, member, member_addr)
+            }
+            CairoVarType::Pointer { ref pointee } => {
+                // If it's a pointer to a struct, we need to access the struct members directly
+                if let CairoVarType::Struct { members, .. } = pointee.as_ref() {
+                    let member = members.get(name).ok_or_else(|| {
+                        PyAttributeError::new_err(format!(
+                            "Struct pointed to by '{}' has no member '{}'",
+                            self.var.name, name
+                        ))
+                    })?;
+                    // For pointers, we need to:
+                    // 1. Get the address the pointer points to
+                    // 2. Calculate the member address by adding the offset to the pointer
+                    let ptr_addr = self
+                        .get_address()?
+                        .ok_or_else(|| PyAttributeError::new_err("Pointer has no address"))?;
+                    let member_addr = (ptr_addr + member.offset).map_err(|e| {
+                        PyRuntimeError::new_err(format!("Address calculation failed: {}", e))
                     })?;
 
                     // Check if the member is a felt* and return a PyRelocatable directly
                     if member.cairo_type.as_str() == "felt*" {
-                        let vm = unsafe { &mut *self.vm };
                         if let Some(MaybeRelocatable::RelocatableValue(rel)) =
                             vm.get_maybe(&member_addr)
                         {
@@ -404,82 +430,31 @@ impl PyVmConst {
                             return Ok(Py::new(py, py_rel)?.into_bound_py_any(py)?.into());
                         }
                     }
-
-                    self.create_member_var(&self.var.name, name, member, member_addr)
-                } else if name == "SIZE" {
-                    // Special case for SIZE member
-                    return Ok(size.into_bound_py_any(py)?.into());
+                    // 3. Create a member variable at that address
+                    self.create_member_var(
+                        &format!("(*{})", self.var.name),
+                        name,
+                        member,
+                        member_addr,
+                    )
                 } else {
-                    Err(PyErr::new::<pyo3::exceptions::PyAttributeError, _>(format!(
-                        "Could not get member and address for struct '{}'",
-                        name
-                    )))
-                }
-            }
-            CairoVarType::Pointer { pointee, .. } => {
-                // If it's a pointer to a struct, we need to access the struct members directly
-                if let CairoVarType::Struct { members, .. } = pointee.as_ref() {
-                    // Check if the member exists in the struct
-                    let vm = unsafe { &mut *self.vm };
-
-                    if let (Some(member), Some(var_address)) = (members.get(name), self.var.address)
-                    {
-                        // For pointers, we need to:
-                        // 1. Get the address the pointer points to
-                        // 2. Calculate the member address by adding the offset to the pointer
-                        let ptr_addr = self.get_address().unwrap();
-                        let offset_value = member.offset;
-                        let member_addr = (ptr_addr + offset_value).map_err(|e| {
-                            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string())
-                        })?;
-
-                        // Check if the member is a felt* and return a PyRelocatable directly
-                        if member.cairo_type.as_str() == "felt*" {
-                            if let Some(MaybeRelocatable::RelocatableValue(rel)) =
-                                vm.get_maybe(&member_addr)
-                            {
-                                let py_rel = PyRelocatable { inner: rel };
-                                return Ok(Py::new(py, py_rel)?.into_bound_py_any(py)?.into());
-                            }
-                        }
-
-                        // 3. Create a member variable at that address
-                        self.create_member_var(
-                            &format!("(*{})", self.var.name),
-                            name,
-                            member,
-                            member_addr,
-                        )
-                    } else {
-                        Err(PyErr::new::<pyo3::exceptions::PyAttributeError, _>(format!(
-                            "'{}' is not a member of the struct pointed to by '{}'",
-                            name, self.var.name
-                        )))
-                    }
-                } else {
-                    Err(PyErr::new::<pyo3::exceptions::PyAttributeError, _>(format!(
+                    Err(PyAttributeError::new_err(format!(
                         "'{}' is not a pointer to a struct",
                         self.var.name
                     )))
                 }
             }
-            _ => Err(PyErr::new::<pyo3::exceptions::PyAttributeError, _>(format!(
-                "'{}' has no attribute '{}'",
-                self.var.name, name
-            ))),
         }
     }
 
-    /// Returns the path to the type of the variable
+    /// Gets the type path as a list of strings (for structs only).
     #[getter]
     pub fn type_path(&self) -> Option<Vec<String>> {
         match &self.var.var_type {
-            CairoVarType::Struct { name, .. } => {
-                Some(name.clone().split(".").map(|s| s.to_string()).collect())
-            }
+            CairoVarType::Struct { name, .. } => Some(name.split('.').map(String::from).collect()),
             CairoVarType::Pointer { pointee, .. } => match &**pointee {
                 CairoVarType::Struct { name, .. } => {
-                    Some(name.clone().split(".").map(|s| s.to_string()).collect())
+                    Some(name.split('.').map(String::from).collect())
                 }
                 _ => None,
             },
@@ -487,11 +462,12 @@ impl PyVmConst {
         }
     }
 
-    fn is_pointer(&self) -> bool {
+    /// Checks if the variable is a pointer.
+    pub fn is_pointer(&self) -> bool {
         matches!(self.var.var_type, CairoVarType::Pointer { .. })
     }
 
-    /// Get the type name of the variable
+    /// Gets the type name as a string.
     pub fn type_name(&self) -> String {
         match &self.var.var_type {
             CairoVarType::Felt => "felt".to_string(),
@@ -506,31 +482,19 @@ impl PyVmConst {
         }
     }
 
-    /// String representation
+    /// Returns a string representation of the variable.
     pub fn __str__(&self) -> String {
         match &self.var.var_type {
-            CairoVarType::Struct { name, .. } => {
-                format!("{}({})", name, self.var.name)
-            }
+            CairoVarType::Struct { name, .. } => format!("{}({})", name, self.var.name),
             CairoVarType::Pointer { pointee, .. } => match &**pointee {
-                CairoVarType::Struct { name, .. } => {
-                    format!("{}*({})", name, self.var.name)
-                }
-                _ => match &self.var.value {
-                    Some(MaybeRelocatable::Int(felt)) => format!("{}", felt),
-                    Some(MaybeRelocatable::RelocatableValue(rel)) => format!("{}", rel),
-                    None => "None".to_string(),
-                },
+                CairoVarType::Struct { name, .. } => format!("{}*({})", name, self.var.name),
+                _ => self.var.value.as_ref().map_or("None".to_string(), |v| v.to_string()),
             },
-            _ => match &self.var.value {
-                Some(MaybeRelocatable::Int(felt)) => format!("{}", felt),
-                Some(MaybeRelocatable::RelocatableValue(rel)) => format!("{}", rel),
-                None => "None".to_string(),
-            },
+            _ => self.var.value.as_ref().map_or("None".to_string(), |v| v.to_string()),
         }
     }
 
-    /// Repr string
+    /// Returns a detailed representation string.
     pub fn __repr__(&self) -> String {
         format!(
             "VmConst(name='{}', path={:?}, address={:?})",
@@ -540,40 +504,34 @@ impl PyVmConst {
         )
     }
 
-    /// Dereference this variable if it's a pointer
+    /// Dereferences a pointer variable.
     pub fn deref(&self, py: Python<'_>) -> PyResult<PyObject> {
-        // Check if this is a pointer type
-        if let CairoVarType::Pointer { pointee, .. } = &self.var.var_type {
-            // Get the relocatable value
-            if let Some(MaybeRelocatable::RelocatableValue(rel)) = self.var.value {
-                let vm = unsafe { &mut *self.vm };
-
-                // Try to get the value at the pointer location
-                if let Some(pointed_value) = vm.get_maybe(&rel) {
-                    // Create a new CairoVar for the dereferenced value
-                    let deref_var = CairoVar {
-                        name: format!("*{}", self.var.name),
-                        value: Some(pointed_value),
-                        address: Some(rel),
-                        var_type: (**pointee).clone(),
-                    };
-
-                    let py_deref =
-                        PyVmConst { var: deref_var, vm: self.vm, identifiers: self.identifiers };
-                    return Ok(Py::new(py, py_deref)?.into_bound_py_any(py)?.into());
-                } else {
-                    return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                        "Could not dereference pointer: no value at address {}",
-                        rel
-                    )));
+        if let CairoVarType::Pointer { pointee } = &self.var.var_type {
+            let rel = match self.var.value {
+                Some(MaybeRelocatable::RelocatableValue(r)) => r,
+                _ => {
+                    return Err(PyTypeError::new_err(format!(
+                        "Cannot dereference '{}': not a pointer with a relocatable value",
+                        self.var.name
+                    )))
                 }
-            }
-        }
+            };
+            let vm = unsafe { &mut *self.vm };
+            let pointed_value = vm.get_maybe(&rel).ok_or_else(|| {
+                PyRuntimeError::new_err(format!("Could not dereference pointer at {}", rel))
+            })?;
 
-        Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
-            "Cannot dereference non-pointer value: {}",
-            self.var.name
-        )))
+            let deref_var = CairoVar {
+                name: format!("*{}", self.var.name),
+                value: Some(pointed_value),
+                address: Some(rel),
+                var_type: (**pointee).clone(),
+            };
+            let py_deref = PyVmConst { var: deref_var, vm: self.vm, identifiers: self.identifiers };
+            Ok(Py::new(py, py_deref)?.into_bound_py_any(py)?.into())
+        } else {
+            Err(PyTypeError::new_err(format!("Cannot dereference non-pointer '{}'", self.var.name)))
+        }
     }
 }
 
@@ -614,97 +572,102 @@ impl PyVmConst {
 /// See module-level documentation for more usage examples.
 #[pyclass(name = "VmConstsDict", unsendable)]
 pub struct PyVmConstsDict {
-    /// Map of variable names to Python objects
+    /// Map of variable names to their Python representations.
     pub(crate) items: HashMap<String, Py<PyAny>>,
+    /// Pointer to the VM for memory operations.
     pub(crate) vm: *mut VirtualMachine,
 }
 
 #[pymethods]
 impl PyVmConstsDict {
-    /// Get a variable by name
+    /// Gets a variable by name.
     pub fn __getattr__(&self, name: &str, py: Python<'_>) -> PyResult<PyObject> {
-        match self.items.get(name) {
-            Some(var) => {
-                // Extract the Python object - this could be a PyVmConst or a native Python type
-                // like int
-                Ok(var.clone_ref(py).into_bound_py_any(py)?.into())
-            }
-            None => Err(PyErr::new::<pyo3::exceptions::PyAttributeError, _>(format!(
-                "'VmConstsDict' object has no attribute '{}'",
-                name
-            ))),
-        }
+        self.items
+            .get(name)
+            .ok_or_else(|| PyAttributeError::new_err(format!("No variable '{}'", name)))
+            .and_then(|var| {
+                let bound_py = var.clone_ref(py).into_bound_py_any(py)?;
+                Ok(bound_py.into())
+            })
     }
 
-    /// Set a variable in the VmConstsDict. If the variable is not a part of the VmConstsDict
-    /// already, it will be added.
+    /// Sets a variable's value if it exists and is unassigned.
     pub fn __setattr__(&mut self, name: &str, value: Py<PyAny>, py: Python<'_>) -> PyResult<()> {
-        match self.items.get_mut(name) {
-            Some(var) => {
-                let mut vm_const = match var.downcast_bound::<PyVmConst>(py) {
-                    Ok(vm_const) => vm_const.as_unbound().borrow_mut(py),
-                    Err(_) => {
-                        return Err(PyErr::new::<pyo3::exceptions::PyAttributeError, _>(format!(
-                            "Expected PyVmConst for var {}, got {:?}",
-                            name, var
-                        )))
-                    }
-                };
-                if vm_const.var.value.is_some() {
-                    return Err(PyErr::new::<pyo3::exceptions::PyAttributeError, _>(format!(
-                        "Cannot set value for var {}, it already has a value",
-                        name
-                    )));
-                }
-                let maybe_relocatable = value.extract::<PyMaybeRelocatable>(py)?;
-                vm_const.var.value = Some(maybe_relocatable.clone().into());
-                let vm = unsafe { &mut *self.vm };
-                vm.insert_value::<MaybeRelocatable>(
-                    vm_const.var.address.unwrap(),
-                    maybe_relocatable.into(),
-                );
-                Ok(())
-            }
-            None => Err(PyErr::new::<pyo3::exceptions::PyAttributeError, _>(format!(
-                "'VmConstsDict' object has no attribute '{}'",
+        let var = self
+            .items
+            .get_mut(name)
+            .ok_or_else(|| PyAttributeError::new_err(format!("No variable '{}' to set", name)))?;
+        let mut vm_const = var
+            .downcast_bound::<PyVmConst>(py)
+            .map_err(|_| {
+                PyAttributeError::new_err(format!("Variable '{}' is not a VmConst", name))
+            })?
+            .as_unbound()
+            .borrow_mut(py);
+
+        if vm_const.var.value.is_some() {
+            return Err(PyAttributeError::new_err(format!(
+                "Cannot set '{}': already has a value",
                 name
-            ))),
+            )));
         }
+
+        let maybe_relocatable = value.extract::<PyMaybeRelocatable>(py)?;
+        vm_const.var.value = Some(maybe_relocatable.clone().into());
+        let vm = unsafe { &mut *self.vm };
+        vm.insert_value::<MaybeRelocatable>(
+            vm_const
+                .var
+                .address
+                .ok_or_else(|| PyRuntimeError::new_err(format!("No address for '{}'", name)))?,
+            maybe_relocatable.into(),
+        )
+        .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+        Ok(())
     }
 
-    /// Get a variable by dictionary access
+    /// Dictionary-style variable access.
     pub fn __getitem__(&self, name: &str, py: Python<'_>) -> PyResult<PyObject> {
         self.__getattr__(name, py)
     }
 
-    /// Add or update a variable - accepts any Python object
+    /// Adds or updates a variable in the dictionary.
     pub fn set_item(&mut self, key: &str, value: Py<PyAny>) {
         self.items.insert(key.to_string(), value);
     }
 
-    /// Get all keys
+    /// Lists all variable names.
     pub fn keys(&self, py: Python<'_>) -> PyResult<PyObject> {
-        let keys = PyList::new(py, self.items.keys().map(|k| k.as_str()))?;
-        Ok(keys.into())
+        Ok(PyList::new(py, self.items.keys().map(|k| k.as_str()))?.into())
     }
 
-    /// Used for dir() in Python
+    /// Supports Python's `dir()` function.
     pub fn __dir__(&self, py: Python<'_>) -> PyResult<PyObject> {
         self.keys(py)
     }
 
-    /// String representation
+    /// String representation.
     pub fn __str__(&self) -> String {
         format!("VmConstsDict with {} items", self.items.len())
     }
 
-    /// Repr string
+    /// Detailed representation.
     pub fn __repr__(&self) -> String {
         format!("VmConstsDict({:?})", self.items.keys().collect::<Vec<_>>())
     }
 }
 
-/// Creates a VmConstsDict from the variable accessible from the hint in `ids_data`.
+/// Creates a `PyVmConstsDict` from hint variables.
+///
+/// # Arguments
+/// - `vm`: The Cairo virtual machine instance.
+/// - `identifiers`: Program identifiers for type resolution.
+/// - `ids_data`: Hint references mapping names to variable metadata.
+/// - `ap_tracking`: AP Tracking data
+/// - `py`: Python GIL token.
+///
+/// # Returns
+/// A `PyResult` containing the constructed dictionary or a `DynamicHintError`.
 pub fn create_vm_consts_dict(
     vm: &mut VirtualMachine,
     identifiers: &HashMap<String, Identifier>,
@@ -713,63 +676,81 @@ pub fn create_vm_consts_dict(
     py: Python<'_>,
 ) -> Result<Py<PyVmConstsDict>, DynamicHintError> {
     let ids_dict = PyVmConstsDict { items: HashMap::new(), vm: vm as *mut VirtualMachine };
-
     let py_ids_dict = Py::new(py, ids_dict)?;
 
-    // Extract variables from ids_data. We basically just iterate over the ids_data and add the
-    // variables to the dictionary - after properly handling the different types.
-    // This function is not recursive, so it does not handle the inner members of structs. Instead,
-    // these will be loaded lazily when the variable is accessed.
     for (name, reference) in ids_data {
-        let cairo_type = reference.cairo_type.clone();
+        let cairo_type = reference.cairo_type.as_ref().ok_or_else(|| {
+            DynamicHintError::UnknownVariableType(format!("No type for '{}'", name))
+        })?;
+        let var_addr = get_relocatable_from_var_name(name, vm, ids_data, ap_tracking)
+            .map_err(|e| DynamicHintError::MemoryError(e.to_string()))?;
+        // Some variables don't have values yet; e.g.
+        // ```
+        // tempvar x: U256
+        // %{ my_hint }
+        // ```
+        let value = vm.get_maybe(&var_addr);
 
-        // Get the address for the variable - we don't know its type yet.
-        if let Ok(var_addr) = get_relocatable_from_var_name(name, vm, ids_data, ap_tracking) {
-            // Some variables don't have values yet; e.g.
-            // ```
-            // tempvar x: U256
-            // %{ my_hint }
-            //
-            // // If the variable has no value, insert a None object.
-            // let var = CairoVar {
-            //     name: name.clone(),
-            //     value: MaybeRelocatable::Int(Felt252::ZERO),
-            //     address: Some(var_addr),
-            //     var_type: CairoVarType::Felt,
-            // };
-
-            // py_ids_dict
-            //     .borrow_mut(py)
-            //     .set_item(name, PyNone::get(py).into_bound_py_any(py)?.into());
-
-            let value = vm.get_maybe(&var_addr);
-            // Based on the cairo_type and value, return different Python objects
-            // to match the original Python VmConsts behavior.
-
-            // Case 1: The variable is a felt
-            if let Some(ref type_str) = cairo_type {
-                if type_str == "felt" {
-                    // It's a felt - return Python int directly
-                    match &value {
-                        Some(MaybeRelocatable::Int(felt)) => {
-                            // Convert to Python int
-                            let py_int = felt.to_biguint().into_bound_py_any(py)?.into();
-                            py_ids_dict.borrow_mut(py).items.insert(name.clone(), py_int);
-                        }
+        // Based on the cairo_type and value, return different Python objects
+        // to match the original Python VmConsts behavior.
+        match cairo_type.as_str() {
+            "felt" => match value {
+                Some(MaybeRelocatable::Int(felt)) => {
+                    // Convert to python int
+                    py_ids_dict
+                        .borrow_mut(py)
+                        .items
+                        .insert(name.clone(), felt.to_biguint().into_bound_py_any(py)?.into());
+                }
+                Some(MaybeRelocatable::RelocatableValue(rel)) => {
+                    // Convert to PyRelocatable
+                    let py_rel = PyRelocatable { inner: rel };
+                    py_ids_dict
+                        .borrow_mut(py)
+                        .items
+                        .insert(name.clone(), Py::new(py, py_rel)?.into_bound_py_any(py)?.into());
+                }
+                None => {
+                    // Create a CairoVar with no value
+                    let var = CairoVar {
+                        name: name.clone(),
+                        value: None,
+                        address: Some(var_addr),
+                        var_type: CairoVarType::Felt,
+                    };
+                    let py_var = PyVmConst {
+                        var,
+                        vm: vm as *mut VirtualMachine,
+                        identifiers: Some(identifiers as *const HashMap<String, Identifier>),
+                    };
+                    py_ids_dict
+                        .borrow_mut(py)
+                        .items
+                        .insert(name.clone(), Py::new(py, py_var)?.into_bound_py_any(py)?.into());
+                }
+            },
+            t if t.ends_with('*') => {
+                // Pointer types
+                let address =
+                    get_ptr_from_var_name(name, vm, ids_data, ap_tracking).unwrap_or(var_addr);
+                let var_type = create_var_type(t, identifiers)?;
+                if t == "felt*" {
+                    // Case 2.1: The pointer is to a felt type
+                    match value {
                         Some(MaybeRelocatable::RelocatableValue(rel)) => {
-                            // Special case for relocatable value with felt type
-                            // Return the relocatable
-                            let py_rel = PyRelocatable { inner: *rel };
-                            let py_rel_obj = Py::new(py, py_rel)?.into_bound_py_any(py)?.into();
-                            py_ids_dict.borrow_mut(py).items.insert(name.clone(), py_rel_obj);
+                            let py_rel = PyRelocatable { inner: rel };
+                            py_ids_dict.borrow_mut(py).items.insert(
+                                name.clone(),
+                                Py::new(py, py_rel)?.into_bound_py_any(py)?.into(),
+                            );
                         }
                         None => {
-                            // If the variable has no value, insert a None object.
+                            // Create a CairoVar with no value
                             let var = CairoVar {
                                 name: name.clone(),
                                 value: None,
-                                address: Some(var_addr),
-                                var_type: CairoVarType::Felt,
+                                address: Some(address),
+                                var_type,
                             };
                             let py_var = PyVmConst {
                                 var,
@@ -778,109 +759,56 @@ pub fn create_vm_consts_dict(
                                     identifiers as *const HashMap<String, Identifier>,
                                 ),
                             };
-                            let py_var_obj = Py::new(py, py_var)?.into_bound_py_any(py)?.into();
-                            py_ids_dict.borrow_mut(py).items.insert(name.clone(), py_var_obj);
+                            py_ids_dict
+                                .borrow_mut(py)
+                                .set_item(name, Py::new(py, py_var)?.into_bound_py_any(py)?.into());
                         }
-                    }
-                } else if type_str.ends_with('*') {
-                    // Case 2: The variable is a pointer
-                    let address =
-                        get_ptr_from_var_name(name, vm, ids_data, ap_tracking).unwrap_or(var_addr);
-
-                    // Create a CairoVarType based on the type_str
-                    let var_type = create_var_type(type_str, identifiers).map_err(|e| {
-                        PyErr::new::<pyo3::exceptions::PyAttributeError, _>(e.to_string())
-                    })?;
-
-                    // Case 2.1: The pointer is to a felt
-                    if type_str == "felt*" {
-                        // Pointer to a felt - return PyRelocatable directly
-                        match &value {
-                            Some(MaybeRelocatable::RelocatableValue(rel)) => {
-                                let py_rel = PyRelocatable { inner: *rel };
-                                let py_rel_obj = Py::new(py, py_rel)?.into_bound_py_any(py)?.into();
-                                py_ids_dict.borrow_mut(py).items.insert(name.clone(), py_rel_obj);
-                            }
-                            None => {
-                                // If the variable has no value, insert a None object.
-                                let var = CairoVar {
-                                    name: name.clone(),
-                                    value: None,
-                                    address: Some(address),
-                                    var_type,
-                                };
-                                let py_var = PyVmConst {
-                                    var,
-                                    vm: vm as *mut VirtualMachine,
-                                    identifiers: Some(
-                                        identifiers as *const HashMap<String, Identifier>,
-                                    ),
-                                };
-                                let py_var_obj = Py::new(py, py_var)?.into_bound_py_any(py)?.into();
-                                py_ids_dict.borrow_mut(py).set_item(name, py_var_obj);
-                            }
-                            _ => {
-                                // Unexpected case, but handle it by creating a PyVmConst
-                                let var = CairoVar {
-                                    name: name.clone(),
-                                    value: value.clone(),
-                                    address: Some(address),
-                                    var_type,
-                                };
-                                let py_var = PyVmConst {
-                                    var,
-                                    vm: vm as *mut VirtualMachine,
-                                    identifiers: Some(
-                                        identifiers as *const HashMap<String, Identifier>,
-                                    ),
-                                };
-                                let py_var_obj = Py::new(py, py_var)?.into_bound_py_any(py)?.into();
-                                py_ids_dict.borrow_mut(py).set_item(name, py_var_obj);
-                            }
+                        _ => {
+                            let var = CairoVar {
+                                name: name.clone(),
+                                value,
+                                address: Some(address),
+                                var_type,
+                            };
+                            let py_var = PyVmConst {
+                                var,
+                                vm: vm as *mut VirtualMachine,
+                                identifiers: Some(
+                                    identifiers as *const HashMap<String, Identifier>,
+                                ),
+                            };
+                            py_ids_dict
+                                .borrow_mut(py)
+                                .set_item(name, Py::new(py, py_var)?.into_bound_py_any(py)?.into());
                         }
-                    } else {
-                        // Case 2.2: The pointer is to a non-felt type
-                        let var = CairoVar {
-                            name: name.clone(),
-                            value: value.clone(),
-                            address: Some(address),
-                            var_type,
-                        };
-                        let py_var = PyVmConst {
-                            var,
-                            vm: vm as *mut VirtualMachine,
-                            identifiers: Some(identifiers as *const HashMap<String, Identifier>),
-                        };
-                        let py_var_obj = Py::new(py, py_var)?.into_bound_py_any(py)?.into();
-                        py_ids_dict.borrow_mut(py).set_item(name, py_var_obj);
                     }
                 } else {
-                    // Case 3: The variable is a struct. In that case we return a PyVmConst
-                    // that will load the struct members lazily when the variable is accessed.
-                    let address = get_relocatable_from_var_name(name, vm, ids_data, ap_tracking)
-                        .unwrap_or(var_addr);
-
-                    // Create a CairoVarType based on the type_str
-                    let var_type = create_var_type(type_str, identifiers).map_err(|e| {
-                        PyErr::new::<pyo3::exceptions::PyAttributeError, _>(e.to_string())
-                    })?;
-
-                    let var = CairoVar {
-                        name: name.clone(),
-                        value: value.clone(),
-                        address: Some(address),
-                        var_type,
-                    };
+                    // Case 2.2: The pointer is to a non-felt type
+                    let var =
+                        CairoVar { name: name.clone(), value, address: Some(address), var_type };
                     let py_var = PyVmConst {
                         var,
                         vm: vm as *mut VirtualMachine,
                         identifiers: Some(identifiers as *const HashMap<String, Identifier>),
                     };
-                    let py_var_obj = Py::new(py, py_var)?.into_bound_py_any(py)?.into();
-                    py_ids_dict.borrow_mut(py).set_item(name, py_var_obj);
+                    py_ids_dict
+                        .borrow_mut(py)
+                        .set_item(name, Py::new(py, py_var)?.into_bound_py_any(py)?.into());
                 }
-            } else {
-                return Err(DynamicHintError::UnknownVariableType(name.clone()));
+            }
+            // Case 3: The variable is a struct. In that case we return a PyVmConst
+            // that will load the struct members lazily when the variable is accessed.
+            _ => {
+                let var_type = create_var_type(cairo_type, identifiers)?;
+                let var = CairoVar { name: name.clone(), value, address: Some(var_addr), var_type };
+                let py_var = PyVmConst {
+                    var,
+                    vm: vm as *mut VirtualMachine,
+                    identifiers: Some(identifiers as *const HashMap<String, Identifier>),
+                };
+                py_ids_dict
+                    .borrow_mut(py)
+                    .set_item(name, Py::new(py, py_var)?.into_bound_py_any(py)?.into());
             }
         }
     }

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -279,3 +279,5 @@ pathlib
 kwargs
 pythonic
 functools
+setattr
+pyfunction

--- a/python/cairo-addons/src/cairo_addons/hints/injected.py
+++ b/python/cairo-addons/src/cairo_addons/hints/injected.py
@@ -65,6 +65,10 @@ def prepare_context(context: Callable[[], dict]):
 
     context()["serialize"] = serialize
 
+    from tests.utils.args_gen import _gen_arg
+
+    context()["_gen_arg"] = _gen_arg
+
 
 def initialize_hint_environment(context: Callable[[], dict]):
     """Initialize the hint environment with all necessary components.

--- a/python/cairo-addons/src/cairo_addons/testing/hooks.py
+++ b/python/cairo-addons/src/cairo_addons/testing/hooks.py
@@ -101,6 +101,12 @@ def pytest_addoption(parser):
         type=int,
         help="The seed to set random with.",
     )
+    parser.addoption(
+        "--disable-pythonic-hints",
+        action="store_true",
+        default=False,
+        help="Disable pythonic hints in the RustVM runner",
+    )
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/python/cairo-addons/src/cairo_addons/testing/runner.py
+++ b/python/cairo-addons/src/cairo_addons/testing/runner.py
@@ -517,9 +517,13 @@ def run_rust_vm(
         #   Unlike Python VM, we don’t append "jmp rel 0" here as Rust handles proof mode differently.
         # ============================================================================
         proof_mode = request.config.getoption("proof_mode")
-        enable_pythonic_hints = request.config.getoption(
-            "--log-cli-level"
-        ) == "TRACE" or not request.config.getoption("disable_pythonic_hints")
+        enable_pythonic_hints = (
+            request.config.getoption("--log-cli-level") == "TRACE"
+            or not request.config.getoption("disable_pythonic_hints")
+            or getattr(request.node, "pytestmark", [{}])[0].get(
+                "enable_pythonic_hints", True
+            )
+        )
         runner = RustCairoRunner(
             program=rust_program,
             py_identifiers=cairo_program.identifiers,

--- a/python/cairo-addons/src/cairo_addons/testing/runner.py
+++ b/python/cairo-addons/src/cairo_addons/testing/runner.py
@@ -512,14 +512,16 @@ def run_rust_vm(
         #   Unlike Python VM, we don’t append "jmp rel 0" here as Rust handles proof mode differently.
         # ============================================================================
         proof_mode = request.config.getoption("proof_mode")
+        enable_pythonic_hints = request.config.getoption(
+            "--log-cli-level"
+        ) == "TRACE" or not request.config.getoption("disable_pythonic_hints")
         runner = RustCairoRunner(
             program=rust_program,
             py_identifiers=cairo_program.identifiers,
             layout=getattr(LAYOUTS, request.config.getoption("layout")).layout_name,
             proof_mode=proof_mode,
             allow_missing_builtins=False,
-            enable_pythonic_hints=request.config.getoption("--log-cli-level")
-            == "TRACE",
+            enable_pythonic_hints=enable_pythonic_hints,
             ordered_builtins=_builtins,
         )
         serde = serde_cls(

--- a/python/cairo-addons/src/cairo_addons/testing/runner.py
+++ b/python/cairo-addons/src/cairo_addons/testing/runner.py
@@ -300,6 +300,11 @@ def run_python_vm(
                     program_identifiers=cairo_program.identifiers,
                     dict_manager=dict_manager,
                 ),
+                "gen_arg": partial(
+                    context["_gen_arg"],
+                    dict_manager,
+                    runner.segments,
+                ),
                 **(hint_locals or {}),
             },
             static_locals={


### PR DESCRIPTION
# Enhanced Cairo VM Variable Access for Python Hints

Closes https://github.com/kkrt-labs/keth/issues/908
Closes #961 
Closes #964

## Description

This PR significantly improves the interaction between Cairo variables and Python hints by enhancing the variable access system in the Rust VM. It adds comprehensive test cases and implements several key features to make Python hints more powerful and intuitive.

## Key Changes

- **Variable Access Improvements**: Added support for accessing `ap`, `pc`, and `fp` directly in Python hints
- **Memory Management**: Implemented `__setitem__` in `PyMemoryWrapper` to allow setting memory values
- **Variable Assignment**: Added ability to assign values to unassigned Cairo variables from Python hints
- **Struct Member Access**: Enhanced support for accessing struct members and nested structs
- **Pointer Dereferencing**: Improved pointer handling with proper dereferencing
- **Test Coverage**: Added comprehensive test cases for all new functionality

## New Features

- **Pointer Handling**: Properly dereference pointers and access their members
- **Variable Assignment**: Set values for unassigned variables (`ids.x = 100`)
- **Memory Access**: Direct memory manipulation (`memory[ap-1] = 100`)
- **Serialization & Argument Generation**: Support for `serialize` and `gen_arg` functions in hints

## Test Coverage

Added extensive test cases in `test_hint_runner.cairo` and `test_hint_runner.py` to verify:
- Access to VM registers (ap, pc, fp)
- Variable assignment
- Struct member access
- Pointer dereferencing
- Memory manipulation
- Serialization and argument generation

These improvements make Python hints more powerful and intuitive, bringing the Rust VM closer to feature parity with the original Python implementation.
