### PR TITLE
feat: add BNP init

### DIFF
--- a/cairo/ethereum/crypto/alt_bn128.cairo
+++ b/cairo/ethereum/crypto/alt_bn128.cairo
@@ -16,6 +16,8 @@ from cairo_ec.circuits.ec_ops_compiled import assert_on_curve
 from ethereum.utils.numeric import divmod, U384_ZERO
 from ethereum_types.numeric import U384
 
+// Field over which the alt_bn128 curve is defined.
+// BNF elements are 1-dimensional.
 struct BNFStruct {
     c0: U384,
 }
@@ -24,6 +26,8 @@ struct BNF {
     value: BNFStruct*,
 }
 
+// Quadratic extension field of BNF.
+// BNF elements are 2-dimensional.
 struct BNF2Struct {
     c0: U384,
     c1: U384,
@@ -947,6 +951,8 @@ func create_bnf12_from_dict{range_check_ptr, mul_dict: DictAccess*}() -> BNF12 {
     return bnf12_result;
 }
 
+// alt_bn128 curve defined over BNF (Fp)
+// BNP represents a point on the curve.
 struct BNPStruct {
     x: BNF,
     y: BNF,

--- a/cairo/ethereum/crypto/alt_bn128.cairo
+++ b/cairo/ethereum/crypto/alt_bn128.cairo
@@ -956,7 +956,7 @@ struct BNP {
     value: BNPStruct*,
 }
 
-// Returns a BNP (alias of G1Point, which is verified to be on the alt_bn128 curve).
+// Returns a BNP, a point that is verified to be on the alt_bn128 curve over Fp.
 func bnp_init{range_check96_ptr: felt*, add_mod_ptr: ModBuiltin*, mul_mod_ptr: ModBuiltin*}(
     x: BNF, y: BNF
 ) -> BNP {

--- a/cairo/ethereum/crypto/alt_bn128.cairo
+++ b/cairo/ethereum/crypto/alt_bn128.cairo
@@ -16,8 +16,13 @@ from cairo_ec.circuits.ec_ops_compiled import assert_on_curve
 from ethereum.utils.numeric import divmod, U384_ZERO
 from ethereum_types.numeric import U384
 
-using BNPStruct = G1PointStruct;
-using BNP = G1Point;
+struct BNFStruct {
+    c0: U384,
+}
+
+struct BNF {
+    value: BNFStruct*,
+}
 
 struct BNF2Struct {
     c0: U384,
@@ -942,15 +947,25 @@ func create_bnf12_from_dict{range_check_ptr, mul_dict: DictAccess*}() -> BNF12 {
     return bnf12_result;
 }
 
+struct BNPStruct {
+    x: BNF,
+    y: BNF,
+}
+
+struct BNP {
+    value: BNPStruct*,
+}
+
 // Returns a BNP (alias of G1Point, which is verified to be on the alt_bn128 curve).
 func bnp_init{range_check96_ptr: felt*, add_mod_ptr: ModBuiltin*, mul_mod_ptr: ModBuiltin*}(
-    x: U384, y: U384
+    x: BNF, y: BNF
 ) -> BNP {
-    tempvar a = new UInt384(alt_bn128.A0, alt_bn128.A1, alt_bn128.A2, alt_bn128.A3);
-    tempvar b = new UInt384(alt_bn128.B0, alt_bn128.B1, alt_bn128.B2, alt_bn128.B3);
+    tempvar a = U384(new UInt384(alt_bn128.A0, alt_bn128.A1, alt_bn128.A2, alt_bn128.A3));
+    tempvar b = U384(new UInt384(alt_bn128.B0, alt_bn128.B1, alt_bn128.B2, alt_bn128.B3));
     tempvar modulus = U384(new UInt384(alt_bn128.P0, alt_bn128.P1, alt_bn128.P2, alt_bn128.P3));
 
-    assert_on_curve(x.value, y.value, a, b, modulus.value);
+    tempvar point = G1Point(new G1PointStruct(x.value.c0, y.value.c0));
+    assert_on_curve(point.value, a, b, modulus);
 
     tempvar res = BNP(new BNPStruct(x, y));
     return res;

--- a/cairo/tests/ethereum/crypto/test_alt_bn128.py
+++ b/cairo/tests/ethereum/crypto/test_alt_bn128.py
@@ -1,5 +1,5 @@
 import pytest
-from ethereum.crypto.alt_bn128 import BNF2, BNF12, BNP, BNP12
+from ethereum.crypto.alt_bn128 import BNF, BNF2, BNF12, BNP, BNP12
 from hypothesis import given
 
 from cairo_ec.curve import AltBn128
@@ -71,12 +71,12 @@ class TestAltBn128:
     def test_bnf2_mul(self, cairo_run, a: BNF2, b: BNF2):
         assert cairo_run("bnf2_mul", a, b) == a * b
 
-    def test_bnp_init_passes(self, cairo_run):
+    def test_bnp_init(self, cairo_run):
         p = AltBn128.random_point()
-        cairo_bnp = cairo_run("bnp_init", U384(p.x), U384(p.y))
-        assert BNP(cairo_bnp.x, cairo_bnp.y) == BNP(p.x, p.y)
+        assert cairo_run("bnp_init", BNF(p.x), BNF(p.y)) == BNP(p.x, p.y)
 
     @given(x=..., y=...)
-    def test_bnp_init_fails(self, cairo_run, x: U384, y: U384):
+    def test_bnp_init_fails(self, cairo_run, x: BNF, y: BNF):
+        _a0 = 0
         with pytest.raises(Exception):
             cairo_run("bnp_init", x, y)

--- a/cairo/tests/ethereum/crypto/test_alt_bn128.py
+++ b/cairo/tests/ethereum/crypto/test_alt_bn128.py
@@ -1,3 +1,4 @@
+import pytest
 from ethereum.crypto.alt_bn128 import BNF2, BNF12, BNP, BNP12
 from hypothesis import given
 
@@ -6,11 +7,6 @@ from tests.utils.args_gen import U384
 
 
 class TestAltBn128:
-    def test_bnp_init(self, cairo_run):
-        p = AltBn128.random_point()
-        cairo_bnp = cairo_run("bnp_init", U384(p.x), U384(p.y))
-        assert BNP(cairo_bnp.x, cairo_bnp.y) == BNP(p.x, p.y)
-
     def test_FROBENIUS_COEFFICIENTS(self, cairo_run):
         cairo_coeffs = cairo_run("FROBENIUS_COEFFICIENTS")
         assert len(cairo_coeffs) == 12
@@ -74,3 +70,13 @@ class TestAltBn128:
     @given(a=..., b=...)
     def test_bnf2_mul(self, cairo_run, a: BNF2, b: BNF2):
         assert cairo_run("bnf2_mul", a, b) == a * b
+
+    def test_bnp_init_passes(self, cairo_run):
+        p = AltBn128.random_point()
+        cairo_bnp = cairo_run("bnp_init", U384(p.x), U384(p.y))
+        assert BNP(cairo_bnp.x, cairo_bnp.y) == BNP(p.x, p.y)
+
+    @given(x=..., y=...)
+    def test_bnp_init_fails(self, cairo_run, x: U384, y: U384):
+        with pytest.raises(Exception):
+            cairo_run("bnp_init", x, y)

--- a/cairo/tests/ethereum/crypto/test_alt_bn128.py
+++ b/cairo/tests/ethereum/crypto/test_alt_bn128.py
@@ -77,6 +77,5 @@ class TestAltBn128:
 
     @given(x=..., y=...)
     def test_bnp_init_fails(self, cairo_run, x: BNF, y: BNF):
-        _a0 = 0
         with pytest.raises(Exception):
             cairo_run("bnp_init", x, y)

--- a/cairo/tests/ethereum/crypto/test_alt_bn128.py
+++ b/cairo/tests/ethereum/crypto/test_alt_bn128.py
@@ -1,10 +1,16 @@
-from ethereum.crypto.alt_bn128 import BNF2, BNF12, BNP12
+from ethereum.crypto.alt_bn128 import BNF2, BNF12, BNP, BNP12
 from hypothesis import given
 
+from cairo_ec.curve import AltBn128
 from tests.utils.args_gen import U384
 
 
 class TestAltBn128:
+    def test_bnp_init(self, cairo_run):
+        p = AltBn128.random_point()
+        cairo_bnp = cairo_run("bnp_init", U384(p.x), U384(p.y))
+        assert BNP(cairo_bnp.x, cairo_bnp.y) == BNP(p.x, p.y)
+
     def test_FROBENIUS_COEFFICIENTS(self, cairo_run):
         cairo_coeffs = cairo_run("FROBENIUS_COEFFICIENTS")
         assert len(cairo_coeffs) == 12

--- a/cairo/tests/test_serde.py
+++ b/cairo/tests/test_serde.py
@@ -30,7 +30,7 @@ from ethereum.cancun.vm.exceptions import (
 )
 from ethereum.cancun.vm.gas import ExtendMemory, MessageCallGas
 from ethereum.cancun.vm.interpreter import MessageCallOutput
-from ethereum.crypto.alt_bn128 import BNF2, BNF12, BNP12
+from ethereum.crypto.alt_bn128 import BNF, BNF2, BNF12, BNP, BNP12
 from ethereum.crypto.hash import Hash32
 from ethereum.exceptions import (
     EthereumException,
@@ -105,7 +105,7 @@ def get_type(instance: Any) -> Type:
     if not isinstance(instance, (tuple, list)):
         return type(instance)
 
-    if isinstance(instance, (BNF2, BNF12, BNP12)):
+    if isinstance(instance, (BNF2, BNF12, BNP, BNF, BNP12)):
         return instance.__class__
 
     # Empty sequence
@@ -293,6 +293,8 @@ class TestSerde:
             Tuple[BNF12, ...],
             BNP12,
             BNF2,
+            BNF,
+            BNP,
         ],
     ):
         assume(no_empty_sequence(b))

--- a/cairo/tests/utils/serde.py
+++ b/cairo/tests/utils/serde.py
@@ -427,8 +427,7 @@ class Serde:
 
         if python_cls == BNF:
             # The BNF constructor accepts int only, not tuples or U384.
-            c0 = value["c0"]
-            return BNF(int(c0))
+            return BNF(int(value["c0"]))
 
         if python_cls in (BNF2, BNF12):
             # The BNF<N> constructor doesn't accept named tuples

--- a/cairo/tests/utils/serde.py
+++ b/cairo/tests/utils/serde.py
@@ -41,7 +41,7 @@ from ethereum.cancun.fork_types import Account, Address
 from ethereum.cancun.state import State, TransientStorage
 from ethereum.cancun.trie import Trie
 from ethereum.cancun.vm.exceptions import InvalidOpcode
-from ethereum.crypto.alt_bn128 import BNF2, BNF12
+from ethereum.crypto.alt_bn128 import BNF, BNF2, BNF12
 from ethereum.crypto.hash import Hash32
 from ethereum_types.bytes import (
     Bytes,
@@ -424,6 +424,11 @@ class Serde:
             return U384(combined_value)
         if python_cls in (Bytes0, Bytes1, Bytes4, Bytes8, Bytes20):
             return python_cls(value.to_bytes(python_cls.LENGTH, "little"))
+
+        if python_cls == BNF:
+            # The BNF constructor accepts int only, not tuples or U384.
+            c0 = value["c0"]
+            return BNF(int(c0))
 
         if python_cls in (BNF2, BNF12):
             # The BNF<N> constructor doesn't accept named tuples

--- a/cairo/tests/utils/strategies.py
+++ b/cairo/tests/utils/strategies.py
@@ -387,7 +387,7 @@ evm = st.builds(
     env=st.from_type(Environment),
     valid_jump_destinations=st.sets(st.from_type(Uint)),
     logs=st.from_type(Tuple[Log, ...]),
-    refund_counter=st.integers(min_value=0),
+    refund_counter=felt,
     running=st.booleans(),
     message=message,
     output=small_bytes,

--- a/cairo/tests/utils/strategies.py
+++ b/cairo/tests/utils/strategies.py
@@ -580,10 +580,8 @@ bnp12_infinity = BNP12(
 )
 
 # Strategy for BNP points on the curve
-bnp_strategy = st.just(
-    st.integers(min_value=0, max_value=BNF.PRIME - 1).map(
-        lambda x: bnp_generate_valid_point(x)
-    ),
+bnp_strategy = st.integers(min_value=0, max_value=BNF.PRIME - 1).map(
+    lambda x: bnp_generate_valid_point(x)
 )
 
 # Strategy for BNP12 points on the curve

--- a/cairo/tests/utils/strategies.py
+++ b/cairo/tests/utils/strategies.py
@@ -580,11 +580,10 @@ bnp12_infinity = BNP12(
 )
 
 # Strategy for BNP points on the curve
-bnp_strategy = st.one_of(
+bnp_strategy = st.just(
     st.integers(min_value=0, max_value=BNF.PRIME - 1).map(
         lambda x: bnp_generate_valid_point(x)
     ),
-    st.just(BNP(0, 0)),
 )
 
 # Strategy for BNP12 points on the curve

--- a/cairo/tests/utils/strategies.py
+++ b/cairo/tests/utils/strategies.py
@@ -25,7 +25,7 @@ from ethereum.cancun.transactions import (
 )
 from ethereum.cancun.trie import BranchNode, ExtensionNode, LeafNode, Trie, copy_trie
 from ethereum.cancun.vm import Environment, Evm, Message
-from ethereum.crypto.alt_bn128 import BNF2, BNF12, BNP12
+from ethereum.crypto.alt_bn128 import BNF, BNF2, BNF12, BNP, BNP12
 from ethereum.crypto.elliptic_curve import SECP256K1N
 from ethereum.crypto.finite_field import GaloisField
 from ethereum.crypto.hash import Hash32
@@ -527,8 +527,9 @@ def bnfN_strategy(field: Type[GaloisField], N: int):
     )
 
 
-bnf12_strategy = bnfN_strategy(BNF12, 12)
+bnf_strategy = st.builds(BNF, st.integers(min_value=0, max_value=BNF.PRIME - 1))
 bnf2_strategy = bnfN_strategy(BNF2, 2)
+bnf12_strategy = bnfN_strategy(BNF12, 12)
 
 
 def compute_sqrt_mod_p(a, p):
@@ -542,6 +543,11 @@ def compute_sqrt_mod_p(a, p):
     if pow(a, (p - 1) // 2, p) != 1:
         return None
     return pow(a, (p + 1) // 4, p)
+
+
+def bnp_generate_valid_point(x):
+    g = BNP(1, 2)
+    return g.mul_by(x)
 
 
 def bnp12_generate_valid_point(x_value):
@@ -571,6 +577,14 @@ def bnp12_generate_valid_point(x_value):
 bnp12_infinity = BNP12(
     BNF12((0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)),
     BNF12((0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)),
+)
+
+# Strategy for BNP points on the curve
+bnp_strategy = st.one_of(
+    st.integers(min_value=0, max_value=BNF.PRIME - 1).map(
+        lambda x: bnp_generate_valid_point(x)
+    ),
+    st.just(BNP(0, 0)),
 )
 
 # Strategy for BNP12 points on the curve
@@ -674,4 +688,6 @@ def register_type_strategies():
     )
     st.register_type_strategy(BNF12, bnf12_strategy)
     st.register_type_strategy(BNP12, bnp12_strategy)
-    st.register_type_strategy(BNF2, bnf2_strategy)
+    st.register_type_strategy(BNF2, bnf2_strategy),
+    st.register_type_strategy(BNF, bnf_strategy),
+    st.register_type_strategy(BNP, bnp_strategy)


### PR DESCRIPTION
Closes #1045
Closes #1050 
Closes #1046

~~`BNP` is an alias of G1Point, which is specifically used in the context of the alt_bn128 curve~~
--> Goal is to have a function which takes x,y coordinates, verifies that the resulting point is on the alt_bn128 curve, and returns it