### PR TITLE
bug: test_serde fails for Extended and Simple types

### DIFF
--- a/cairo/tests/test_serde.py
+++ b/cairo/tests/test_serde.py
@@ -37,6 +37,7 @@ from ethereum.exceptions import (
     InvalidSignatureError,
     InvalidTransaction,
 )
+from ethereum_rlp.rlp import Extended, Simple
 from ethereum_types.bytes import Bytes, Bytes0, Bytes8, Bytes20, Bytes32, Bytes256
 from ethereum_types.numeric import U64, U256, Uint
 from hypothesis import HealthCheck, assume, given, settings
@@ -240,6 +241,8 @@ class TestSerde:
             Optional[InternalNode],
             Mapping[Hash32, Optional[InternalNode]],
             Node,
+            Extended,
+            Simple,
             Mapping[Bytes, Bytes],
             Tuple[Mapping[Bytes, Bytes], ...],
             Set[Uint],

--- a/cairo/tests/test_serde.py
+++ b/cairo/tests/test_serde.py
@@ -40,7 +40,7 @@ from ethereum.exceptions import (
 from ethereum_rlp.rlp import Extended, Simple
 from ethereum_types.bytes import Bytes, Bytes0, Bytes8, Bytes20, Bytes32, Bytes256
 from ethereum_types.numeric import U64, U256, Uint
-from hypothesis import HealthCheck, assume, given, settings
+from hypothesis import HealthCheck, assume, given, reproduce_failure, settings
 from starkware.cairo.common.dict import DictManager
 from starkware.cairo.lang.cairo_constants import DEFAULT_PRIME
 from starkware.cairo.lang.vm.memory_dict import MemoryDict
@@ -191,6 +191,7 @@ class TestSerde:
         max_examples=20 * len(_cairo_struct_to_python_type),
         suppress_health_check=[HealthCheck.data_too_large, HealthCheck.filter_too_much],
     )
+    @reproduce_failure("6.128.2", b"AEEoZcxUw8qP")
     def test_type(
         self,
         to_cairo_type,


### PR DESCRIPTION
Problem:
`args_gen.py` has:
```
    ("ethereum_rlp", "rlp", "Simple"): Simple,
    ("ethereum_rlp", "rlp", "Extended"): Extended,
```
Also, tests `test_rlp.py` using Simple and Extended appear to work fine
Nonetheless, when we add in `test_serde.py`: 
```
def test_type(
...
            Extended,
            Simple,
```
Then the test fails