### PR TITLE
feat: e2e Keth block proving

### DIFF
--- a/.github/workflows/nightly_fuzzing.yml
+++ b/.github/workflows/nightly_fuzzing.yml
@@ -39,7 +39,7 @@ jobs:
         id: unit-tests
         continue-on-error: true
         run: |
-          uv run --reinstall pytest -n logical --durations=0 --disable-pythonic-hints -v -s --log-cli-level=DEBUG --no-skip-cached-tests --ignore-glob=cairo/tests/ef_tests/
+          uv run --reinstall pytest -n logical --durations=0 -v -s --log-cli-level=DEBUG --no-skip-cached-tests --ignore-glob=cairo/tests/ef_tests/
 
       - name: Upload coverage
         uses: codecov/codecov-action@v5
@@ -80,7 +80,7 @@ jobs:
         continue-on-error: true
         # Running on 48 cores to avoid out of memory issues
         run: |
-          uv run --reinstall pytest -n 48 -m "not slow" --disable-pythonic-hints --durations=0 -v -s --log-cli-level=DEBUG cairo/tests/ef_tests/ --ignore-glob='cairo/tests/ef_tests/fixtures/*'
+          uv run --reinstall pytest -n 48 -m "not slow" --durations=0 -v -s --log-cli-level=DEBUG cairo/tests/ef_tests/ --ignore-glob='cairo/tests/ef_tests/fixtures/*'
       - name: Notify Slack on Failure
         if: steps.ef-tests.outcome == 'failure'
         uses: slackapi/slack-github-action@v1.24.0

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -44,7 +44,7 @@ jobs:
       # <https://github.com/kkrt-labs/keth/issues/694>
       - name: Run unit tests without caching
         run: |
-          uv run --reinstall pytest -n logical --durations=0 --disable-pythonic-hints -v -s --log-cli-level=DEBUG --no-skip-cached-tests --ignore-glob=cairo/tests/ef_tests/
+          uv run --reinstall pytest -n logical --durations=0 -v -s --log-cli-level=DEBUG --no-skip-cached-tests --ignore-glob=cairo/tests/ef_tests/
 
       - uses: actions/cache/save@v4
         with:
@@ -77,7 +77,7 @@ jobs:
         run: |
           # Runs up to ${{ inputs.max-tests }} tests, randomly sampled using the GITHUB_RUN_ID seed
           # Use only 48 cores to avoid out of memory issues
-          uv run --reinstall pytest -n 48 -m "not slow" --disable-pythonic-hints --timeout 300 --durations=0 -v -s --log-cli-level=DEBUG --max-tests=${{ inputs.max-tests }} --randomly-seed=$GITHUB_RUN_ID cairo/tests/ef_tests/ --ignore-glob='cairo/tests/ef_tests/fixtures/*'
+          uv run --reinstall pytest -n 48 -m "not slow" --timeout 300 --durations=0 -v -s --log-cli-level=DEBUG --max-tests=${{ inputs.max-tests }} --randomly-seed=$GITHUB_RUN_ID cairo/tests/ef_tests/ --ignore-glob='cairo/tests/ef_tests/fixtures/*'
       - name: Upload coverage
         uses: codecov/codecov-action@v5
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -49,9 +49,11 @@ cairo/tests/ef_tests/fixtures/
 # zk-pig default output directory
 data
 
+# prover input files
 *.trace
 *.air_public_input.json
 *.air_private_input.json
 *.memory
 *.trace.bin
 *.memory.bin
+output/

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ data
 *.air_public_input.json
 *.air_private_input.json
 *.memory
+*.trace.bin
+*.memory.bin

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -659,6 +659,7 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "cairo-vm",
+ "chrono",
  "garaga_rs",
  "lazy_static",
  "num-bigint",
@@ -709,7 +710,9 @@ checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
+ "wasm-bindgen",
  "windows-link",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,7 +192,7 @@ dependencies = [
  "ark-std 0.4.0",
  "derivative",
  "hashbrown 0.13.2",
- "itertools",
+ "itertools 0.10.5",
  "num-traits",
  "zeroize",
 ]
@@ -227,7 +227,7 @@ dependencies = [
  "ark-std 0.4.0",
  "derivative",
  "digest 0.10.7",
- "itertools",
+ "itertools 0.10.5",
  "num-bigint",
  "num-traits",
  "paste",
@@ -487,6 +487,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "bigdecimal"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6773ddc0eafc0e509fb60e48dff7f450f8e674a0686ae8605e8d9901bd5eefa"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
 name = "bincode"
 version = "2.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -526,6 +538,28 @@ dependencies = [
  "radium",
  "tap",
  "wyz",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "blake3"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "675f87afced0413c9bb02843499dbbd3882a237645883f71a2b59644a6d2f753"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
 ]
 
 [[package]]
