### PR TITLE
feat: base structs for pairings

### DIFF
--- a/python/cairo-ec/src/cairo_ec/curve/g1_point.cairo
+++ b/python/cairo-ec/src/cairo_ec/curve/g1_point.cairo
@@ -1,6 +1,8 @@
 from starkware.cairo.common.cairo_builtins import UInt384
 from cairo_core.numeric import bool
 
+// A G1Point is a point on an elliptic curve over a field Fp.
+// Affine coordinates representation.
 struct G1Point {
     x: UInt384,
     y: UInt384,

--- a/python/cairo-ec/src/cairo_ec/curve/g1g2pair.cairo
+++ b/python/cairo-ec/src/cairo_ec/curve/g1g2pair.cairo
@@ -1,0 +1,9 @@
+from cairo_ec.curve.g1_point import G1Point
+from cairo_ec.curve.g2_point import G2Point
+
+// A pair of two points, a G1Point and a G2Point.
+// Represent the pair of points of one pairing.
+struct G1G2Pair {
+    p: G1Point,
+    q: G2Point,
+}

--- a/python/cairo-ec/src/cairo_ec/curve/g2_point.cairo
+++ b/python/cairo-ec/src/cairo_ec/curve/g2_point.cairo
@@ -1,0 +1,12 @@
+from starkware.cairo.common.cairo_builtins import UInt384
+
+// A G2Point is a point on an elliptic curve over the quadratic extension field Fp2,
+// when Fp is the base field of that elliptic curve.
+// A G2Point P = (x, y) where x = a0 * i + b0 and y = a1 * i + b1.
+// Affine coordinates representation.
+struct G2Point {
+    a0: UInt384,
+    b0: UInt384,
+    a1: UInt384,
+    b1: UInt384,
+}


### PR DESCRIPTION
Closes #973 

Add the basic structs `G2Point` and `G1G2Pair` to be used for pairings.
They will be used whether we compute the pairings, or implement the multi pairing checks