@@ -621,9 +655,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "cairo-lang-casm"
+version = "2.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99b3c953c0321df1d7ce9101c7a94e2d4007aa8c3362ee96be54bbe77916ef60"
+dependencies = [
+ "cairo-lang-utils",
+ "indoc",
+ "num-bigint",
+ "num-traits",
+ "parity-scale-codec",
+ "serde",
+]
+
+[[package]]
+name = "cairo-lang-utils"
+version = "2.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e621368454b62603ae035d04864770a70952e6ca8341b78c1ac50a0088939e3f"
+dependencies = [
+ "hashbrown 0.15.2",
+ "indexmap",
+ "itertools 0.14.0",
+ "num-bigint",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
 name = "cairo-vm"
 version = "2.0.0"
-source = "git+https://github.com/kkrt-labs/cairo-vm?rev=af22b7189f3ebf0f225711d58be133d217b0a3d8#af22b7189f3ebf0f225711d58be133d217b0a3d8"
+source = "git+https://github.com/kkrt-labs/cairo-vm?rev=9d6259c73ceec53d00fb859b90b6ad0a36df030a#9d6259c73ceec53d00fb859b90b6ad0a36df030a"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -646,10 +708,9 @@ dependencies = [
  "serde_json",
  "sha2 0.10.8",
  "sha3",
- "starknet-crypto",
+ "starknet-crypto 0.7.4",
  "starknet-types-core",
  "thiserror-no-std",
- "wasm-bindgen",
  "zip",
 ]
 
@@ -671,9 +732,14 @@ dependencies = [
  "pyo3-polars",
  "revm",
  "revm-precompile 17.0.0-alpha.1",
- "starknet-crypto",
+ "serde_json",
+ "starknet-crypto 0.7.4",
  "starknet-types-core",
+ "stwo-cairo-adapter",
+ "stwo_cairo_prover",
  "thiserror 2.0.11",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -801,6 +867,12 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "core-foundation"
@@ -1035,6 +1107,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "educe"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4bd92664bf78c4d3dba9b7cdafce6fa15b13ed3ed16175218196942e99168a8"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "either"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1066,6 +1150,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea0dcfa4e54eeb516fe454635a95753ddd39acda650ce703031c6973e315dd5"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1151,6 +1255,18 @@ dependencies = [
  "arrayvec",
  "auto_impl",
  "bytes",
+]
+
+[[package]]
+name = "faststr"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6503af7917fea18ffef8f7e8553fb8dff89e2e6837e94e09dd7fb069c82d62c"
+dependencies = [
+ "bytes",
+ "rkyv",
+ "serde",
+ "simdutf8",
 ]
 
 [[package]]
@@ -1812,6 +1928,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2100,6 +2243,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "munge"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0091202c98cf06da46c279fdf50cccb6b1c43b4521abdf6a27b4c7e71d5d9d7"
+dependencies = [
+ "munge_macro",
+]
+
+[[package]]
+name = "munge_macro"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "734799cf91479720b2f970c61a22850940dd91e27d4f02b1c6fc792778df2459"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2141,6 +2304,16 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
 dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
  "winapi",
 ]
 
@@ -2334,6 +2507,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parity-scale-codec"
@@ -3053,6 +3232,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe9e76f66d3f9606f44e45598d155cb13ecf09f4a28199e48daf8c8fc937ea90"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca414edb151b4c8d125c12566ab0d74dc9cdba36fb80eb7b848c15f495fd32d1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "pyo3"
 version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3151,6 +3350,15 @@ name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "rancor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf5f7161924b9d1cea0e4cabc97c372cea92b5f927fc13c6bca67157a0ad947"
+dependencies = [
+ "ptr_meta",
+]
 
 [[package]]
 name = "rand"
@@ -3260,6 +3468,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3287,6 +3515,12 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "rend"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a35e8a6bf28cd121053a66aa2e6a2e3eaffad4a60012179f0e864aa5ffeff215"
 
 [[package]]
 name = "reqwest"
@@ -3518,6 +3752,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e147371c75553e1e2fcdb483944a8540b8438c31426279553b9a8182a9b7b65"
+dependencies = [
+ "bytes",
+ "hashbrown 0.15.2",
+ "indexmap",
+ "munge",
+ "ptr_meta",
+ "rancor",
+ "rend",
+ "rkyv_derive",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "246b40ac189af6c675d124b802e8ef6d5246c53e17367ce9501f8f66a81abb7a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3869,6 +4132,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3931,6 +4203,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "sonic-number"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a74044c092f4f43ca7a6cfd62854cf9fb5ac8502b131347c990bf22bef1dfe"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "sonic-rs"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0275f9f2f07d47556fe60c2759da8bc4be6083b047b491b2d476aa0bfa558eb1"
+dependencies = [
+ "bumpalo",
+ "bytes",
+ "cfg-if",
+ "faststr",
+ "itoa",
+ "ref-cast",
+ "ryu",
+ "serde",
+ "simdutf8",
+ "sonic-number",
+ "sonic-simd",
+ "thiserror 2.0.11",
+]
+
+[[package]]
+name = "sonic-simd"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940a24e82c9a97483ef66cef06b92160a8fa5cd74042c57c10b24d99d169d2fc"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3976,6 +4286,26 @@ dependencies = [
 
 [[package]]
 name = "starknet-crypto"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e2c30c01e8eb0fc913c4ee3cf676389fffc1d1182bfe5bb9670e4e72e968064"
+dependencies = [
+ "crypto-bigint",
+ "hex",
+ "hmac",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "rfc6979",
+ "sha2 0.10.8",
+ "starknet-crypto-codegen",
+ "starknet-curve 0.4.2",
+ "starknet-ff",
+ "zeroize",
+]
+
+[[package]]
+name = "starknet-crypto"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "039a3bad70806b494c9e6b21c5238a6c8a373d66a26071859deb0ccca6f93634"
@@ -3988,9 +4318,29 @@ dependencies = [
  "num-traits",
  "rfc6979",
  "sha2 0.10.8",
- "starknet-curve",
+ "starknet-curve 0.5.1",
  "starknet-types-core",
  "zeroize",
+]
+
+[[package]]
+name = "starknet-crypto-codegen"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc159a1934c7be9761c237333a57febe060ace2bc9e3b337a59a37af206d19f"
+dependencies = [
+ "starknet-curve 0.4.2",
+ "starknet-ff",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "starknet-curve"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1c383518bb312751e4be80f53e8644034aa99a0afb29d7ac41b89a997db875b"
+dependencies = [
+ "starknet-ff",
 ]
 
 [[package]]
@@ -4000,6 +4350,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcde6bd74269b8161948190ace6cf069ef20ac6e79cd2ba09b320efa7500b6de"
 dependencies = [
  "starknet-types-core",
+]
+
+[[package]]
+name = "starknet-ff"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abf1b44ec5b18d87c1ae5f54590ca9d0699ef4dd5b2ffa66fc97f24613ec585"
+dependencies = [
+ "ark-ff 0.4.2",
+ "bigdecimal",
+ "crypto-bigint",
+ "getrandom 0.2.15",
+ "hex",
+ "serde",
 ]
 
 [[package]]
@@ -4055,6 +4419,133 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 2.0.98",
+]
+
+[[package]]
+name = "stwo-air-utils"
+version = "0.1.1"
+source = "git+https://github.com/starkware-libs/stwo?rev=305cabc#305cabc2b06dd86aa1af678af1064dbc038323a8"
+dependencies = [
+ "bytemuck",
+ "itertools 0.12.1",
+ "rayon",
+ "stwo-air-utils-derive",
+ "stwo-prover",
+]
+
+[[package]]
+name = "stwo-air-utils-derive"
+version = "0.1.0"
+source = "git+https://github.com/starkware-libs/stwo?rev=305cabc#305cabc2b06dd86aa1af678af1064dbc038323a8"
+dependencies = [
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "stwo-cairo-adapter"
+version = "0.1.0"
+source = "git+https://github.com/starkware-libs/stwo-cairo?rev=219a2c5158b2380a7aed170126c8f9c7b865a203#219a2c5158b2380a7aed170126c8f9c7b865a203"
+dependencies = [
+ "bytemuck",
+ "cairo-lang-casm",
+ "cairo-vm",
+ "itertools 0.12.1",
+ "serde",
+ "serde_json",
+ "sonic-rs",
+ "stwo-cairo-common",
+ "stwo-prover",
+ "thiserror 2.0.11",
+ "tracing",
+]
+
+[[package]]
+name = "stwo-cairo-common"
+version = "0.1.0"
+source = "git+https://github.com/starkware-libs/stwo-cairo?rev=219a2c5158b2380a7aed170126c8f9c7b865a203#219a2c5158b2380a7aed170126c8f9c7b865a203"
+dependencies = [
+ "bytemuck",
+ "itertools 0.12.1",
+ "num-traits",
+ "ruint",
+ "serde",
+ "starknet-ff",
+ "starknet-types-core",
+ "stwo-cairo-serialize",
+ "stwo-prover",
+]
+
+[[package]]
+name = "stwo-cairo-serialize"
+version = "0.1.0"
+source = "git+https://github.com/starkware-libs/stwo-cairo?rev=219a2c5158b2380a7aed170126c8f9c7b865a203#219a2c5158b2380a7aed170126c8f9c7b865a203"
+dependencies = [
+ "starknet-ff",
+ "stwo-cairo-serialize-derive",
+ "stwo-prover",
+]
+
+[[package]]
+name = "stwo-cairo-serialize-derive"
+version = "0.1.0"
+source = "git+https://github.com/starkware-libs/stwo-cairo?rev=219a2c5158b2380a7aed170126c8f9c7b865a203#219a2c5158b2380a7aed170126c8f9c7b865a203"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "stwo-prover"
+version = "0.1.1"
+source = "git+https://github.com/starkware-libs/stwo?rev=305cabc#305cabc2b06dd86aa1af678af1064dbc038323a8"
+dependencies = [
+ "blake2",
+ "blake3",
+ "bytemuck",
+ "cfg-if",
+ "educe",
+ "hex",
+ "itertools 0.12.1",
+ "num-traits",
+ "rand",
+ "rayon",
+ "serde",
+ "starknet-crypto 0.6.2",
+ "starknet-ff",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
+name = "stwo_cairo_prover"
+version = "0.1.0"
+source = "git+https://github.com/starkware-libs/stwo-cairo?rev=219a2c5158b2380a7aed170126c8f9c7b865a203#219a2c5158b2380a7aed170126c8f9c7b865a203"
+dependencies = [
+ "bytemuck",
+ "cairo-lang-casm",
+ "cairo-vm",
+ "hex",
+ "itertools 0.12.1",
+ "num-traits",
+ "paste",
+ "rayon",
+ "serde",
+ "serde_json",
+ "starknet-curve 0.5.1",
+ "starknet-ff",
+ "starknet-types-core",
+ "stwo-air-utils",
+ "stwo-air-utils-derive",
+ "stwo-cairo-adapter",
+ "stwo-cairo-common",
+ "stwo-cairo-serialize",
+ "stwo-prover",
+ "thiserror 2.0.11",
+ "tracing",
 ]
 
 [[package]]
@@ -4239,6 +4730,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "threadpool"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4380,7 +4881,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4390,6 +4903,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2177,6 +2177,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2935,7 +2944,7 @@ dependencies = [
  "polars-utils",
  "rayon",
  "regex",
- "regex-syntax",
+ "regex-syntax 0.8.5",
  "strum_macros",
  "unicode-normalization",
  "unicode-reverse",
@@ -3216,7 +3225,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rand_xorshift",
- "regex-syntax",
+ "regex-syntax 0.8.5",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -3495,8 +3504,17 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -3507,8 +3525,14 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -4923,10 +4947,14 @@ version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,11 +50,16 @@ serde_json = "1"
 thiserror = "1.0"
 url = "2.5"
 reqwest = { version = "0.12", features = ["json", "multipart"] }
-
+stwo-cairo-adapter = { version = "*", features = ["std"] }
+stwo_cairo_prover = "*"
 cairo-vm = { git = "https://github.com/lambdaclass/cairo-vm.git", tag = "v2.0.0-rc5", features = [
   "test_utils",
   "mod_builtin",
 ] }
 
 [patch."https://github.com/lambdaclass/cairo-vm.git"]
-cairo-vm = { git = "https://github.com/kkrt-labs/cairo-vm", rev = "af22b7189f3ebf0f225711d58be133d217b0a3d8" }
+cairo-vm = { git = "https://github.com/kkrt-labs/cairo-vm", rev = "9d6259c73ceec53d00fb859b90b6ad0a36df030a" }
+
+[patch.crates-io]
+stwo-cairo-adapter = { git = "https://github.com/starkware-libs/stwo-cairo", rev = "219a2c5158b2380a7aed170126c8f9c7b865a203" }
+stwo_cairo_prover = { git = "https://github.com/starkware-libs/stwo-cairo", rev = "219a2c5158b2380a7aed170126c8f9c7b865a203" }

--- a/README.md
+++ b/README.md
@@ -104,6 +104,31 @@ Then, you can run the tests with:
 uv run pytest cairo/tests/ethereum/cancun/test_fork.py -k "test_state_transition_eth_mainnet"
 ```
 
+### Proving a Block
+
+To generate a proof for an Ethereum block, use the `prove_block.py` script:
+
+```bash
+uv run prove-block <BLOCK_NUMBER>
+```
+
+```bash
+usage: prove-block [-h] [--output-dir OUTPUT_DIR] [--data-dir DATA_DIR] [--compiled-program COMPILED_PROGRAM]
+                   block_number
+```
+
+Requirements:
+
+- Block must be post-Cancun fork (block number ≥ 19426587)
+- ZKPI data must be available as a JSON file
+- Compiled Cairo program must exist at the specified path (you can run
+  `cairo-compile --proof_mode cairo/ethereum/cancun/main.cairo --cairo_path=cairo --no_debug_info --output build/main.json`
+  for that)
+
+The script will load the ZKPI data for the specified block, convert it to the
+format required by Keth, run the proof generation process, and save proof
+artifacts to the output directory.
+
 ### Updating Rust dependencies
 
 Any changes to the rust code requires a re-build and re-install of the python

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Requirements:
 - Block must be post-Cancun fork (block number ≥ 19426587)
 - ZKPI data must be available as a JSON file
 - Compiled Cairo program must exist at the specified path (you can run
-  `cairo-compile --proof_mode cairo/ethereum/cancun/main.cairo --cairo_path=cairo --no_debug_info --output build/main.json`
+  `cairo-compile --proof_mode cairo/ethereum/cancun/main.cairo --cairo_path=cairo --no_debug_info --output build/main_compiled.json`
   for that)
 
 The script will load the ZKPI data for the specified block, convert it to the

--- a/cairo/ethereum/cancun/fork.cairo
+++ b/cairo/ethereum/cancun/fork.cairo
@@ -1360,14 +1360,12 @@ func state_transition{
 
     let excess_blob_gas = calculate_excess_blob_gas(parent_header);
     with_attr error_message("InvalidBlock") {
-        %{ logger.debug_cairo(f"excess_blob_gas: {serialize(ids.block.value.header.value.excess_blob_gas)} == {serialize(ids.excess_blob_gas)}") %}
         assert block.value.header.value.excess_blob_gas = excess_blob_gas;
     }
 
     validate_header(block.value.header, parent_header);
 
     with_attr error_message("InvalidBlock") {
-        %{ logger.debug_cairo(f"block.value.ommers.value.len: {serialize(ids.block.value.ommers.value.len)} == 0") %}
         assert block.value.ommers.value.len = 0;
     }
 
@@ -1394,40 +1392,33 @@ func state_transition{
     );
 
     with_attr error_message("InvalidBlock") {
-        %{ logger.debug_cairo(f"output.value.block_gas_used: {serialize(ids.output.value.block_gas_used)} == {serialize(ids.block.value.header.value.gas_used)}") %}
         assert output.value.block_gas_used = block.value.header.value.gas_used;
 
         let transactions_root_equal = Bytes32__eq__(
             output.value.transactions_root, block.value.header.value.transactions_root
         );
-        %{ logger.debug_cairo(f"transactions_root_equal: {serialize(ids.transactions_root_equal)} == 1") %}
         assert transactions_root_equal.value = 1;
 
         let state_root_equal = Bytes32__eq__(
             output.value.state_root, block.value.header.value.state_root
         );
-        %{ logger.debug_cairo(f"state_root_equal: {serialize(ids.state_root_equal)} == 1") %}
         assert state_root_equal.value = 1;
 
         let receipt_root_equal = Bytes32__eq__(
             output.value.receipt_root, block.value.header.value.receipt_root
         );
-        %{ logger.debug_cairo(f"receipt_root_equal: {serialize(ids.receipt_root_equal)} == 1") %}
         assert receipt_root_equal.value = 1;
 
         let logs_bloom_equal = Bytes256__eq__(
             output.value.block_logs_bloom, block.value.header.value.bloom
         );
-        %{ logger.debug_cairo(f"logs_bloom_equal: {serialize(ids.logs_bloom_equal)} == 1") %}
         assert logs_bloom_equal.value = 1;
 
         let withdrawals_root_equal = Bytes32__eq__(
             output.value.withdrawals_root, block.value.header.value.withdrawals_root
         );
-        %{ logger.debug_cairo(f"withdrawals_root_equal: {serialize(ids.withdrawals_root_equal)} == 1") %}
         assert withdrawals_root_equal.value = 1;
 
-        %{ logger.debug_cairo(f"output.value.blob_gas_used.value: {serialize(ids.output.value.blob_gas_used.value)} == {serialize(ids.block.value.header.value.blob_gas_used.value)}") %}
         assert output.value.blob_gas_used.value = block.value.header.value.blob_gas_used.value;
     }
 

--- a/cairo/ethereum/cancun/main.cairo
+++ b/cairo/ethereum/cancun/main.cairo
@@ -38,6 +38,8 @@ func main{
         from ethereum.cancun.fork import BlockChain, Block
         from ethereum_types.bytes import Bytes32
 
+        # Note: for efficiency purposes, we don't use the `ids` object to
+        # avoid loading program identifiers into the context.
         memory[fp+2] = gen_arg(Bytes32, public_inputs["pre_state_root"])
         memory[fp+3] = gen_arg(Bytes32, public_inputs["post_state_root"])
         memory[fp+4] = gen_arg(Bytes32, public_inputs["block_hash"])

--- a/cairo/ethereum/cancun/main.cairo
+++ b/cairo/ethereum/cancun/main.cairo
@@ -1,4 +1,4 @@
-%builtins output pedersen range_check ecdsa bitwise ec_op keccak poseidon range_check96 add_mod mul_mod
+%builtins output range_check bitwise keccak poseidon range_check96 add_mod mul_mod
 // In proof mode running with RustVM requires declaring all builtins and taking them as entrypoint
 // This is probably a mis-handling from the RustVM side.
 
@@ -16,11 +16,8 @@ from ethereum_types.bytes import Bytes32
 
 func main{
     output_ptr: felt*,
-    pedersen_ptr: HashBuiltin*,
     range_check_ptr,
-    ecdsa_ptr: SignatureBuiltin*,
     bitwise_ptr: BitwiseBuiltin*,
-    ec_op_ptr: EcOpBuiltin*,
     keccak_ptr: KeccakBuiltin*,
     poseidon_ptr: PoseidonBuiltin*,
     range_check96_ptr: felt*,

--- a/cairo/ethereum/cancun/main.cairo
+++ b/cairo/ethereum/cancun/main.cairo
@@ -1,6 +1,4 @@
 %builtins output range_check bitwise keccak poseidon range_check96 add_mod mul_mod
-// In proof mode running with RustVM requires declaring all builtins and taking them as entrypoint
-// This is probably a mis-handling from the RustVM side.
 
 from starkware.cairo.common.cairo_builtins import (
     BitwiseBuiltin,

--- a/cairo/ethereum/cancun/main.cairo
+++ b/cairo/ethereum/cancun/main.cairo
@@ -1,0 +1,60 @@
+%builtins output pedersen range_check ecdsa bitwise ec_op keccak poseidon range_check96 add_mod mul_mod
+// In proof mode running with RustVM requires declaring all builtins and taking them as entrypoint
+// This is probably a mis-handling from the RustVM side.
+
+from starkware.cairo.common.cairo_builtins import (
+    BitwiseBuiltin,
+    KeccakBuiltin,
+    PoseidonBuiltin,
+    ModBuiltin,
+    HashBuiltin,
+    SignatureBuiltin,
+    EcOpBuiltin,
+)
+from ethereum.cancun.fork import state_transition, BlockChain, Block
+from ethereum_types.bytes import Bytes32
+
+func main{
+    output_ptr: felt*,
+    pedersen_ptr: HashBuiltin*,
+    range_check_ptr,
+    ecdsa_ptr: SignatureBuiltin*,
+    bitwise_ptr: BitwiseBuiltin*,
+    ec_op_ptr: EcOpBuiltin*,
+    keccak_ptr: KeccakBuiltin*,
+    poseidon_ptr: PoseidonBuiltin*,
+    range_check96_ptr: felt*,
+    add_mod_ptr: ModBuiltin*,
+    mul_mod_ptr: ModBuiltin*,
+}() {
+    alloc_locals;
+
+    local chain: BlockChain;
+    local block: Block;
+    local pre_state_root: Bytes32;
+    local post_state_root: Bytes32;
+    local block_hash: Bytes32;
+    %{
+        from ethereum.cancun.fork import BlockChain, Block
+        from ethereum_types.bytes import Bytes32
+
+        memory[fp+2] = gen_arg(Bytes32, public_inputs["pre_state_root"])
+        memory[fp+3] = gen_arg(Bytes32, public_inputs["post_state_root"])
+        memory[fp+4] = gen_arg(Bytes32, public_inputs["block_hash"])
+
+        memory[fp] = gen_arg(BlockChain, private_inputs["blockchain"])
+        memory[fp+1] = gen_arg(Block, private_inputs["block"])
+    %}
+
+    state_transition{chain=chain}(block);
+
+    assert [output_ptr] = pre_state_root.value.low;
+    assert [output_ptr + 1] = pre_state_root.value.high;
+    assert [output_ptr + 2] = post_state_root.value.low;
+    assert [output_ptr + 3] = post_state_root.value.high;
+    assert [output_ptr + 4] = block_hash.value.low;
+    assert [output_ptr + 5] = block_hash.value.high;
+
+    let output_ptr = output_ptr + 6;
+    return ();
+}

--- a/cairo/ethereum/cancun/main.cairo
+++ b/cairo/ethereum/cancun/main.cairo
@@ -35,8 +35,8 @@ func main{
         # avoid loading program identifiers into the context.
         # see: README of cairo-addons crate
         memory[fp] = gen_arg(BlockChain, public_inputs["blockchain"])
-        memory[fp+1] = gen_arg(Block, public_inputs["block"])
-        memory[fp+2] = gen_arg(Bytes32, public_inputs["block_hash"])
+        memory[fp + 1] = gen_arg(Block, public_inputs["block"])
+        memory[fp + 2] = gen_arg(Bytes32, public_inputs["block_hash"])
     %}
 
     let parent_header = chain.value.blocks.value.data[

--- a/cairo/ethereum/cancun/vm/interpreter.cairo
+++ b/cairo/ethereum/cancun/vm/interpreter.cairo
@@ -329,7 +329,7 @@ func execute_code{
         if (precompile_address != 0) {
             %{
                 precompile_address_bytes = ids.precompile_address.to_bytes(20, "little")
-                print(f"[CAIRO] PrecompileStart: {precompile_address_bytes}")
+                logger.trace_cairo(f"PrecompileStart: {precompile_address_bytes}")
             %}
             // Prepare arguments
             // MARK: args assignment
@@ -356,7 +356,7 @@ func execute_code{
 
             %{
                 precompile_address_bytes = ids.precompile_address.to_bytes(20, "little")
-                print(f"[CAIRO] PrecompileEnd: {precompile_address_bytes}")
+                logger.trace_cairo(f"PrecompileEnd: {precompile_address_bytes}")
             %}
 
             if (cast(err, felt) != 0) {

--- a/cairo/scripts/compile_cairo.py
+++ b/cairo/scripts/compile_cairo.py
@@ -23,7 +23,7 @@ def compile_cairo(file_name, should_implement_hints=True):
         json.dump(program.Schema().dump(program), f, indent=4, sort_keys=True)
 
 
-if __name__ == "__main__":
+def main():
     parser = argparse.ArgumentParser(description="Compile Cairo program")
     parser.add_argument("file_name", help="The Cairo file to compile")
     parser.add_argument(
@@ -36,3 +36,21 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
     compile_cairo(args.file_name, args.implement_hints)
+
+
+def compile_keth():
+    keth_main_path = Path("cairo/ethereum/cancun/main.cairo")
+    debug_info = False
+    proof_mode = True
+    output_path = Path("build/main_compiled.json")
+    logger.info(f"Compiling Keth with {debug_info=} and {proof_mode=}")
+    program = cairo_compile(
+        keth_main_path, debug_info=debug_info, proof_mode=proof_mode
+    )
+    with open(output_path, "w") as f:
+        logger.info(f"Writing compiled program to {output_path}")
+        json.dump(program.Schema().dump(program), f, indent=4, sort_keys=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/cairo/scripts/prove_block.py
+++ b/cairo/scripts/prove_block.py
@@ -53,8 +53,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--compiled-program",
         type=Path,
-        default=Path("build/main.json"),
-        help="Path to compiled Cairo program (default: ./build/main.json)",
+        default=Path("build/main_compiled.json"),
+        help="Path to compiled Cairo program (default: ./build/main_compiled.json)",
     )
     parser.add_argument(
         "--stwo-proof",
@@ -182,7 +182,7 @@ def load_zkpi_fixture(zkpi_path: Path) -> Dict[str, Any]:
     )
 
     # Prepare inputs
-    public_inputs = {
+    program_inputs = {
         "block": block,
         "blockchain": chain,
         "block_hash": Bytes32(
@@ -190,7 +190,7 @@ def load_zkpi_fixture(zkpi_path: Path) -> Dict[str, Any]:
         ),
     }
 
-    return public_inputs
+    return program_inputs
 
 
 def prove_block(
@@ -212,14 +212,13 @@ def prove_block(
 
     # Load ZKPI data
     logger.info(f"Fetching ZKPI data for block {block_number}")
-    public_inputs = load_zkpi_fixture(zkpi_path)
+    program_inputs = load_zkpi_fixture(zkpi_path)
 
     # Generate proof
     logger.info(f"Running Keth for block {block_number}")
     run_proof_mode(
         entrypoint="main",
-        public_inputs=public_inputs,
-        private_inputs={},
+        program_inputs=program_inputs,
         compiled_program_path=str(compiled_program.absolute()),
         output_dir=str(output_dir.absolute()),
         stwo_proof=stwo_proof,

--- a/cairo/scripts/prove_block.py
+++ b/cairo/scripts/prove_block.py
@@ -6,7 +6,6 @@ Fetches zkpi data, converts it to EELS/Keth format, and generates a proof.
 import argparse
 import json
 import logging
-import sys
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -60,7 +59,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--stwo-proof",
         action="store_true",
-        help="Generate Stwo proof instead of traditional proof artifacts",
+        help="Generate Stwo proof instead of prover inputs",
     )
     parser.add_argument(
         "--proof-path",
@@ -194,7 +193,7 @@ def load_zkpi_fixture(zkpi_path: Path) -> Dict[str, Any]:
     return public_inputs
 
 
-def run_proof(
+def prove_block(
     block_number: int,
     output_dir: Path,
     zkpi_path: Path,
@@ -249,7 +248,7 @@ def main() -> int:
     zkpi_path = args.data_dir / f"{args.block_number}.json"
 
     try:
-        run_proof(
+        prove_block(
             args.block_number,
             args.output_dir,
             zkpi_path,
@@ -277,4 +276,4 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    main()

--- a/cairo/scripts/prove_block.py
+++ b/cairo/scripts/prove_block.py
@@ -1,0 +1,254 @@
+"""
+Prove an Ethereum block using Keth given a block number.
+Fetches zkpi data, converts it to EELS/Keth format, and runs it through the Keth.
+"""
+
+import argparse
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Tuple
+
+from ethereum.cancun.blocks import Block, Withdrawal
+from ethereum.cancun.fork import (
+    BlockChain,
+    apply_body,
+    get_last_256_block_hashes,
+)
+from ethereum.cancun.fork_types import Address
+from ethereum.cancun.transactions import (
+    LegacyTransaction,
+)
+from ethereum.cancun.vm.gas import calculate_excess_blob_gas
+from ethereum.utils.hexadecimal import hex_to_bytes, hex_to_u256, hex_to_uint
+from ethereum_spec_tools.evm_tools.loaders.fixture_loader import Load
+from ethereum_types.bytes import Bytes, Bytes0, Bytes32
+from ethereum_types.numeric import U64, U256
+
+from cairo_addons.vm import run_proof_mode
+from tests.ef_tests.helpers.load_state_tests import convert_defaultdict
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+
+def init_tracer():
+    """Initialize the logger "trace" mode."""
+    import logging
+
+    from colorama import Fore, Style, init
+
+    init()
+
+    # Define TRACE level
+    TRACE_LEVEL = logging.DEBUG - 5
+    logging.addLevelName(TRACE_LEVEL, "TRACE")
+
+    # Custom trace methods for Logger instances
+    def trace(self, message, *args, **kwargs):
+        if self.isEnabledFor(TRACE_LEVEL):
+            colored_msg = f"{Fore.YELLOW}TRACE{Style.RESET_ALL} {message}"
+            print(colored_msg)
+
+    def trace_cairo(self, message, *args, **kwargs):
+        if self.isEnabledFor(TRACE_LEVEL):
+            colored_msg = f"{Fore.YELLOW}TRACE{Style.RESET_ALL} [CAIRO] {message}"
+            print(colored_msg)
+
+    def trace_eels(self, message, *args, **kwargs):
+        if self.isEnabledFor(TRACE_LEVEL):
+            colored_msg = f"{Fore.YELLOW}TRACE{Style.RESET_ALL} [EELS] {message}"
+            print(colored_msg)
+
+    def debug_cairo(self, message, *args, **kwargs):
+        if self.isEnabledFor(logging.DEBUG):
+            colored_msg = f"{Fore.BLUE}DEBUG{Style.RESET_ALL} [DEBUG-CAIRO] {message}"
+            print(colored_msg)
+
+    # Patch the logging module with our new trace methods
+    setattr(logging, "TRACE", TRACE_LEVEL)
+    setattr(logging.getLoggerClass(), "trace", trace)
+    setattr(logging.getLoggerClass(), "trace_cairo", trace_cairo)
+    setattr(logging.getLoggerClass(), "trace_eels", trace_eels)
+    setattr(logging.getLoggerClass(), "debug_cairo", debug_cairo)
+
+
+@dataclass
+class PublicInputs:
+    pre_state_root: Bytes32
+    post_state_root: Bytes32
+    block_hash: Bytes32
+
+
+@dataclass
+class PrivateInputs:
+    block: Block
+    blockchain: BlockChain
+
+
+def zkpi_fixture(zkpi_path) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    with open(zkpi_path, "r") as f:
+        fixture = json.load(f)
+
+    load = Load("Cancun", "cancun")
+    block = Block(
+        header=load.json_to_header(fixture["newBlockParameters"]["blockHeader"]),
+        transactions=tuple(
+            (
+                LegacyTransaction(
+                    nonce=hex_to_u256(tx["nonce"]),
+                    gas_price=hex_to_uint(tx["gasPrice"]),
+                    gas=hex_to_uint(tx["gas"]),
+                    to=Address(hex_to_bytes(tx["to"])) if tx["to"] else Bytes0(),
+                    value=hex_to_u256(tx["value"]),
+                    data=Bytes(hex_to_bytes(tx["data"])),
+                    v=hex_to_u256(tx["v"]),
+                    r=hex_to_u256(tx["r"]),
+                    s=hex_to_u256(tx["s"]),
+                )
+                if isinstance(tx, dict)
+                else Bytes(hex_to_bytes(tx))
+            )  # Non-legacy txs are hex strings
+            for tx in fixture["newBlockParameters"]["transactions"]
+        ),
+        ommers=(),
+        withdrawals=tuple(
+            Withdrawal(
+                index=U64(int(w["index"], 16)),
+                validator_index=U64(int(w["validatorIndex"], 16)),
+                address=Address(hex_to_bytes(w["address"])),
+                amount=U256(int(w["amount"], 16)),
+            )
+            for w in fixture["newBlockParameters"]["withdrawals"]
+        ),
+    )
+    blocks = [
+        Block(
+            header=load.json_to_header(ancestor),
+            transactions=(),
+            ommers=(),
+            withdrawals=(),
+        )
+        for ancestor in fixture["ancestors"]
+    ]
+    chain = BlockChain(
+        blocks=blocks,
+        state=convert_defaultdict(load.json_to_state(fixture["pre"])),
+        chain_id=U64(fixture["chainId"]),
+    )
+
+    # TODO: Remove when we have a working partial MPT
+    state_root = apply_body(
+        chain.state,
+        get_last_256_block_hashes(chain),
+        block.header.coinbase,
+        block.header.number,
+        block.header.base_fee_per_gas,
+        block.header.gas_limit,
+        block.header.timestamp,
+        block.header.prev_randao,
+        block.transactions,
+        chain.chain_id,
+        block.withdrawals,
+        block.header.parent_beacon_block_root,
+        calculate_excess_blob_gas(chain.blocks[-1].header),
+    ).state_root
+    block = Block(
+        header=load.json_to_header(
+            {
+                **fixture["newBlockParameters"]["blockHeader"],
+                "stateRoot": "0x" + state_root.hex(),
+            }
+        ),
+        transactions=tuple(
+            (
+                LegacyTransaction(
+                    nonce=hex_to_u256(tx["nonce"]),
+                    gas_price=hex_to_uint(tx["gasPrice"]),
+                    gas=hex_to_uint(tx["gas"]),
+                    to=Address(hex_to_bytes(tx["to"])) if tx["to"] else Bytes0(),
+                    value=hex_to_u256(tx["value"]),
+                    data=Bytes(hex_to_bytes(tx["data"])),
+                    v=hex_to_u256(tx["v"]),
+                    r=hex_to_u256(tx["r"]),
+                    s=hex_to_u256(tx["s"]),
+                )
+                if isinstance(tx, dict)
+                else Bytes(hex_to_bytes(tx))
+            )  # Non-legacy txs are hex strings
+            for tx in fixture["newBlockParameters"]["transactions"]
+        ),
+        ommers=(),
+        withdrawals=tuple(
+            Withdrawal(
+                index=U64(int(w["index"], 16)),
+                validator_index=U64(int(w["validatorIndex"], 16)),
+                address=Address(hex_to_bytes(w["address"])),
+                amount=U256(int(w["amount"], 16)),
+            )
+            for w in fixture["newBlockParameters"]["withdrawals"]
+        ),
+    )
+    chain = BlockChain(
+        blocks=blocks,
+        state=convert_defaultdict(load.json_to_state(fixture["pre"])),
+        chain_id=U64(fixture["chainId"]),
+    )
+
+    public_inputs = {
+        "pre_state_root": Bytes32(
+            bytes.fromhex(
+                fixture["newBlockParameters"]["blockHeader"]["stateRoot"].removeprefix(
+                    "0x"
+                )
+            )
+        ),
+        "post_state_root": Bytes32(
+            bytes.fromhex(fixture["ancestors"][-1]["stateRoot"].removeprefix("0x"))
+        ),
+        "block_hash": Bytes32(
+            bytes.fromhex(fixture["newBlockHash"].removeprefix("0x"))
+        ),
+    }
+    private_inputs = {
+        "block": block,
+        "blockchain": chain,
+    }
+    return public_inputs, private_inputs
+
+
+def main():
+    init_tracer()
+    parser = argparse.ArgumentParser(description="Prove an Ethereum block using Keth")
+    parser.add_argument("block_number", type=int, help="Block number to prove")
+    parser.add_argument(
+        "--output-dir", type=Path, default=Path("output"), help="Output directory"
+    )
+    args = parser.parse_args()
+
+    output_dir = args.output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Fetch zkpi data
+    logger.info(f"Fetching zkpi data for block {args.block_number}")
+    path = Path(f"data/1/eels/{args.block_number}.json")
+    public_inputs, private_inputs = zkpi_fixture(path)
+
+    # Run Keth
+    logger.info(f"Running Keth for block {args.block_number}")
+    run_proof_mode(
+        entrypoint="main",
+        public_inputs=public_inputs,
+        private_inputs=private_inputs,
+        compiled_program_path="./main_compiled.json",
+        output_dir=output_dir,
+    )
+
+    logger.info(f"Proof artifacts saved to {output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/cairo/scripts/zkpi_to_eels.py
+++ b/cairo/scripts/zkpi_to_eels.py
@@ -196,6 +196,7 @@ def process_zkpi_file(zkpi_file: Path, do_check: bool = False) -> None:
         "newBlockParameters": create_eels_block_parameters(zkpi_data["block"]),
         "pre": convert_accounts(zkpi_data, code_hashes),
         "chainId": zkpi_data["chainConfig"].get("chainId", 1),
+        "newBlockHash": zkpi_data["block"]["hash"],
         "ancestors": zkpi_data["ancestors"][::-1],
     }
 

--- a/cairo/tests/test_hint_runner.py
+++ b/cairo/tests/test_hint_runner.py
@@ -1,8 +1,6 @@
 import pytest
 from ethereum_types.numeric import U256
 
-pytestmark = pytest.mark.enable_pythonic_hints
-
 
 class TestRunner:
     def test__ap_accessible(self, cairo_run, cairo_run_py):

--- a/crates/cairo-addons/Cargo.toml
+++ b/crates/cairo-addons/Cargo.toml
@@ -18,6 +18,8 @@ pyo3 = { version = "0.23.3", features = [
   "experimental-inspect",
 ] }
 cairo-vm = { workspace = true }
+stwo-cairo-adapter = { workspace = true }
+stwo_cairo_prover = { workspace = true }
 num-traits = "0.2.18"
 num-bigint = "0.4.6"
 starknet-crypto = "0.7.4"
@@ -36,6 +38,9 @@ bincode = { version = "2.0.0-rc.3", default-features = false, features = [
   "serde",
 ] }
 chrono = "0.4.40"
+serde_json = "1.0"
+tracing-subscriber = "0.3.19"
+tracing = "0.1.41"
 
 [build-dependencies]
 pyo3-build-config = "0.23.3" # Should match pyo3 version

--- a/crates/cairo-addons/Cargo.toml
+++ b/crates/cairo-addons/Cargo.toml
@@ -35,6 +35,7 @@ thiserror = "2.0"
 bincode = { version = "2.0.0-rc.3", default-features = false, features = [
   "serde",
 ] }
+chrono = "0.4.40"
 
 [build-dependencies]
 pyo3-build-config = "0.23.3" # Should match pyo3 version
@@ -42,5 +43,3 @@ pyo3-build-config = "0.23.3" # Should match pyo3 version
 [features]
 extension-module = ["pyo3/extension-module"]
 default = ["extension-module", "pyo3/experimental-inspect"]
-# Pythonic hints feature - not enabled by default
-pythonic-hints = []

--- a/crates/cairo-addons/Cargo.toml
+++ b/crates/cairo-addons/Cargo.toml
@@ -39,7 +39,7 @@ bincode = { version = "2.0.0-rc.3", default-features = false, features = [
 ] }
 chrono = "0.4.40"
 serde_json = "1.0"
-tracing-subscriber = "0.3.19"
+tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 tracing = "0.1.41"
 
 [build-dependencies]

--- a/crates/cairo-addons/README.md
+++ b/crates/cairo-addons/README.md
@@ -16,8 +16,7 @@ The execution does not support the execution of trace hints
 ```rust
 pub fn run_proof_mode(
     entrypoint: String,
-    public_inputs: PyObject,
-    private_inputs: PyObject,
+    program_inputs: PyObject,
     compiled_program_path: String,
     output_dir: PathBuf,
 ) -> PyResult<()>
@@ -26,8 +25,7 @@ pub fn run_proof_mode(
 ### Parameters
 
 - `entrypoint`: Function name in the Cairo program to execute
-- `public_inputs`: Python dictionary containing public inputs
-- `private_inputs`: Python dictionary containing private inputs
+- `program_inputs`: Python dictionary containing public inputs
 - `compiled_program_path`: Path to the compiled Cairo program JSON
 - `output_dir`: Directory where proof artifacts will be saved
 
@@ -38,9 +36,8 @@ from cairo_addons.vm import run_proof_mode
 
 run_proof_mode(
     entrypoint="main",
-    public_inputs=public_inputs_dict,
-    private_inputs=private_inputs_dict,
-    compiled_program_path="./build/main.json",
+    program_inputs=program_inputs_dict,
+    compiled_program_path="./build/main_compiled.json",
     output_dir="./output"
 )
 ```

--- a/crates/cairo-addons/README.md
+++ b/crates/cairo-addons/README.md
@@ -1,0 +1,98 @@
+# Cairo Addons
+
+Rust bindings for Cairo VM with support for:
+
+- Running programs in proof mode, with python objects as inputs
+- Running pythonic hints inside the Rust VM
+
+## Running a Program in Proof Mode
+
+The `run_proof_mode` function provides a high-level interface for running a
+Cairo program in proof mode.
+
+The execution does not support the execution of trace hints
+(`%{logger.trace ... %}`), which will be skipped to avoid slowing down the runs.
+
+```rust
+pub fn run_proof_mode(
+    entrypoint: String,
+    public_inputs: PyObject,
+    private_inputs: PyObject,
+    compiled_program_path: String,
+    output_dir: PathBuf,
+) -> PyResult<()>
+```
+
+### Parameters
+
+- `entrypoint`: Function name in the Cairo program to execute
+- `public_inputs`: Python dictionary containing public inputs
+- `private_inputs`: Python dictionary containing private inputs
+- `compiled_program_path`: Path to the compiled Cairo program JSON
+- `output_dir`: Directory where proof artifacts will be saved
+
+### Python Usage
+
+```python
+from cairo_addons.vm import run_proof_mode
+
+run_proof_mode(
+    entrypoint="main",
+    public_inputs=public_inputs_dict,
+    private_inputs=private_inputs_dict,
+    compiled_program_path="./build/main.json",
+    output_dir="./output"
+)
+```
+
+### Output Files
+
+- `trace.bin`: Binary trace of program execution
+- `memory.bin`: Memory dump after execution
+- `air_public_input.json`: Public inputs for the AIR
+- `air_private_input.json`: Private inputs for the AIR
+
+## CairoRunner for Tests
+
+The `PyCairoRunner` class provides a Python interface to the Cairo VM for
+testing:
+
+### Initialization
+
+`enable_traces` is a flag that is used to control whether `logger.trace` hints
+are executed. If enabled, this will considerably slow down the execution.
+
+```python
+from cairo_addons.vm import CairoRunner
+
+runner = CairoRunner(
+    program=program,
+    layout="all_cairo",
+    proof_mode=False,
+    enable_traces=True
+)
+```
+
+## Pythonic Hint Execution
+
+The `PythonicHintExecutor` enables execution of Python code within Cairo hints.
+Notably, we developed an API that is transparent with how we interact with the
+Python Cairo VM.
+
+This means that we can:
+
+- Stop during the execution of a program using `breakpoint()`
+- Access `memory`, `segments`, `dict_manager`, `ids` data inside hints, like we
+  would on the Python VM
+- Added are global variables that are available to all hints, like a `logger`
+  object that, if enabled, can be used to print execution traces; as well as
+  `gen_arg` and `serialize` functions that can be used to convert between Cairo
+  and Python types.
+
+During execution, the VM passes hints to the hint processor. If a hint is not
+registered (meaning, we can't find a Rust function that matches the hint's
+content), it's executed using Python Interpreter inside the Rust VM.
+
+Serializing and writing to stdout during the execution of hints has performance
+impacts; which is why, unless `enable_traces` is set to `True`, we do not
+execute hints containing `logger.trace`.

--- a/crates/cairo-addons/src/vm/mod.rs
+++ b/crates/cairo-addons/src/vm/mod.rs
@@ -10,7 +10,6 @@ mod layout;
 mod maybe_relocatable;
 mod memory_segments;
 mod program;
-#[cfg(feature = "pythonic-hints")]
 mod pythonic_hint;
 mod relocatable;
 mod relocated_trace;
@@ -29,7 +28,6 @@ use relocated_trace::PyRelocatedTraceEntry;
 use run_resources::PyRunResources;
 use runner::PyCairoRunner;
 use stripped_program::PyStrippedProgram;
-#[cfg(feature = "pythonic-hints")]
 use vm_consts::{PyVmConst, PyVmConstsDict};
 
 #[pymodule]
@@ -44,9 +42,7 @@ fn vm(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_class::<PyDictManager>()?;
     module.add_class::<PyDictTracker>()?;
     module.add_function(wrap_pyfunction!(runner::run_proof_mode, module)?).unwrap();
-    #[cfg(feature = "pythonic-hints")]
     module.add_class::<PyVmConst>()?;
-    #[cfg(feature = "pythonic-hints")]
     module.add_class::<PyVmConstsDict>()?;
     Ok(())
 }

--- a/crates/cairo-addons/src/vm/mod.rs
+++ b/crates/cairo-addons/src/vm/mod.rs
@@ -43,6 +43,7 @@ fn vm(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_class::<PyStrippedProgram>()?;
     module.add_class::<PyDictManager>()?;
     module.add_class::<PyDictTracker>()?;
+    module.add_function(wrap_pyfunction!(runner::run_proof_mode, module)?).unwrap();
     #[cfg(feature = "pythonic-hints")]
     module.add_class::<PyVmConst>()?;
     #[cfg(feature = "pythonic-hints")]

--- a/crates/cairo-addons/src/vm/pythonic_hint.rs
+++ b/crates/cairo-addons/src/vm/pythonic_hint.rs
@@ -250,7 +250,8 @@ impl PythonicHintExecutor {
             let injected_py_code = r#"
 from functools import partial
 
-serialize = partial(serialize, segments=segments, program_identifiers=py_identifiers, dict_manager=dict_manager)
+if globals().get("py_identifiers"):
+    serialize = partial(serialize, segments=segments, program_identifiers=py_identifiers, dict_manager=dict_manager)
 gen_arg = partial(_gen_arg, dict_manager, segments)
 "#;
             let full_hint_code = format!("{}\n{}", injected_py_code, hint_code);

--- a/crates/cairo-addons/src/vm/runner.rs
+++ b/crates/cairo-addons/src/vm/runner.rs
@@ -93,8 +93,8 @@ impl PyCairoRunner {
             layout,
             None, // dynamic_layout_params
             proof_mode,
-            true, // trace_enabled
-            true, // disable_trace_padding
+            true,       // trace_enabled
+            proof_mode, // disable_trace_padding can only be used in proof_mode
         )
         .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
 

--- a/crates/cairo-addons/src/vm/runner.rs
+++ b/crates/cairo-addons/src/vm/runner.rs
@@ -590,11 +590,10 @@ impl PyCairoRunner {
 /// Runs the Cairo program in proof mode with public and private inputs.
 /// Mimics the behavior of the `run` function from cairo-vm-cli.
 #[allow(clippy::too_many_arguments)]
-#[pyfunction(signature = (entrypoint, public_inputs, private_inputs, compiled_program_path, output_dir, stwo_proof=false, proof_path=None, verify=false))]
+#[pyfunction(signature = (entrypoint, program_inputs, compiled_program_path, output_dir, stwo_proof=false, proof_path=None, verify=false))]
 pub fn run_proof_mode(
     entrypoint: String,
-    public_inputs: PyObject,
-    private_inputs: PyObject,
+    program_inputs: PyObject,
     compiled_program_path: String,
     output_dir: PathBuf,
     stwo_proof: bool,
@@ -638,8 +637,7 @@ pub fn run_proof_mode(
     Python::with_gil(|py| {
         let context = PyDict::new(py);
 
-        context.set_item("public_inputs", public_inputs)?;
-        context.set_item("private_inputs", private_inputs)?;
+        context.set_item("program_inputs", program_inputs)?;
 
         let identifiers = program
             .iter_identifiers()

--- a/crates/cairo-addons/src/vm/vm_consts.rs
+++ b/crates/cairo-addons/src/vm/vm_consts.rs
@@ -1,4 +1,3 @@
-#![cfg(feature = "pythonic-hints")]
 //! # Cairo VM Constants and Variable Access
 //!
 //! This module provides a bridge between Cairo variables in the Rust VM and Python code.

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -281,3 +281,4 @@ pythonic
 functools
 setattr
 pyfunction
+chrono

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -282,3 +282,4 @@ functools
 setattr
 pyfunction
 chrono
+stwo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,3 +207,4 @@ packages = ["cairo/src", "cairo/tests", "cairo/scripts"]
 compile_os = "scripts.compile_cairo:compile_os"
 compile_fibonacci = "scripts.compile_cairo:compile_fibonacci"
 zkpi_to_eels = "scripts.zkpi_to_eels:main"
+prove-block = "scripts.prove_block:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -204,7 +204,7 @@ build-backend = "hatchling.build"
 packages = ["cairo/src", "cairo/tests", "cairo/scripts"]
 
 [project.scripts]
-compile_os = "scripts.compile_cairo:compile_os"
-compile_fibonacci = "scripts.compile_cairo:compile_fibonacci"
+compile = "scripts.compile_cairo:main"
+compile_keth = "scripts.compile_cairo:compile_keth"
 zkpi_to_eels = "scripts.zkpi_to_eels:main"
 prove-block = "scripts.prove_block:main"

--- a/python/cairo-addons/pyproject.toml
+++ b/python/cairo-addons/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 ]
 
 [tool.maturin]
-features = ["pyo3/extension-module", "pythonic-hints"]
+features = ["pyo3/extension-module"]
 module-name = "cairo_addons.vm"
 python-packages = ["cairo_addons"]
 python-source = "src"

--- a/python/cairo-addons/src/cairo_addons/hints/injected.py
+++ b/python/cairo-addons/src/cairo_addons/hints/injected.py
@@ -9,8 +9,8 @@ def set_identifiers(context: Callable[[], dict]):
 
     __program_json__ = context().get("__program_json__")
     if __program_json__ is None:
-        raise ValueError("__program_json__ must be available in the execution scope")
-
+        context()["py_identifiers"] = None
+        return
     program = Program.Schema().loads(__program_json__)
     context()["py_identifiers"] = program.identifiers
 

--- a/python/cairo-addons/src/cairo_addons/testing/hooks.py
+++ b/python/cairo-addons/src/cairo_addons/testing/hooks.py
@@ -101,12 +101,6 @@ def pytest_addoption(parser):
         type=int,
         help="The seed to set random with.",
     )
-    parser.addoption(
-        "--disable-pythonic-hints",
-        action="store_true",
-        default=False,
-        help="Disable pythonic hints in the RustVM runner",
-    )
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/python/cairo-addons/src/cairo_addons/testing/runner.py
+++ b/python/cairo-addons/src/cairo_addons/testing/runner.py
@@ -517,20 +517,17 @@ def run_rust_vm(
         #   Unlike Python VM, we don’t append "jmp rel 0" here as Rust handles proof mode differently.
         # ============================================================================
         proof_mode = request.config.getoption("proof_mode")
-        enable_pythonic_hints = (
-            request.config.getoption("--log-cli-level") == "TRACE"
-            or not request.config.getoption("disable_pythonic_hints")
-            or getattr(request.node, "pytestmark", [{}])[0].get(
-                "enable_pythonic_hints", True
-            )
+        enable_logger = request.config.getoption("--log-cli-level") == "TRACE"
+        logger.info(
+            f"Running with enable_logger={enable_logger}, proof_mode={proof_mode}"
         )
         runner = RustCairoRunner(
             program=rust_program,
-            py_identifiers=cairo_program.identifiers,
+            py_identifiers=cairo_program.identifiers if enable_logger else None,
             layout=getattr(LAYOUTS, request.config.getoption("layout")).layout_name,
             proof_mode=proof_mode,
             allow_missing_builtins=False,
-            enable_pythonic_hints=enable_pythonic_hints,
+            enable_logger=enable_logger,
             ordered_builtins=_builtins,
         )
         serde = serde_cls(

--- a/python/cairo-addons/src/cairo_addons/testing/runner.py
+++ b/python/cairo-addons/src/cairo_addons/testing/runner.py
@@ -517,17 +517,14 @@ def run_rust_vm(
         #   Unlike Python VM, we don’t append "jmp rel 0" here as Rust handles proof mode differently.
         # ============================================================================
         proof_mode = request.config.getoption("proof_mode")
-        enable_logger = request.config.getoption("--log-cli-level") == "TRACE"
-        logger.info(
-            f"Running with enable_logger={enable_logger}, proof_mode={proof_mode}"
-        )
+        enable_traces = request.config.getoption("--log-cli-level") == "TRACE"
         runner = RustCairoRunner(
             program=rust_program,
-            py_identifiers=cairo_program.identifiers if enable_logger else None,
+            py_identifiers=cairo_program.identifiers,
             layout=getattr(LAYOUTS, request.config.getoption("layout")).layout_name,
             proof_mode=proof_mode,
             allow_missing_builtins=False,
-            enable_logger=enable_logger,
+            enable_traces=enable_traces,
             ordered_builtins=_builtins,
         )
         serde = serde_cls(

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2024-09-15"
+channel = "nightly-2025-01-02"
 components = ["rustfmt", "clippy"]
 profile = "minimal"

--- a/uv.lock
+++ b/uv.lock
@@ -15,11 +15,11 @@ members = [
 
 [[package]]
 name = "aiohappyeyeballs"
-version = "2.4.8"
+version = "2.5.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/de/7c/79a15272e88d2563c9d63599fa59f05778975f35b255bf8f90c8b12b4ada/aiohappyeyeballs-2.4.8.tar.gz", hash = "sha256:19728772cb12263077982d2f55453babd8bec6a052a926cd5c0c42796da8bf62", size = 22337 }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/0c/458958007041f4b4de2d307e6b75d9e7554dad0baf26fe7a48b741aac126/aiohappyeyeballs-2.5.0.tar.gz", hash = "sha256:18fde6204a76deeabc97c48bdd01d5801cfda5d6b9c8bbeb1aaaee9d648ca191", size = 22494 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/0e/b187e2bb3eeb2644515109657c4474d65a84e7123de249bf1e8467d04a65/aiohappyeyeballs-2.4.8-py3-none-any.whl", hash = "sha256:6cac4f5dd6e34a9644e69cf9021ef679e4394f54e58a183056d12009e42ea9e3", size = 15005 },
+    { url = "https://files.pythonhosted.org/packages/1b/9a/e4886864ce06e1579bd428208127fbdc0d62049c751e4e9e3b509c0059dc/aiohappyeyeballs-2.5.0-py3-none-any.whl", hash = "sha256:0850b580748c7071db98bffff6d4c94028d0d3035acc20fd721a0ce7e8cac35d", size = 15128 },
 ]
 
 [[package]]
@@ -279,72 +279,72 @@ wheels = [
 
 [[package]]
 name = "bitarray"
-version = "3.1.0"
+version = "3.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/33/33/1cacd69541f57649a55db29dbdaae8c93a2e64583388363aa3c62dc1b5c2/bitarray-3.1.0.tar.gz", hash = "sha256:71757171a45eac58782861c49137ba3bed0da489155311857f69f4e9baf81fa4", size = 127114 }
+sdist = { url = "https://files.pythonhosted.org/packages/41/9a/19f3d74ed2949afcc5c4f2ae6aec2e962004b8a9855070f68b3c6d7e838b/bitarray-3.1.1.tar.gz", hash = "sha256:a3c1d74ac2c969bac33169286fe601f8a6f4ca0e8f26dbaa22ad61fbf8fcf259", size = 135976 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/21/29/9cfda55fff2447d1469461f4d2361d02e14fc14f330f98ef9816f6c7931f/bitarray-3.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:3c1fad6456993f604726dcb21d1f003430988d5138f858d79e5b8682f56dfad6", size = 123462 },
-    { url = "https://files.pythonhosted.org/packages/01/65/a6cbeb1b0b03c6bcf291122d102cd793a81544bbf2f2e480b76983e1ea35/bitarray-3.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0dc0f28340929fffa17fbd3eca5bfae5c1827f3000c0bd9312999d8c5b1464a0", size = 120104 },
-    { url = "https://files.pythonhosted.org/packages/61/8b/a5a1c35bcf24e2c3ae678e8f34284e998ade61e80d93c09d879516481ca0/bitarray-3.1.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84de57891a80944e259956fd72bd542290b76c063182f0e85ce5380c49cfcfb6", size = 284556 },
-    { url = "https://files.pythonhosted.org/packages/97/23/782f6b3d5556b64a7b1a4d9a9fc689431571014f83ad51093cc9a14fca8a/bitarray-3.1.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b3f4be402e7c611a0a7048f3d042b9e4d697ca6f721d08098118d1ae8bb8a69c", size = 299526 },
-    { url = "https://files.pythonhosted.org/packages/dd/14/7a7db155c915b492475897a843a098cdd8351205aec16c305ddf06cc7eab/bitarray-3.1.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eabaee3c7d411f6ed48f92752e61a409530a0ebf65498bd408432800a804e0b8", size = 300221 },
-    { url = "https://files.pythonhosted.org/packages/52/76/634cb3ed8161ec5bbbd33093cc2e9f3a6a7b645a130eba7ba8835e73fc5d/bitarray-3.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7cb6c270c49d6779af97586a955977493146626ae34710a4c1ec84cb0115f4d4", size = 285123 },
-    { url = "https://files.pythonhosted.org/packages/63/f2/109a6ce801eb2346db8e60e04a194fc86b402daf1c0c9cfa3c605669f7e0/bitarray-3.1.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:481a00d710c7811b38563f6fe22da20be2e6f722196f68873e12d23f4fdf82c1", size = 274469 },
-    { url = "https://files.pythonhosted.org/packages/0e/2c/b4474666b8be94d196ce15c840bbc284b6886bd7d0763bd565e447bd2b2c/bitarray-3.1.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b81bbefe9d205af66a15a3097f8b66f29fe767fa9cb5dd5a7881f53d2505c2d5", size = 279113 },
-    { url = "https://files.pythonhosted.org/packages/d9/fb/112397a57fba6c55bc42e4595eef2c46672af39651e3d80c84cac225506a/bitarray-3.1.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:506df7b12e1380f56cfa20b9c203518afe585f0b86e850a96e3691cf0175e4c0", size = 270691 },
-    { url = "https://files.pythonhosted.org/packages/40/80/e74a41e90a57b156e33818c6699d5234fb5929ffbc648756b625c7155bb6/bitarray-3.1.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:43ec740770723de6c99f0a858807ef905664f31cf254e0b803f3dd2797537d7a", size = 294955 },
-    { url = "https://files.pythonhosted.org/packages/40/c4/c8554f431cc0f620085e20282b2327c4f341b19054c4b3f0e938e37624c0/bitarray-3.1.0-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:4deac3da54c3df136d6615a2410d5a6170353b4d08142273266296c376fb1889", size = 304673 },
-    { url = "https://files.pythonhosted.org/packages/6c/77/fe27654c1ecf19625b0a914b3586c363f1f87226a03e57b2fe4a8134614a/bitarray-3.1.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c58cbd0cc9f6347fffa36a6870fac695cd6e98c39fcfd8002d44a70fba03cd8c", size = 277614 },
-    { url = "https://files.pythonhosted.org/packages/ff/ff/57f32626f7824206b3a1a836b3b4dd6eb6254e5b531925006c980f41dade/bitarray-3.1.0-cp310-cp310-win32.whl", hash = "sha256:e092a5c4cc9ae6bc757bc1fee8894cd0275f0a0689c8f57555b00e198cdbcecc", size = 116764 },
-    { url = "https://files.pythonhosted.org/packages/6f/d4/e06bc3f9ac7fd216330c73f2094a79163bb34b507f3c963ef39b9eaf288c/bitarray-3.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:453395201790f16b22092c25bed6ecf3bafee7f36db840d4cfc07cd9b6f9628f", size = 122931 },
-    { url = "https://files.pythonhosted.org/packages/c1/51/503136a07a44b03b279c8e06823bdae7d2147b2512700c4d7129c786e67e/bitarray-3.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a1cb97bdc51e3db8def039607ca42d12c6e55fb134a8d211cca2fcf0a7b3a986", size = 123595 },
-    { url = "https://files.pythonhosted.org/packages/2a/ec/41d9ddfc5375118d07b721c3a50eddd2c0dd1ad0693865075e470c3d3b12/bitarray-3.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:92d8130efa6bebd4903b70f6d98832aabbd78c1031bc64c7c9d4e39b9db3bfa6", size = 120261 },
-    { url = "https://files.pythonhosted.org/packages/a1/64/aed159110569362af829d5dcd9b65517d720e762dfc233cc833e1b10b3b7/bitarray-3.1.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:37a9559ab050618902f8b8055c5b0b78dfc2a7974656fddee26b033ec56945f7", size = 291726 },
-    { url = "https://files.pythonhosted.org/packages/77/91/16d437a8d31b75c62cbf3f404af0385b8631ef980dfb3df38b4ddb1df33b/bitarray-3.1.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b2c57a4e8f0d9eb5cef7c83c8a4fd8bf06c35d641fc3cb24bf9511adb54e2d8a", size = 306650 },
-    { url = "https://files.pythonhosted.org/packages/63/cc/74a8dfc7070baf508fb4285d01c2726e6981297b3952c6d96d682caf366a/bitarray-3.1.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d9bcaa1764d0d302050a31b0f6879ea20e3900b2e73b4ea647ab570950c2062b", size = 308349 },
-    { url = "https://files.pythonhosted.org/packages/10/8c/9398986e210be15ae0bb4f1c5f392e9c4d058dfbe9c89b4eac0a23fee74a/bitarray-3.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:769184a57abfdfc24c37bb5d0f3836ffe65c7c5cdbeec431766520cd246a27c6", size = 292485 },
-    { url = "https://files.pythonhosted.org/packages/9d/a5/ee6730aa5bb323d0e7530f55dd63fb59e160cc4a4c0edbac4eebc6497ece/bitarray-3.1.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8f247387bb58b8c626088be2fa4ca5869fb12638b45acd29fab21aee48529560", size = 282421 },
-    { url = "https://files.pythonhosted.org/packages/51/12/01b3f08b73e472d3bf1ec015bd5c5e02b7f21fc2f63aff0d278cdc827401/bitarray-3.1.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1303604e4069699cef3e969f31d6c3e8e5a0bc637569d90b3647469eff91dc7b", size = 286256 },
-    { url = "https://files.pythonhosted.org/packages/6b/3b/c9f75c3fccbf384f6ffc5e40316226f131280d9f21d6678de1bfc934a5d8/bitarray-3.1.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:f238c2eb7a0a6a50537e5d182edb629901af94746854108483f0b11b0e3d1a78", size = 278171 },
-    { url = "https://files.pythonhosted.org/packages/17/68/741b59febef912876c0f95c450eb842c7138cd067e24ca4ff459265d82ef/bitarray-3.1.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:e43a96b9b63348d9e5cca70fc31b5d0f07a420a70ef89b376aa4148b87d24b39", size = 302004 },
-    { url = "https://files.pythonhosted.org/packages/1e/2d/bc2db4c27d7de4bb60420a1a2204e93695378e9c7ae2ed50c6bed1de23ce/bitarray-3.1.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:5255fb9e4e4879adea5fb61cbde347767d346e29822a51ca21816f28340f4cdb", size = 312651 },
-    { url = "https://files.pythonhosted.org/packages/d8/c5/4bd5f3b051f439d8fd612f40b83ae6f7dbd6d408de98a5885c6b4a181882/bitarray-3.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:68bab51a827abc6f037ea76bb374ec28804a47b51716f9eb3f7da3d754bc8431", size = 284627 },
-    { url = "https://files.pythonhosted.org/packages/16/3a/11b27412dc829b08ceb7773ea730ad5cccc311b7268557bbedb861ec7754/bitarray-3.1.0-cp311-cp311-win32.whl", hash = "sha256:7ff061c714ff62357ff3be23d96c73944ad9181b8b21d49c29ed82fb2fb0efa4", size = 116761 },
-    { url = "https://files.pythonhosted.org/packages/c3/27/fce9e948da179d8329192fca1e431b2211c14dd18c21529fc30254bae2c2/bitarray-3.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:b2f8aed62de760be852e0dee0ad507e0fe17fc12f83b36cc0bfe4900e0a0e915", size = 122981 },
-    { url = "https://files.pythonhosted.org/packages/5c/d3/4be50f727dd2786dd545030fd6cb16ba678405ef147d647a8d89d7a673c1/bitarray-3.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4c298fefda9dfe2ef24aee8fe48acc3a1a063b266791a814330c6932248785c4", size = 123470 },
-    { url = "https://files.pythonhosted.org/packages/5f/02/8bf64399507ec94422635b621eeea00a649413988fc19ae54ce54f3a239f/bitarray-3.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e9211fb3a109ba76cb8bd0f76645d256f8a46e733693de22d0d7857941603cee", size = 120359 },
-    { url = "https://files.pythonhosted.org/packages/71/75/4febe1ee16e3fecd8f29fdab2911233f956cc09d40b6238ec626dec3bbfd/bitarray-3.1.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2b6bfe0a618301f0afed9004b8230a413ad399b58fef50a744a623461b96d8e3", size = 293893 },
-    { url = "https://files.pythonhosted.org/packages/fe/a0/7cc3a299f3afb752b0a5ee31c9ed2a201f1972110036fe589dd66928c3c9/bitarray-3.1.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2db21d733e06d0d5b86fd3c848a84b8930e71250542aa7602e2c048b96fce163", size = 307813 },
-    { url = "https://files.pythonhosted.org/packages/77/a4/bc83b3407b0ca3ce451788322a51b3b071701145158a69bdad273624cdd2/bitarray-3.1.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3807c38b37a500583eafd4ae866d2a051834acd4e11cd8557af9cf5379fa7e21", size = 309871 },
-    { url = "https://files.pythonhosted.org/packages/5b/e6/f07e7098fda874d1dcd19d06663dbc22ea63567d85623a904d3127d458d6/bitarray-3.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dcd15f43e846bfdaac8e5420006eba2d6adce29b6336492cf9d651e4a313ea86", size = 294630 },
-    { url = "https://files.pythonhosted.org/packages/2c/e4/c5e564076e74b21ddc7223b00258c38d56302e08b74569865b186e8bfceb/bitarray-3.1.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fc2266e15f02d3192d1c2d29a790a4eccb230e23de0de6136815b32f9cdd5b4d", size = 284269 },
-    { url = "https://files.pythonhosted.org/packages/5b/7b/b93fde3d9fbd542e4eefdc0b269d73374c5ba1ff4d0bde2aea262f0166c7/bitarray-3.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:54a6a8525bc66228ed9cc69d562979319ef151dba2ed302bf7a21c7e124c137b", size = 287778 },
-    { url = "https://files.pythonhosted.org/packages/1a/10/c4fe19255336574c19fa2fc85f1b8dd7f22670fd424c142d43ad07e360d7/bitarray-3.1.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:ffb6b3a6efdabe6a4f3042b16a68499711a7835e950847a5643f60a43de3335f", size = 279965 },
-    { url = "https://files.pythonhosted.org/packages/d0/81/cae2db147b124e11479639edf7ddc35ba3ddea42369906a58bba9cde2ea8/bitarray-3.1.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:430302c3ca7ed0dbb629db87e24a3be082851d71777787d4c8ad424624363780", size = 303054 },
-    { url = "https://files.pythonhosted.org/packages/39/1b/0cd00721f0db83575db77b0be7dc6dba4542e33d7dd7d929a836a6ad4705/bitarray-3.1.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:d4277999453fa63e96ed8a31698c9ac64ee5f38bd5c63205d69d9b73780fa152", size = 314566 },
-    { url = "https://files.pythonhosted.org/packages/23/ed/e9c759617b4765444cfa9678d6a10d6eb22f9c970c6c6a691d047b6937ae/bitarray-3.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f8fab5053ff281954718dc56c44ee7d1462ccc7e296b84da504b72b01c6c0c41", size = 286825 },
-    { url = "https://files.pythonhosted.org/packages/cc/65/ec5f63c32a49155ac6080e40a0e0d94ee64777701bc399010d67b62a4af9/bitarray-3.1.0-cp312-cp312-win32.whl", hash = "sha256:598072dbe456cc57270c6f34fa6b9aafd56bb5291e0d14f8509c1522f6d77f32", size = 116848 },
-    { url = "https://files.pythonhosted.org/packages/cd/99/619f92fa9fa037f36394f7c7f28827d632bed5eb1bfb83a246cdee1bbfc3/bitarray-3.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:4fed8491a77f9fa5303bf6a24a76fcafbf1b496bb22d72b213b673ef8ce6e201", size = 123158 },
-    { url = "https://files.pythonhosted.org/packages/7d/2d/8e9b60dcf950b6680597e4fbbbac75c8c65a109d2d91e0ce452c07ba410b/bitarray-3.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6ea4a888e45fdabc89705837b10030a990ec4879d14fccc3b9450ab56ca9d7ec", size = 123473 },
-    { url = "https://files.pythonhosted.org/packages/1a/d0/2acf62614c9f502f479c4b03ac79ab17a91d3db354406b0b67839adb7ab2/bitarray-3.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2695c23b9857105631e9d4f8ebbcc8a4e55c6c9f31bc80d9e5e018e377d650d8", size = 120338 },
-    { url = "https://files.pythonhosted.org/packages/a2/6c/4a736189e261293f50057b700176b28a135e8a75ed41ea63edaa732cd66b/bitarray-3.1.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:577a1ffc6318cdcbf91e8492596004bb1572ce3c703aa42c16c8ac1188625b8d", size = 293831 },
-    { url = "https://files.pythonhosted.org/packages/c5/74/4352988907e5a2cb846fb12e57ad336855a81e78665cdec6072fd0a385cf/bitarray-3.1.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1221d5d1255a74397f938ff822d8df4b0cc416b74e5659d21c3fe5f3d06590a1", size = 307758 },
-    { url = "https://files.pythonhosted.org/packages/74/68/080243639c2dabaa100a7b6e539c6f6719186b0de312aa575e77a6502f4c/bitarray-3.1.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:91e9309912700ab085cf78d162ad0bf0d3de35e5e084868400672b4ce3befbb0", size = 309828 },
-    { url = "https://files.pythonhosted.org/packages/bd/9f/7b8edbf10d1fadf6df73ba668cb49d1626c464e85484a40b42b389ebc2f4/bitarray-3.1.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e8c319f77118bac6aded58a0d2f172ac1b06e00bfa5391033848864e39bfd771", size = 294524 },
-    { url = "https://files.pythonhosted.org/packages/19/56/cfa3c34f5a56e52ef91036cf26e2e6df9576e01c449414831fabd0c5eed1/bitarray-3.1.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:08004c22af11a234a73a8edf744524fb67e89ab4c80791f647c522687ddcb4b9", size = 284160 },
-    { url = "https://files.pythonhosted.org/packages/15/63/ae160f4fe8bcf46c4ed057d277ad6e03532f50583599fc74b80f3d1c347d/bitarray-3.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:afb4d8876fff11cced4377f055498fd3c179e6e2bf7165fd055dabc494005252", size = 287858 },
-    { url = "https://files.pythonhosted.org/packages/d6/23/5061657b3cff855dcd9d273e9edf39dfe68e9de3fd61036ef30b2dc70410/bitarray-3.1.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:7c228c78bd20f2a46a2f3f2e349292c604ae26210dad56afe4b64ea65f72db75", size = 280029 },
-    { url = "https://files.pythonhosted.org/packages/8b/1a/460b993d20088917661b14f3c32f2036b332c281a57f89d73e33918de541/bitarray-3.1.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:139115998ffcffd8b883e1f21ced6f1d96947c5ace51f9656ceccedea5765557", size = 303238 },
-    { url = "https://files.pythonhosted.org/packages/74/a6/41092e6a2bf2f05e971dd609999312da2cf0a1b03f6839a366a45d4550c5/bitarray-3.1.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:7e3ade382c9a5d5d77635041dd2aaa4e59326c8f62e1fb33ce28ddaeaa6ae7b6", size = 314627 },
-    { url = "https://files.pythonhosted.org/packages/bf/d9/af8af3a7cd1d4543a4d097b2e2f55ae959ba2c70311c30a4330266165c00/bitarray-3.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5efdb6403d206068d434caf9deb7ab936732c06e5617a63e213c94ac750303f4", size = 286901 },
-    { url = "https://files.pythonhosted.org/packages/56/06/37c3b60e6a0da03cba7a437e6b8143affe8c6ba9c44345f6635d8ebb7620/bitarray-3.1.0-cp313-cp313-win32.whl", hash = "sha256:69721fef0427a7f56ed7eef16ff9ddec96c64cee4d7abb5e7511c9aedebafc0f", size = 116827 },
-    { url = "https://files.pythonhosted.org/packages/c1/83/e2ced9b9d289c6d97bc756c7e5c7773d2d9791f6ac26b0a49f25eaa85068/bitarray-3.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:34d75765b5c558e7bffa247493412831c6edb5c40e639a6ac94999bc6f40a6c8", size = 123146 },
-    { url = "https://files.pythonhosted.org/packages/07/62/049a0e18fae8b642c8a7ab7fd735b8193cad5910598ada525ef259f27639/bitarray-3.1.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:c0790bbbe08b141d6a93061e68d1954c86374ca4982e5586becdf7dc0d61e95c", size = 119656 },
-    { url = "https://files.pythonhosted.org/packages/99/71/f7bad2f64e19f9b22ed4ffa6557a72d49accc93567dd11f689a216047ed5/bitarray-3.1.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:dde6268797d6e3f0639b1a5048eee5e42aa63fd00c4477741f9a5b1720f1aa8f", size = 116759 },
-    { url = "https://files.pythonhosted.org/packages/d2/ba/c6551403d7e31c886dd2d225127ed12773dae1c9b9ea544c7479c5dd9ab2/bitarray-3.1.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ea7791224248fe8ad6f5533877f94850b5636cf957f245a2f4854da21d0be766", size = 124971 },
-    { url = "https://files.pythonhosted.org/packages/69/e6/b50c534831f8104c0c705d7ab6aa6ea8c9facb09462b6ac86ffb24069fc5/bitarray-3.1.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ea7319e68ad1cb081dd7d1b2fe1242c12fe8f9ee3c78812db010b18e9753f7bb", size = 125763 },
-    { url = "https://files.pythonhosted.org/packages/aa/d2/5d86e4fac05e24044df512079e8b5245108abc45a4a3387c7c2d4c5b74c4/bitarray-3.1.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3aab1395cd4a23b1815f87120e59e1a66a5f3e92cbe42e4653b9fae1320e0eeb", size = 127378 },
-    { url = "https://files.pythonhosted.org/packages/18/55/e8bff6b5051dbc0aa828c7ad45226b3af6e4c3533fd0ced4d31f0c5dc261/bitarray-3.1.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:729ede2a88c0b379080606f2dd6ff4b4fc1798683f1fb244d79e929b298784c4", size = 123515 },
+    { url = "https://files.pythonhosted.org/packages/12/99/2e2657d6037416f8c5b2ebce1aa2686c0ace44cbcdcbd646391b59e86a7e/bitarray-3.1.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:cb630142c0371862e114cc92fb3c7984b72bbbc4c7e7465225402ab8c7737637", size = 132301 },
+    { url = "https://files.pythonhosted.org/packages/5d/42/0b9cbcc123b06e2c861b524328a25b54250f68a866beee51e51cee716d5b/bitarray-3.1.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:737755812c8834077885c0843e80eaaa2bf289c149f40a4ad0ed79e848fcbaf3", size = 128944 },
+    { url = "https://files.pythonhosted.org/packages/9a/e6/702ed267b954353f110e2f7026041446eedbb21b21360f4921fce4103809/bitarray-3.1.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e6a5d705bf86501db0106a25f4558f4954346ab13ac6eff6cb6d680c3f8e7fc9", size = 293431 },
+    { url = "https://files.pythonhosted.org/packages/5b/f0/70794ebac57e6870147b1d62fc7b915bbf565ef9473842251b53cb65aa89/bitarray-3.1.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:19e04daf81ff027e474e02c1cb5b56faa4180eab60efa60552ca6035957f067d", size = 308518 },
+    { url = "https://files.pythonhosted.org/packages/50/1d/09ff7242bc0d70928f40a6f22f2cb14c1050b978febcccccd29353ba988e/bitarray-3.1.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d9af2df20c620a989a853afa9b01e1be85c9e8c22390aa508d3bbaff1abea27b", size = 309144 },
+    { url = "https://files.pythonhosted.org/packages/d9/93/4db18c8271390f007e2d585b4be96e78929afa292a88c60420d346310ad2/bitarray-3.1.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:81587e9e3e6a5fc528a3207fd7b2ff5690cf5b041d7786d851ed0618d6a7db55", size = 294159 },
+    { url = "https://files.pythonhosted.org/packages/44/96/0aba2b070a3259dc8dfc01b577bcf0c3cfaabc814823260fabcf50d5d0df/bitarray-3.1.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:121478e4c265ee84d0d154c0e227eee311d9e5885bd36c688b0db5c2c399f7bf", size = 283456 },
+    { url = "https://files.pythonhosted.org/packages/00/c3/8ee8e0b930efee982ef03d166417d4161613b6e2215f15e8b5980e7754da/bitarray-3.1.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:38fae12b6578585a3ebf917303893d4cc917ddafa5f7dfe4dd3e9a3c7e487786", size = 288128 },
+    { url = "https://files.pythonhosted.org/packages/0c/fa/2e5c7d9ad3973c1613445def07f1878eedcd194db9e5db6ca30edc8c2ac1/bitarray-3.1.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:210ae85e2a1ea9ee56fbfa749c43e1b4a883eae8676909a3e5c5e07ab6e64a19", size = 279726 },
+    { url = "https://files.pythonhosted.org/packages/73/b0/9f763a5c400a43ce38591650065e15eb21ed5d69caa9b00168faeefa5b1e/bitarray-3.1.1-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:a190b72836c5ffc31bb33e4d042da74520f4fdb484a3e3b6d4cbb344a220ef4e", size = 303818 },
+    { url = "https://files.pythonhosted.org/packages/6d/3e/5d01da4884e3d00f15c8fb29f8c0aac3ad5ba982ff613b065961fc677d81/bitarray-3.1.1-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:08d344b28b91c09d752f8c3737e48de745d1c4c38a82ae1a22d537ab7b401958", size = 313671 },
+    { url = "https://files.pythonhosted.org/packages/43/e8/c4f725a896f20589831862d991f76c38f2c43cc2b1602dae94cefac343dc/bitarray-3.1.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:38dea3ce372a7383d1396c46ec816b92738bd50cf14d785770d68565f2234cbd", size = 286623 },
+    { url = "https://files.pythonhosted.org/packages/db/fc/25598dbd772c0773a0b627a097312dfa64f1fb81dce69f730a519ae78a16/bitarray-3.1.1-cp310-cp310-win32.whl", hash = "sha256:76cc30fc59ba83dbc91d56c30325c509e13c7264d98a3e8c80a4be5a429e745f", size = 127382 },
+    { url = "https://files.pythonhosted.org/packages/23/74/f9c37e66a5d709805172eb590d616285c343c6ed770f0fec6faf293571d6/bitarray-3.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:66b9a9e6879733aa435ebf5aaa04adb2b577e09109383f301bf4da506ac08eb0", size = 133646 },
+    { url = "https://files.pythonhosted.org/packages/e1/90/9e76cbbb7875bd993ed618c1b90d2f2170daad25c44efc71259521af640f/bitarray-3.1.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b4703f0a0b79b9567433f66a736f3d62f5f51e31f653ade93e7ee3f4d53388ab", size = 132451 },
+    { url = "https://files.pythonhosted.org/packages/cf/25/55a7bbcc291b05f82aaaa0c243ad1035580ec5eef00d94a5a4a0c8025e47/bitarray-3.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:60b4dd3285ebef22d633d7d6d62dedbe812f5c989718adbfbbca8203072bdda2", size = 129102 },
+    { url = "https://files.pythonhosted.org/packages/85/f2/ac71ef34bde8db0d07f80380bb8b513ac3ff554c86ed991426af1dd64954/bitarray-3.1.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:26a6c4ca77395248ffdac578328f5375a9adec19a9dafe2609279f47b485c4bd", size = 300689 },
+    { url = "https://files.pythonhosted.org/packages/ab/72/f754716895d31b7bfe47294e5afe67427dfaf80ee5c0110d4aeac04b782a/bitarray-3.1.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:606c19d19cfe6940863e2eb8063524b51fc9422908ac8684782165e287f7a9b0", size = 315597 },
+    { url = "https://files.pythonhosted.org/packages/91/2b/725a3699ff2fdfb85ca6ef0a83cda807ef7f111b021f005b4f7cc4e3878b/bitarray-3.1.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:327e9831662b94e1fabb4325b405a6aba945862d23e15f4fe2d79a9ab1a3956a", size = 317298 },
+    { url = "https://files.pythonhosted.org/packages/20/eb/e338f1c7a84aa3a009d847ab9888dabb74924acd1120e756d919f19e18f1/bitarray-3.1.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:91474a151d0b891bb4fba59d280f0fc2aa691e4509053b105972471e6e3bdb0a", size = 301518 },
+    { url = "https://files.pythonhosted.org/packages/e6/ee/994bafb4479630290ed53a27c9d6b40f96d1a0da16ec62aaa52edb0db36f/bitarray-3.1.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:811825c71ac5c6b6996ee480f1a9290ccb096c539e169349b480db6133748d26", size = 291406 },
+    { url = "https://files.pythonhosted.org/packages/24/c7/35fde149d15434a70aa6125a258de2dc946997b151ecf6bf03d352cc47a3/bitarray-3.1.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b8676f54ba745554f9f989e1d7fa6c39ba1420042755c1259933f206d10bfe20", size = 295325 },
+    { url = "https://files.pythonhosted.org/packages/30/c8/1f4dbe1cfc2152991bfe0f58ba2aed1563dbdcc0e07356ccb09fa160b9c8/bitarray-3.1.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:38ff12457e6d3123060af83fa442c310550eac11efa0918301afe3caced559e3", size = 287215 },
+    { url = "https://files.pythonhosted.org/packages/50/75/8ef882f0a76e35337b83c6a8bcb646e4771bd913ce7e83afde073f76b52b/bitarray-3.1.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:5c7ebd040c5aef90608ecf709590900c1ec1131b19b3bd6972218d740ba6ab88", size = 310923 },
+    { url = "https://files.pythonhosted.org/packages/b0/40/dcc4cce6750e014d8f4ff0fcba3b0c979e8a7adaa3caa86d999497fb6611/bitarray-3.1.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:ea6babf32bce3a8c5249adb6cde389dd4bacb50f926ebd5171ffea6c9897491a", size = 321694 },
+    { url = "https://files.pythonhosted.org/packages/95/21/d587073b86cfb24afbd4ee4dac189f289d55d50febc40bd8c3843efe7325/bitarray-3.1.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:11fdd645909abbac60bca0579bd62a43d0f22850a2c2659e39509c1ccf96a4b0", size = 293564 },
+    { url = "https://files.pythonhosted.org/packages/39/8d/5137f2d387434a486ff26d1c1ec7de38abaf25cb47e3900601b7002f353a/bitarray-3.1.1-cp311-cp311-win32.whl", hash = "sha256:2b27ab40f4b3861b32a380031d7f33952e16b968759446c8be07c64f9035a2d8", size = 127563 },
+    { url = "https://files.pythonhosted.org/packages/3e/b2/4a7934b0c8316ab063cc68f14f0f06b71c12581e11d70885281ae260e5c4/bitarray-3.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:2080b6110ffa62513774d9140ad6562fd1e478853a46ebe80b6b2cbb13bbfeb2", size = 133843 },
+    { url = "https://files.pythonhosted.org/packages/29/e8/b24ad217de77f89b045c994159d9411d18aa6e900b450186160c8d3c51c8/bitarray-3.1.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:1af43aa945c595bff4386a2b64c46f6cee653883e295907e419f6745123a168f", size = 132304 },
+    { url = "https://files.pythonhosted.org/packages/f4/3a/d690bf045027bf68008698ad05622a95bebb9744a4f03b65b7ccc8e27161/bitarray-3.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:9e43e1a8b38d6e8ccc27cad74dabd8005b078856c471a1d0537491b71184f209", size = 129192 },
+    { url = "https://files.pythonhosted.org/packages/22/8d/27917c589b2abd4e7d9625e809ecb94d58a7bab795980aad71ccb9e2ec37/bitarray-3.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6a3816df3db86feaa8b4efd6844c6808147954626898355253e11e2544145f48", size = 302728 },
+    { url = "https://files.pythonhosted.org/packages/af/b2/8853417c300ed2deba433370adcbcc7782d127fb8689b81900ef30fefc01/bitarray-3.1.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f913548d2907633782f0c3de72fa28646e1f97bdaf7f2df04014a17e923a258b", size = 316634 },
+    { url = "https://files.pythonhosted.org/packages/ac/27/4e73989d43b3fa50846aba2786dce9e287bad50d51bf10626ba54f126d82/bitarray-3.1.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7aceaaff83bcdf87bcc13788e29fd068d1a1e6965946ffed80f6e9323e5edd3d", size = 318709 },
+    { url = "https://files.pythonhosted.org/packages/89/b8/5a3ba6c0c7bc5c45ded73d346cf9e9ebd6724c5afdc741a4255a7531e718/bitarray-3.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:079a2fd318d2300c2ef6e84fe9f8f563bcfad46b1360b7d58d82711e5bd8ea56", size = 303590 },
+    { url = "https://files.pythonhosted.org/packages/03/45/f28008eea33a8dceaab3887d3085402f7a6aa8db440b93e7789099d7ca20/bitarray-3.1.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:41f0f93a3ccde6f0e3b953d5adc89f7d4acdd3aadf71af8353c8b288a9d4bd80", size = 293191 },
+    { url = "https://files.pythonhosted.org/packages/7a/d8/97e13bfcfd89232a89880aced20548672fbb64a1eb652aab26a7e786d264/bitarray-3.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:51f860b200fa90e446db77fe57173603ddb81eef4d4ba1ccdc277b564b3f20ab", size = 296698 },
+    { url = "https://files.pythonhosted.org/packages/8f/1a/bae81c46ebddf5024e8eabe894d76c4095a8bea6d868edfdb6a0fc207f17/bitarray-3.1.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5c819daa6c11107614328d9018ccbaf5b7c64060172bf564373d62928f139e87", size = 288895 },
+    { url = "https://files.pythonhosted.org/packages/be/ef/e2984fc89c94a05d8d27647ae734e360d85f9fac042d7ea18547f28ac64e/bitarray-3.1.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:21081fb49d6b0a19b238d30dc0c948bec365bf16fccc2a1478a2794b37a6a812", size = 311913 },
+    { url = "https://files.pythonhosted.org/packages/0e/1c/032b6e09d39e80a9df1ca644bfb6b8a0dbdfd68c12c4195e060797ea19d2/bitarray-3.1.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:514757d0f76d9f84187ea15debd8b3956438f6f4f1e600be1019facdb6076796", size = 323415 },
+    { url = "https://files.pythonhosted.org/packages/40/fe/ec3ce002540644f2c89ea6109138d3281336f2d11af33dd77729314bf93e/bitarray-3.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a44c5271f7e079530f7a5eecac55cb4ff350ac82db768c550f66c1419893e4c7", size = 295773 },
+    { url = "https://files.pythonhosted.org/packages/ea/aa/de763b168406eb23a8f489006905dd51c9ee3965f5220170b74097662d8f/bitarray-3.1.1-cp312-cp312-win32.whl", hash = "sha256:97825938fa3fd7e917e40d66ab70ff133dee385da13cf91e0bd5cd4ec2d97048", size = 127695 },
+    { url = "https://files.pythonhosted.org/packages/fa/a1/3331f8b4c422f30839fee1f5e486524a7f82269d46008af84ff300b39084/bitarray-3.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:1dffa70fdf6e4aba4e4f8c8aa408950c3199f71546fb24cafc70f03400b22a59", size = 134144 },
+    { url = "https://files.pythonhosted.org/packages/43/7f/738612915b939522e1bce9529ddece71133a7de794441eb4375a11c1a79a/bitarray-3.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:20969936312f1f141448debcfd48ec9f64fbf5981b5cd8e01261c8307f7d4be3", size = 132305 },
+    { url = "https://files.pythonhosted.org/packages/90/46/f7e6fa3c9c699bcaa468c9f548d360b3b874001d0678c06936f41ace049d/bitarray-3.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1e2240b17a3161f5b921a915c2c43091dfb00d8fd495663b31dfe7edbebd7ef6", size = 129183 },
+    { url = "https://files.pythonhosted.org/packages/6d/b1/c74d9120ecce47221c3445047cfb8bfe725209177f6ded422d67d710d067/bitarray-3.1.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:71c2cdbb3f625f676f7d1aaab11e29e87195ef07bbf4b5cd7688fc560336a8f1", size = 302700 },
+    { url = "https://files.pythonhosted.org/packages/2a/f1/5c79c6e75c11dfe8097a160a332a2a12c87eb0735e718484512be6ed3c26/bitarray-3.1.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4eb3a9c105f7c92c1369fffdd6635344173cf855d9aa1cb74d2485a77ff4c9e7", size = 316589 },
+    { url = "https://files.pythonhosted.org/packages/d6/50/84da6c6225b1f4611e64105a2cb9ee4a0c677b73e8e4bdc4300448d91313/bitarray-3.1.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:db71d42035a1789409975c09c70305930a0b7e0f448aba0a198b2f8505bacd6d", size = 318663 },
+    { url = "https://files.pythonhosted.org/packages/76/07/35e32fd180773797732e3a33cc09d39cc4427ae9a3e4e6468e085dbfecb2/bitarray-3.1.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0948fc9408f8e691d8f83460b1a9376543909bf66a7c7325e9a1974ed045e9c3", size = 303487 },
+    { url = "https://files.pythonhosted.org/packages/65/b3/a21dbe67f8bb336a1be7308d283fdac8666dc12ce76886ab55f65d766a67/bitarray-3.1.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:22bc5460e2b28674c49842f9c5f47ed68866dbb97d4ee6fc627efce9dda35a6e", size = 293063 },
+    { url = "https://files.pythonhosted.org/packages/70/c9/b33f10ab47f973af2fb80562a00bff10d568bd05500e92b483cd4ca0f1e8/bitarray-3.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9ba698f812926a4026929891ecde4f863cb80139bd06581767c77edc63de578c", size = 296777 },
+    { url = "https://files.pythonhosted.org/packages/4a/ec/1cde0f81bbb2075c2595c81e17dd5966bcc97b7fae7bc057614b7813562b/bitarray-3.1.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:651e38e3368b3f79b5aadf2eda04cb3fcb2007513bcee4c658fed2b419be3083", size = 288964 },
+    { url = "https://files.pythonhosted.org/packages/a4/86/e2f4a4aae2d700dc60c52f8a086ad05b66cc60fac961d5629d0a8637d750/bitarray-3.1.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:9c3b7e2ffdfbf535268c588c566013b7da99b3e70ff6f968f1a76b32e6252c6a", size = 312096 },
+    { url = "https://files.pythonhosted.org/packages/94/c5/04d3df1c3b600877c27b9a35e11b9402a9a9e34d8a19c6fe4357bc954246/bitarray-3.1.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3e305f7ecdac83d83e68c87f3bc0c9be64941e34b58d7b4ad171fbb7c0d0aaaf", size = 323559 },
+    { url = "https://files.pythonhosted.org/packages/32/a0/0b950502fec513e4dc8161d3821891b9ad31b875372df4d0b5c9ffb172e6/bitarray-3.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b23df9c5b767a58fe6a9ce79f126ebacd8bc4b1c93d9eec8904727baad887a5b", size = 295864 },
+    { url = "https://files.pythonhosted.org/packages/ab/03/7b8952f659a1875463861867941528a3ab974b0ba6f2a6092bed47321238/bitarray-3.1.1-cp313-cp313-win32.whl", hash = "sha256:b9b1109ca43344333a4106b22d70c41c21c559fd8199f09fcfbb9f9e5fd3130b", size = 127706 },
+    { url = "https://files.pythonhosted.org/packages/92/b4/f8537e79ba2e4615e0898881341dbbb04bb219cae7618e7bf3880cfd551c/bitarray-3.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:72d6a03b5c27a27ba6a528d511b70f256796ae228c6b97aac9e8c87f53392d3b", size = 134212 },
+    { url = "https://files.pythonhosted.org/packages/5d/79/f67b3ca83c03884532fd7f06e219e346be1d1622400c17006b6ddbd9d383/bitarray-3.1.1-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:e597f014af2538475b0815a035b1d9353eb0206ede61675354ab410026f66948", size = 128506 },
+    { url = "https://files.pythonhosted.org/packages/5c/38/3c324bb80aa1e69b33031e4a68b3be3091dd89ddb955f42bdc8063e9a31e/bitarray-3.1.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:b658a1cc62b8c6c2375a56b99330c1d66be9352ce299fd649b3f82b055532c07", size = 125591 },
+    { url = "https://files.pythonhosted.org/packages/ad/18/ab8ab3229d4748857e0fda8886b76a1407fcb91de3a095e7ead861b1bcc3/bitarray-3.1.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c96382afde96fe02a138bb5d76bb9cad22bcdfe51f223a0cf855c66c0d866af8", size = 133823 },
+    { url = "https://files.pythonhosted.org/packages/0d/8e/95f22f7308e2255e03ced4fdd88fb746c5a3ac1d354e0235da6d664f5b7d/bitarray-3.1.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9e32b3b2224ef4855c024c9b3a98bc2cd3d2785937472af1c929ada347fe7cb2", size = 134624 },
+    { url = "https://files.pythonhosted.org/packages/96/26/b8d2c7ddcb2ef4feeccaa69a6e1cf170958cfd1d7ebfb0bfd956fdace518/bitarray-3.1.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:34d5d9d72b6db783d7427e4a5a5b2d48b2ec9df0772d859483a5e31b1231b001", size = 136250 },
+    { url = "https://files.pythonhosted.org/packages/7d/27/73ca754c226badce7f64a25964d990954f50ab672a401b81b7ee55e6c1bd/bitarray-3.1.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:8560480a743341f5720e1ed91234e2199ca4422a6afe849575562aa920468487", size = 132431 },
 ]
 
 [[package]]
@@ -898,27 +898,27 @@ wheels = [
 
 [[package]]
 name = "debugpy"
-version = "1.8.12"
+version = "1.8.13"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/68/25/c74e337134edf55c4dfc9af579eccb45af2393c40960e2795a94351e8140/debugpy-1.8.12.tar.gz", hash = "sha256:646530b04f45c830ceae8e491ca1c9320a2d2f0efea3141487c82130aba70dce", size = 1641122 }
+sdist = { url = "https://files.pythonhosted.org/packages/51/d4/f35f539e11c9344652f362c22413ec5078f677ac71229dc9b4f6f85ccaa3/debugpy-1.8.13.tar.gz", hash = "sha256:837e7bef95bdefba426ae38b9a94821ebdc5bea55627879cd48165c90b9e50ce", size = 1641193 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/19/dd58334c0a1ec07babf80bf29fb8daf1a7ca4c1a3bbe61548e40616ac087/debugpy-1.8.12-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:a2ba7ffe58efeae5b8fad1165357edfe01464f9aef25e814e891ec690e7dd82a", size = 2076091 },
-    { url = "https://files.pythonhosted.org/packages/4c/37/bde1737da15f9617d11ab7b8d5267165f1b7dae116b2585a6643e89e1fa2/debugpy-1.8.12-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cbbd4149c4fc5e7d508ece083e78c17442ee13b0e69bfa6bd63003e486770f45", size = 3560717 },
-    { url = "https://files.pythonhosted.org/packages/d9/ca/bc67f5a36a7de072908bc9e1156c0f0b272a9a2224cf21540ab1ffd71a1f/debugpy-1.8.12-cp310-cp310-win32.whl", hash = "sha256:b202f591204023b3ce62ff9a47baa555dc00bb092219abf5caf0e3718ac20e7c", size = 5180672 },
-    { url = "https://files.pythonhosted.org/packages/c1/b9/e899c0a80dfa674dbc992f36f2b1453cd1ee879143cdb455bc04fce999da/debugpy-1.8.12-cp310-cp310-win_amd64.whl", hash = "sha256:9649eced17a98ce816756ce50433b2dd85dfa7bc92ceb60579d68c053f98dff9", size = 5212702 },
-    { url = "https://files.pythonhosted.org/packages/af/9f/5b8af282253615296264d4ef62d14a8686f0dcdebb31a669374e22fff0a4/debugpy-1.8.12-cp311-cp311-macosx_14_0_universal2.whl", hash = "sha256:36f4829839ef0afdfdd208bb54f4c3d0eea86106d719811681a8627ae2e53dd5", size = 2174643 },
-    { url = "https://files.pythonhosted.org/packages/ef/31/f9274dcd3b0f9f7d1e60373c3fa4696a585c55acb30729d313bb9d3bcbd1/debugpy-1.8.12-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a28ed481d530e3138553be60991d2d61103ce6da254e51547b79549675f539b7", size = 3133457 },
-    { url = "https://files.pythonhosted.org/packages/ab/ca/6ee59e9892e424477e0c76e3798046f1fd1288040b927319c7a7b0baa484/debugpy-1.8.12-cp311-cp311-win32.whl", hash = "sha256:4ad9a94d8f5c9b954e0e3b137cc64ef3f579d0df3c3698fe9c3734ee397e4abb", size = 5106220 },
-    { url = "https://files.pythonhosted.org/packages/d5/1a/8ab508ab05ede8a4eae3b139bbc06ea3ca6234f9e8c02713a044f253be5e/debugpy-1.8.12-cp311-cp311-win_amd64.whl", hash = "sha256:4703575b78dd697b294f8c65588dc86874ed787b7348c65da70cfc885efdf1e1", size = 5130481 },
-    { url = "https://files.pythonhosted.org/packages/ba/e6/0f876ecfe5831ebe4762b19214364753c8bc2b357d28c5d739a1e88325c7/debugpy-1.8.12-cp312-cp312-macosx_14_0_universal2.whl", hash = "sha256:7e94b643b19e8feb5215fa508aee531387494bf668b2eca27fa769ea11d9f498", size = 2500846 },
-    { url = "https://files.pythonhosted.org/packages/19/64/33f41653a701f3cd2cbff8b41ebaad59885b3428b5afd0d93d16012ecf17/debugpy-1.8.12-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:086b32e233e89a2740c1615c2f775c34ae951508b28b308681dbbb87bba97d06", size = 4222181 },
-    { url = "https://files.pythonhosted.org/packages/32/a6/02646cfe50bfacc9b71321c47dc19a46e35f4e0aceea227b6d205e900e34/debugpy-1.8.12-cp312-cp312-win32.whl", hash = "sha256:2ae5df899732a6051b49ea2632a9ea67f929604fd2b036613a9f12bc3163b92d", size = 5227017 },
-    { url = "https://files.pythonhosted.org/packages/da/a6/10056431b5c47103474312cf4a2ec1001f73e0b63b1216706d5fef2531eb/debugpy-1.8.12-cp312-cp312-win_amd64.whl", hash = "sha256:39dfbb6fa09f12fae32639e3286112fc35ae976114f1f3d37375f3130a820969", size = 5267555 },
-    { url = "https://files.pythonhosted.org/packages/cf/4d/7c3896619a8791effd5d8c31f0834471fc8f8fb3047ec4f5fc69dd1393dd/debugpy-1.8.12-cp313-cp313-macosx_14_0_universal2.whl", hash = "sha256:696d8ae4dff4cbd06bf6b10d671e088b66669f110c7c4e18a44c43cf75ce966f", size = 2485246 },
-    { url = "https://files.pythonhosted.org/packages/99/46/bc6dcfd7eb8cc969a5716d858e32485eb40c72c6a8dc88d1e3a4d5e95813/debugpy-1.8.12-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:898fba72b81a654e74412a67c7e0a81e89723cfe2a3ea6fcd3feaa3395138ca9", size = 4218616 },
-    { url = "https://files.pythonhosted.org/packages/03/dd/d7fcdf0381a9b8094da1f6a1c9f19fed493a4f8576a2682349b3a8b20ec7/debugpy-1.8.12-cp313-cp313-win32.whl", hash = "sha256:22a11c493c70413a01ed03f01c3c3a2fc4478fc6ee186e340487b2edcd6f4180", size = 5226540 },
-    { url = "https://files.pythonhosted.org/packages/25/bd/ecb98f5b5fc7ea0bfbb3c355bc1dd57c198a28780beadd1e19915bf7b4d9/debugpy-1.8.12-cp313-cp313-win_amd64.whl", hash = "sha256:fdb3c6d342825ea10b90e43d7f20f01535a72b3a1997850c0c3cefa5c27a4a2c", size = 5267134 },
-    { url = "https://files.pythonhosted.org/packages/38/c4/5120ad36405c3008f451f94b8f92ef1805b1e516f6ff870f331ccb3c4cc0/debugpy-1.8.12-py2.py3-none-any.whl", hash = "sha256:274b6a2040349b5c9864e475284bce5bb062e63dce368a394b8cc865ae3b00c6", size = 5229490 },
+    { url = "https://files.pythonhosted.org/packages/3f/32/901c7204cceb3262fdf38f4c25c9a46372c11661e8490e9ea702bc4ff448/debugpy-1.8.13-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:06859f68e817966723ffe046b896b1bd75c665996a77313370336ee9e1de3e90", size = 2076250 },
+    { url = "https://files.pythonhosted.org/packages/95/10/77fe746851c8d84838a807da60c7bd0ac8627a6107d6917dd3293bf8628c/debugpy-1.8.13-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cb56c2db69fb8df3168bc857d7b7d2494fed295dfdbde9a45f27b4b152f37520", size = 3560883 },
+    { url = "https://files.pythonhosted.org/packages/a1/ef/28f8db2070e453dda0e49b356e339d0b4e1d38058d4c4ea9e88cdc8ee8e7/debugpy-1.8.13-cp310-cp310-win32.whl", hash = "sha256:46abe0b821cad751fc1fb9f860fb2e68d75e2c5d360986d0136cd1db8cad4428", size = 5180149 },
+    { url = "https://files.pythonhosted.org/packages/89/16/1d53a80caf5862627d3eaffb217d4079d7e4a1df6729a2d5153733661efd/debugpy-1.8.13-cp310-cp310-win_amd64.whl", hash = "sha256:dc7b77f5d32674686a5f06955e4b18c0e41fb5a605f5b33cf225790f114cfeec", size = 5212540 },
+    { url = "https://files.pythonhosted.org/packages/31/90/dd2fcad8364f0964f476537481985198ce6e879760281ad1cec289f1aa71/debugpy-1.8.13-cp311-cp311-macosx_14_0_universal2.whl", hash = "sha256:eee02b2ed52a563126c97bf04194af48f2fe1f68bb522a312b05935798e922ff", size = 2174802 },
+    { url = "https://files.pythonhosted.org/packages/5c/c9/06ff65f15eb30dbdafd45d1575770b842ce3869ad5580a77f4e5590f1be7/debugpy-1.8.13-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4caca674206e97c85c034c1efab4483f33971d4e02e73081265ecb612af65377", size = 3133620 },
+    { url = "https://files.pythonhosted.org/packages/3b/49/798a4092bde16a4650f17ac5f2301d4d37e1972d65462fb25c80a83b4790/debugpy-1.8.13-cp311-cp311-win32.whl", hash = "sha256:7d9a05efc6973b5aaf076d779cf3a6bbb1199e059a17738a2aa9d27a53bcc888", size = 5104764 },
+    { url = "https://files.pythonhosted.org/packages/cd/d5/3684d7561c8ba2797305cf8259619acccb8d6ebe2117bb33a6897c235eee/debugpy-1.8.13-cp311-cp311-win_amd64.whl", hash = "sha256:62f9b4a861c256f37e163ada8cf5a81f4c8d5148fc17ee31fb46813bd658cdcc", size = 5129670 },
+    { url = "https://files.pythonhosted.org/packages/79/ad/dff929b6b5403feaab0af0e5bb460fd723f9c62538b718a9af819b8fff20/debugpy-1.8.13-cp312-cp312-macosx_14_0_universal2.whl", hash = "sha256:2b8de94c5c78aa0d0ed79023eb27c7c56a64c68217d881bee2ffbcb13951d0c1", size = 2501004 },
+    { url = "https://files.pythonhosted.org/packages/d6/4f/b7d42e6679f0bb525888c278b0c0d2b6dff26ed42795230bb46eaae4f9b3/debugpy-1.8.13-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:887d54276cefbe7290a754424b077e41efa405a3e07122d8897de54709dbe522", size = 4222346 },
+    { url = "https://files.pythonhosted.org/packages/ec/18/d9b3e88e85d41f68f77235112adc31012a784e45a3fcdbb039777d570a0f/debugpy-1.8.13-cp312-cp312-win32.whl", hash = "sha256:3872ce5453b17837ef47fb9f3edc25085ff998ce63543f45ba7af41e7f7d370f", size = 5226639 },
+    { url = "https://files.pythonhosted.org/packages/c9/f7/0df18a4f530ed3cc06f0060f548efe9e3316102101e311739d906f5650be/debugpy-1.8.13-cp312-cp312-win_amd64.whl", hash = "sha256:63ca7670563c320503fea26ac688988d9d6b9c6a12abc8a8cf2e7dd8e5f6b6ea", size = 5268735 },
+    { url = "https://files.pythonhosted.org/packages/b1/db/ae7cd645c1826aae557cebccbc448f0cc9a818d364efb88f8d80e7a03f41/debugpy-1.8.13-cp313-cp313-macosx_14_0_universal2.whl", hash = "sha256:31abc9618be4edad0b3e3a85277bc9ab51a2d9f708ead0d99ffb5bb750e18503", size = 2485416 },
+    { url = "https://files.pythonhosted.org/packages/ec/ed/db4b10ff3b5bb30fe41d9e86444a08bb6448e4d8265e7768450b8408dd36/debugpy-1.8.13-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a0bd87557f97bced5513a74088af0b84982b6ccb2e254b9312e29e8a5c4270eb", size = 4218784 },
+    { url = "https://files.pythonhosted.org/packages/82/82/ed81852a8d94086f51664d032d83c7f87cd2b087c6ea70dabec7c1ba813d/debugpy-1.8.13-cp313-cp313-win32.whl", hash = "sha256:5268ae7fdca75f526d04465931cb0bd24577477ff50e8bb03dab90983f4ebd02", size = 5226270 },
+    { url = "https://files.pythonhosted.org/packages/15/63/aa92fb341a78ec40f1c414ec7a7885c2ee17032eee00d12cee0cdc502af4/debugpy-1.8.13-cp313-cp313-win_amd64.whl", hash = "sha256:79ce4ed40966c4c1631d0131606b055a5a2f8e430e3f7bf8fd3744b09943e8e8", size = 5268621 },
+    { url = "https://files.pythonhosted.org/packages/37/4f/0b65410a08b6452bfd3f7ed6f3610f1a31fb127f46836e82d31797065dcb/debugpy-1.8.13-py2.py3-none-any.whl", hash = "sha256:d4ba115cdd0e3a70942bd562adba9ec8c651fe69ddde2298a1be296fc331906f", size = 5229306 },
 ]
 
 [[package]]
@@ -1368,16 +1368,16 @@ wheels = [
 
 [[package]]
 name = "hypothesis"
-version = "6.127.6"
+version = "6.128.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "sortedcontainers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3b/73/109fbf6f9a76db10ebdbff69b3aba59e3b9ade6fd0702811a9be796702f3/hypothesis-6.127.6.tar.gz", hash = "sha256:9b5292f3f2d505bf0f3e060b1c12f3643fa9b7cd036f41f3456c5f7cc7f73164", size = 419736 }
+sdist = { url = "https://files.pythonhosted.org/packages/56/21/aacb20704bc69f519526150e97cae8adc54148a2de3c6b4b7ed8d0c92fe4/hypothesis-6.128.2.tar.gz", hash = "sha256:a6e0e61bdb9ee6d1459687e4169e76a7bce830bb88f7e9948c2c1c4c39dd74b3", size = 422443 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/3f/c9d2506f026137bba258c736c9383d1ce198b2e57894411393a111943601/hypothesis-6.127.6-py3-none-any.whl", hash = "sha256:4967702ee2f8c8d7d0d50f14940c3496bd32ac8b8a2b362ace34c722e842d00b", size = 483286 },
+    { url = "https://files.pythonhosted.org/packages/ce/36/58ea6d196dc45a2a3e3bb2dc90368be85b39a84da587ca9bc06ea55bec18/hypothesis-6.128.2-py3-none-any.whl", hash = "sha256:a4815dfb8bccfe26ccffa26e4c50d2f07adb45b1b4c66f4dd23ffbfb8cbf8ed3", size = 486232 },
 ]
 
 [[package]]
@@ -1406,8 +1406,8 @@ dependencies = [
     { name = "appnope", marker = "platform_system == 'Darwin'" },
     { name = "comm" },
     { name = "debugpy" },
-    { name = "ipython", version = "8.33.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "ipython", version = "9.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "ipython", version = "8.34.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "ipython", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "jupyter-client" },
     { name = "jupyter-core" },
     { name = "matplotlib-inline" },
@@ -1425,7 +1425,7 @@ wheels = [
 
 [[package]]
 name = "ipython"
-version = "8.33.0"
+version = "8.34.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version < '3.11'",
@@ -1443,14 +1443,14 @@ dependencies = [
     { name = "traitlets", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/99/5d/27844489a849a9ceb94ea59c1adac9323fb77175a3076742ed76dcc87f07/ipython-8.33.0.tar.gz", hash = "sha256:4c3e36a6dfa9e8e3702bd46f3df668624c975a22ff340e96ea7277afbd76217d", size = 5508284 }
+sdist = { url = "https://files.pythonhosted.org/packages/13/18/1a60aa62e9d272fcd7e658a89e1c148da10e1a5d38edcbcd834b52ca7492/ipython-8.34.0.tar.gz", hash = "sha256:c31d658e754673ecc6514583e7dda8069e47136eb62458816b7d1e6625948b5a", size = 5508477 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/e7/7b144d0c3a16f56b213b2d9f9bee22e50f6e54265a551db9f43f09e2c084/ipython-8.33.0-py3-none-any.whl", hash = "sha256:aa5b301dfe1eaf0167ff3238a6825f810a029c9dad9d3f1597f30bd5ff65cc44", size = 826720 },
+    { url = "https://files.pythonhosted.org/packages/04/78/45615356bb973904856808183ae2a5fba1f360e9d682314d79766f4b88f2/ipython-8.34.0-py3-none-any.whl", hash = "sha256:0419883fa46e0baa182c5d50ebb8d6b49df1889fdb70750ad6d8cfe678eda6e3", size = 826731 },
 ]
 
 [[package]]
 name = "ipython"
-version = "9.0.1"
+version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.11'",
@@ -1468,9 +1468,9 @@ dependencies = [
     { name = "traitlets", marker = "python_full_version >= '3.11'" },
     { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/33/1901c9a842b301d8674f367dee597e654e402548a903faf7280aae8fc2d4/ipython-9.0.1.tar.gz", hash = "sha256:377ea91c8226b48dc9021ac9846a64761abc7ddf74c5efe38e6eb06f6e052f3a", size = 4365847 }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/ce/012a0f40ca58a966f87a6e894d6828e2817657cbdf522b02a5d3a87d92ce/ipython-9.0.2.tar.gz", hash = "sha256:ec7b479e3e5656bf4f58c652c120494df1820f4f28f522fb7ca09e213c2aab52", size = 4366102 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/28/39/fda74f8215ef94a812dd780073c61a826a88a01e51f627a3454f7ae6951d/ipython-9.0.1-py3-none-any.whl", hash = "sha256:3e878273824b52e0a2280ed84f8193aba8c4ba9a6f45a438348a3d5ef1a34bd0", size = 600186 },
+    { url = "https://files.pythonhosted.org/packages/20/3a/917cb9e72f4e1a4ea13c862533205ae1319bd664119189ee5cc9e4e95ebf/ipython-9.0.2-py3-none-any.whl", hash = "sha256:143ef3ea6fb1e1bffb4c74b114051de653ffb7737a3f7ab1670e657ca6ae8c44", size = 600524 },
 ]
 
 [[package]]
@@ -1491,8 +1491,8 @@ version = "8.1.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "comm" },
-    { name = "ipython", version = "8.33.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "ipython", version = "9.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "ipython", version = "8.34.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "ipython", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "jupyterlab-widgets" },
     { name = "traitlets" },
     { name = "widgetsnbextension" },
@@ -1528,14 +1528,14 @@ wheels = [
 
 [[package]]
 name = "jinja2"
-version = "3.1.5"
+version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/af/92/b3130cbbf5591acf9ade8708c365f3238046ac7cb8ccba6e81abccb0ccff/jinja2-3.1.5.tar.gz", hash = "sha256:8fefff8dc3034e27bb80d67c671eb8a9bc424c0ef4c0826edbff304cceff43bb", size = 244674 }
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/0f/2ba5fbcd631e3e88689309dbe978c5769e883e4b84ebfe7da30b43275c5a/jinja2-3.1.5-py3-none-any.whl", hash = "sha256:aba0f4dc9ed8013c424088f68a5c226f7d6097ed89b246d7749c2ec4175c6adb", size = 134596 },
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899 },
 ]
 
 [[package]]
@@ -1634,8 +1634,8 @@ version = "6.6.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ipykernel" },
-    { name = "ipython", version = "8.33.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "ipython", version = "9.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "ipython", version = "8.34.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "ipython", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "jupyter-client" },
     { name = "jupyter-core" },
     { name = "prompt-toolkit" },
@@ -2907,11 +2907,11 @@ wheels = [
 
 [[package]]
 name = "python-json-logger"
-version = "3.2.1"
+version = "3.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e3/c4/358cd13daa1d912ef795010897a483ab2f0b41c9ea1b35235a8b2f7d15a7/python_json_logger-3.2.1.tar.gz", hash = "sha256:8eb0554ea17cb75b05d2848bc14fb02fbdbd9d6972120781b974380bfa162008", size = 16287 }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/de/d3144a0bceede957f961e975f3752760fbe390d57fbe194baf709d8f1f7b/python_json_logger-3.3.0.tar.gz", hash = "sha256:12b7e74b17775e7d565129296105bbe3910842d9d0eb083fc83a6a617aa8df84", size = 16642 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4b/72/2f30cf26664fcfa0bd8ec5ee62ec90c03bd485e4a294d92aabc76c5203a5/python_json_logger-3.2.1-py3-none-any.whl", hash = "sha256:cdc17047eb5374bd311e748b42f99d71223f3b0e186f4206cc5d52aefe85b090", size = 14924 },
+    { url = "https://files.pythonhosted.org/packages/08/20/0f2523b9e50a8052bc6a8b732dfc8568abbdc42010aef03a2d750bdab3b2/python_json_logger-3.3.0-py3-none-any.whl", hash = "sha256:dd980fae8cffb24c13caf6e158d3d61c0d6d22342f932cb6e9deedab3d35eec7", size = 15163 },
 ]
 
 [[package]]
@@ -3309,11 +3309,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "75.8.2"
+version = "76.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d1/53/43d99d7687e8cdef5ab5f9ec5eaf2c0423c2b35133a2b7e7bc276fc32b21/setuptools-75.8.2.tar.gz", hash = "sha256:4880473a969e5f23f2a2be3646b2dfd84af9028716d398e46192f84bc36900d2", size = 1344083 }
+sdist = { url = "https://files.pythonhosted.org/packages/32/d2/7b171caf085ba0d40d8391f54e1c75a1cda9255f542becf84575cfd8a732/setuptools-76.0.0.tar.gz", hash = "sha256:43b4ee60e10b0d0ee98ad11918e114c70701bc6051662a9a675a0496c1a158f4", size = 1349387 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/38/7d7362e031bd6dc121e5081d8cb6aa6f6fedf2b67bf889962134c6da4705/setuptools-75.8.2-py3-none-any.whl", hash = "sha256:558e47c15f1811c1fa7adbd0096669bf76c1d3f433f58324df69f3f5ecac4e8f", size = 1229385 },
+    { url = "https://files.pythonhosted.org/packages/37/66/d2d7e6ad554f3a7c7297c3f8ef6e22643ad3d35ef5c63bf488bc89f32f31/setuptools-76.0.0-py3-none-any.whl", hash = "sha256:199466a166ff664970d0ee145839f5582cb9bca7a0a3a2e795b6a9cb2308e9c6", size = 1236106 },
 ]
 
 [[package]]
@@ -3572,14 +3572,14 @@ wheels = [
 
 [[package]]
 name = "types-requests"
-version = "2.32.0.20250301"
+version = "2.32.0.20250306"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/87/88/365d6b46f1088ddeccbc89c26190c3180088ef6e7c8d162fc619496aab96/types_requests-2.32.0.20250301.tar.gz", hash = "sha256:3d909dc4eaab159c0d964ebe8bfa326a7afb4578d8706408d417e17d61b0c500", size = 22977 }
+sdist = { url = "https://files.pythonhosted.org/packages/09/1a/beaeff79ef9efd186566ba5f0d95b44ae21f6d31e9413bcfbef3489b6ae3/types_requests-2.32.0.20250306.tar.gz", hash = "sha256:0962352694ec5b2f95fda877ee60a159abdf84a0fc6fdace599f20acb41a03d1", size = 23012 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/c2/e44564e8995dbc1738c2acacb8009d59c8cb19327da95a1b5c5d9cb68364/types_requests-2.32.0.20250301-py3-none-any.whl", hash = "sha256:0003e0124e2cbefefb88222ff822b48616af40c74df83350f599a650c8de483b", size = 20671 },
+    { url = "https://files.pythonhosted.org/packages/99/26/645d89f56004aa0ba3b96fec27793e3c7e62b40982ee069e52568922b6db/types_requests-2.32.0.20250306-py3-none-any.whl", hash = "sha256:25f2cbb5c8710b2022f8bbee7b2b66f319ef14aeea2f35d80f18c9dbf3b60a0b", size = 20673 },
 ]
 
 [[package]]


### PR DESCRIPTION
### PR Summary

Closes #959  
Closes #968  
Closes #975 
Closes #1006

**Title:** Optimize Rust Runner for Proof Mode and Integrate Stwo Proof Generation

**Issues Addressed:**
1. Update Rust runner to minimize performance impact of pythonic hints in proof mode.
2. Add script to prove Ethereum blocks using Cairo runner with ZKPI inputs.
3. Integrate Stwo proof generation into the `run-block` pipeline, bypassing intermediate trace files.

**Changes:**
- **Rust Runner Optimization:**
  - Removed `pythonic-hints` feature flag; hints always supported.
  - Added `enable_traces` flag to control logger hint execution (skipped by default for performance).
  - Skipped `logger.trace` hints unless `enable_traces` is true.
  - Mapped hint IDs to functions directly on top of mapping of Python code to hint functions.
  - Updated `PyCairoRunner` to use `enable_traces` instead of `enable_pythonic_hints`.

- **Block Proving Script:**
  - Added `prove_block.py`: loads ZKPI JSON, converts to EELS, runs proof via `CairoRunner`.
  - New `main.cairo` entrypoint: loads inputs, runs `state_transition`, writes outputs.
  - Enhanced `run_proof_mode` Rust function:
    - Executes program and saves trace/memory/AIR files by default.
    - Added `--stwo-proof` option to generate Stwo-compatible proofs instead of trace files.
    - Added `--proof-path` to specify Stwo proof output location (defaults to `output/proof.json`).
    - Added `--verify` flag to optionally verify the Stwo proof after generation.
  - Inputs: new block, chain objects (public).

- **Stwo Proof Integration:**
  - Added `stwo-cairo-adapter` and `stwo_cairo_prover` as dependencies.
  - Integrated `adapt_finished_runner` to convert `CairoRunner` output to Stwo `ProverInput`.
  - Used `prove_cairo` to generate Stwo proofs with `Blake2sMerkleChannel`.
  - Skips writing `trace.bin` and `memory.bin` when `--stwo-proof` is enabled, improving performance.
  - Added tracing support with `tracing` and `tracing-subscriber` for debugging Stwo proof generation.

- **File Updates:**
  - Updated `Cargo.toml`:
    - Added `stwo-cairo-adapter` and `stwo_cairo_prover` with specific git revisions.
    - Updated `cairo-vm` patch to a newer revision.
    - Added `chrono`, `serde_json`, `tracing`, and `tracing-subscriber` dependencies.
  - Updated `prove_block.py`:
    - Added `--stwo-proof`, `--proof-path`, and `--verify` CLI arguments.
    - Extended `run_proof` to handle Stwo proof generation and verification.
  - Updated `.gitignore` to include prover output files (e.g., `*.trace.bin`, `*.memory.bin`).
  - Updated `fork.cairo`: removed logger hints for performance.
  - Updated `rust-toolchain` to `nightly-2025-01-02` for compatibility.
  - Updated `dictionary.txt` to include `stwo`.

**Notes:**
- When `--stwo-proof` is enabled, intermediate trace files are skipped, and the proof is saved directly to the specified `--proof-path`.
- The pipeline remains backward-compatible: without `--stwo-proof`, it generates traditional proof artifacts (trace, memory, AIR files).
- Execution resources are logged for both traditional and Stwo proof modes.