### PR TITLE
ci: add rust caching to test jobs

### DIFF
--- a/.github/actions/setup-environment/action.yaml
+++ b/.github/actions/setup-environment/action.yaml
@@ -32,6 +32,9 @@ runs:
       uses: Swatinem/rust-cache@v2
       with:
         cache-on-failure: ${{ inputs.cache-on-failure }}
+        # Hash of source files in crates/cairo-addons to invalidate
+        # maturin build if the source files change.
+        key: ${{ hashFiles('crates/cairo-addons/**') }}
 
     - name: Setup uv
       uses: astral-sh/setup-uv@v3

--- a/.github/actions/setup-environment/action.yaml
+++ b/.github/actions/setup-environment/action.yaml
@@ -1,0 +1,61 @@
+name: Setup Environment
+description: Sets up Rust, Python, Foundry, and caching for CI jobs
+inputs:
+  python-version-file:
+    description: Path to the Python version file
+    default: .python-version
+  enable-uv-cache:
+    description: Whether to enable uv caching
+    default: true
+  cache-dependency-glob:
+    description: Glob pattern for dependency caching
+    default: "uv.lock"
+  cache-on-failure:
+    description: Whether to cache on failure
+    default: true
+outputs:
+  python-version:
+    description: The resolved Python version
+    value: ${{ steps.setup-python.outputs.python-version }}
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Install Rust toolchain
+      run: rustup toolchain install --profile minimal
+      shell: bash
+
+    - name: Rust cache
+      uses: Swatinem/rust-cache@v2
+      with:
+        cache-on-failure: ${{ inputs.cache-on-failure }}
+
+    - name: Setup uv
+      uses: astral-sh/setup-uv@v3
+      with:
+        enable-cache: ${{ inputs.enable-uv-cache }}
+        cache-dependency-glob: ${{ inputs.cache-dependency-glob }}
+
+    - name: Setup Python
+      id: setup-python
+      uses: actions/setup-python@v5
+      with:
+        python-version-file: ${{ inputs.python-version-file }}
+
+    - name: Install dependencies
+      shell: bash
+      run: uv sync -v
+
+    - name: Install Foundry
+      uses: foundry-rs/foundry-toolchain@v1
+
+    - name: Install forge deps
+      shell: bash
+      run: forge install
+
+    - name: Build solidity contracts
+      shell: bash
+      run: forge build

--- a/.github/workflows/nightly_fuzzing.yml
+++ b/.github/workflows/nightly_fuzzing.yml
@@ -48,13 +48,14 @@ jobs:
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-environment
       - name: Run full EF tests
         id: ef-tests
         continue-on-error: true
         # Running on 48 cores to avoid out of memory issues
         run: |
-          uv run pytest -n 48 -m "not slow" --durations=0 -v -s --log-cli-level=DEBUG cairo/tests/ef_tests/ --ignore-glob='cairo/tests/ef_tests/fixtures/*'
+          uv run pytest -n 48 -m "not slow" --durations=0 -v -s --log-cli-level=DEBUG cairo/tests/ef_tests/
       - name: Upload coverage
         uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/nightly_fuzzing.yml
+++ b/.github/workflows/nightly_fuzzing.yml
@@ -15,6 +15,7 @@ jobs:
       HYPOTHESIS_PROFILE: nightly
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-environment
       - name: Run unit tests
         id: unit-tests

--- a/.github/workflows/nightly_fuzzing.yml
+++ b/.github/workflows/nightly_fuzzing.yml
@@ -8,39 +8,19 @@ on:
 permissions: read-all
 
 jobs:
-  tests-unit:
+  unit-tests:
     runs-on: ubuntu-latest-64-cores
     timeout-minutes: 1440
     env:
       HYPOTHESIS_PROFILE: nightly
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Rust toolchain
-        run: rustup show
-
-      - uses: astral-sh/setup-uv@v2
-        with:
-          enable-cache: true
-          cache-dependency-glob: uv.lock
-      - uses: actions/setup-python@v5
-        with:
-          python-version-file: .python-version
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly
-      - name: Install forge deps
-        run: forge install
-      - name: Build solidity contracts
-        run: forge build
+      - uses: ./.github/actions/setup-environment
       - name: Run unit tests
         id: unit-tests
         continue-on-error: true
         run: |
-          uv run --reinstall pytest -n logical --durations=0 -v -s --log-cli-level=DEBUG --no-skip-cached-tests --ignore-glob=cairo/tests/ef_tests/
-
+          uv run pytest -n logical --durations=0 -v -s --log-cli-level=DEBUG --no-skip-cached-tests --ignore-glob=cairo/tests/ef_tests/
       - name: Upload coverage
         uses: codecov/codecov-action@v5
         with:
@@ -67,20 +47,20 @@ jobs:
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v2
-        with:
-          enable-cache: true
-          cache-dependency-glob: uv.lock
-      - uses: actions/setup-python@v5
-        with:
-          python-version-file: .python-version
+      - uses: ./.github/actions/setup-environment
       - name: Run full EF tests
         id: ef-tests
         continue-on-error: true
         # Running on 48 cores to avoid out of memory issues
         run: |
-          uv run --reinstall pytest -n 48 -m "not slow" --durations=0 -v -s --log-cli-level=DEBUG cairo/tests/ef_tests/ --ignore-glob='cairo/tests/ef_tests/fixtures/*'
+          uv run pytest -n 48 -m "not slow" --durations=0 -v -s --log-cli-level=DEBUG cairo/tests/ef_tests/ --ignore-glob='cairo/tests/ef_tests/fixtures/*'
+      - name: Upload coverage
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
+          files: ./coverage/**/*.json
+          flags: nightly-ef-tests
       - name: Notify Slack on Failure
         if: steps.ef-tests.outcome == 'failure'
         uses: slackapi/slack-github-action@v1.24.0
@@ -94,10 +74,3 @@ jobs:
       - name: Fail workflow if tests failed
         if: steps.ef-tests.outcome == 'failure'
         run: exit 1
-      - name: Upload coverage
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          verbose: true
-          files: ./coverage/**/*.json
-          flags: nightly-ef-tests

--- a/.github/workflows/nightly_fuzzing.yml
+++ b/.github/workflows/nightly_fuzzing.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest-64-cores
     timeout-minutes: 1440
     env:
+      CAIRO_PATH: cairo:tests:python/cairo-ec/src:python/cairo-addons/src:python/cairo-core/src:python/mpt/src:.venv/lib/python3.10/site-packages/src
       HYPOTHESIS_PROFILE: nightly
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
@@ -46,6 +47,7 @@ jobs:
   ef-tests-full:
     runs-on: ubuntu-latest-64-cores
     env:
+      CAIRO_PATH: cairo:tests:python/cairo-ec/src:python/cairo-addons/src:python/cairo-core/src:python/mpt/src:.venv/lib/python3.10/site-packages/src
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,7 +17,6 @@ jobs:
     uses: ./.github/workflows/python_tests.yml
     with:
       hypothesis-profile: "ci"
-      pytest-add-params: "--ignore-glob=cairo/tests/ef_tests/"
       coverage-flags: "ci-unit"
 
   python-ef-tests:
@@ -26,5 +25,5 @@ jobs:
       hypothesis-profile: "ci"
       pytest-add-params:
         "-m 'not slow' --max-tests=8000 --randomly-seed=$GITHUB_RUN_ID
-        cairo/tests/ef_tests/ --ignore-glob='cairo/tests/ef_tests/fixtures/*'"
+        cairo/tests/ef_tests/"
       coverage-flags: "ci-ef-tests"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,12 +10,21 @@ concurrency:
 permissions: read-all
 
 jobs:
-  rust_tests:
-    name: Tests
+  rust-tests:
     uses: ./.github/workflows/rust_tests.yml
 
-  python_tests:
-    name: Tests
+  python-unit-tests:
     uses: ./.github/workflows/python_tests.yml
     with:
-      max-tests: 8000
+      hypothesis-profile: "ci"
+      pytest-add-params: "--ignore-glob=cairo/tests/ef_tests/"
+      coverage-flags: "ci-unit"
+
+  python-ef-tests:
+    uses: ./.github/workflows/python_tests.yml
+    with:
+      hypothesis-profile: "ci"
+      pytest-add-params:
+        "-m 'not slow' --max-tests=8000 --randomly-seed=$GITHUB_RUN_ID
+        cairo/tests/ef_tests/ --ignore-glob='cairo/tests/ef_tests/fixtures/*'"
+      coverage-flags: "ci-ef-tests"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,6 +18,8 @@ jobs:
     with:
       hypothesis-profile: "ci"
       coverage-flags: "ci-unit"
+      # Ignore ef-test run in this job (handled in the ef-tests job)
+      pytest-add-params: "--ignore-glob=cairo/tests/ef_tests/"
 
   python-ef-tests:
     uses: ./.github/workflows/python_tests.yml

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,5 +17,4 @@ jobs:
     uses: ./.github/workflows/python_tests.yml
     with:
       hypothesis-profile: "ci"
-      pytest-add-params: "--ignore-glob=cairo/tests/ef_tests/"
       coverage-flags: "ci-unit"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,10 +1,8 @@
 ---
 name: Workflow - Push
-
 on:
   push:
     branches: [main]
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -12,48 +10,12 @@ concurrency:
 permissions: read-all
 
 jobs:
-  rust_tests:
-    name: Tests
+  rust-tests:
     uses: ./.github/workflows/rust_tests.yml
 
-  python_tests:
-    name: Python
-    runs-on: ubuntu-latest-64-cores
-    env:
-      HYPOTHESIS_PROFILE: ci
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      CAIRO_PATH: cairo:tests:python/cairo-ec/src:python/cairo-addons/src:python/cairo-core/src:python/mpt/src:.venv/lib/python3.10/site-packages/src
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Rust toolchain
-        run: rustup show
-
-      - uses: astral-sh/setup-uv@v3
-        with:
-          enable-cache: true
-          cache-dependency-glob: uv.lock
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version-file: .python-version
-
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-
-      - name: Install forge deps
-        run: forge install
-
-      - name: Build solidity contracts
-        run: forge build
-
-      - name: Run tests
-        run: |
-          uv run --reinstall pytest -n logical --durations=0 -v -s --no-skip-cached-tests --log-cli-level=DEBUG --ignore-glob=cairo/tests/ef_tests/
-
-      - name: Upload coverage
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          verbose: true
-          files: ./coverage/**/*.json
+  python-tests:
+    uses: ./.github/workflows/python_tests.yml
+    with:
+      hypothesis-profile: "ci"
+      pytest-add-params: "--ignore-glob=cairo/tests/ef_tests/"
+      coverage-flags: "ci-unit"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,3 +18,4 @@ jobs:
     with:
       hypothesis-profile: "ci"
       coverage-flags: "ci-unit"
+      pytest-add-params: "--ignore-glob=cairo/tests/ef_tests/"

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -22,7 +22,7 @@ on:
         default: "ci-unit"
 
 env:
-  CAIRO_PATH: cairo:tests:python/cairo-ec/src:python/cairo-addons/src:python/cairo-core/src:python/mpt/src
+  CAIRO_PATH: cairo:tests:python/cairo-ec/src:python/cairo-addons/src:python/cairo-core/src:python/mpt/src:.venv/lib/python3.10/site-packages/src
   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   CHAIN_RPC_URL: ${{ secrets.CHAIN_RPC_URL }}
   HYPOTHESIS_PROFILE: ${{ inputs.hypothesis-profile }}

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -1,88 +1,49 @@
-name: Python CI
+name: Python Tests
+
+permissions: read-all
 
 on:
   workflow_call:
     inputs:
-      max-tests:
+      hypothesis-profile:
         required: true
+        type: string
+      max-tests:
+        required: false
         type: number
+        default: 8000
+      pytest-add-params:
+        required: false
+        type: string
+        default: ""
+      coverage-flags:
+        required: false
+        type: string
+        default: "ci-unit"
 
-permissions: read-all
+env:
+  CAIRO_PATH: cairo:tests:python/cairo-ec/src:python/cairo-addons/src:python/cairo-core/src:python/mpt/src
+  CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  CHAIN_RPC_URL: ${{ secrets.CHAIN_RPC_URL }}
+  HYPOTHESIS_PROFILE: ${{ inputs.hypothesis-profile }}
 
 jobs:
-  test-unit:
-    name: Python Unit Tests
+  python-tests:
     runs-on: ubuntu-latest-64-cores
-    env:
-      HYPOTHESIS_PROFILE: ci
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      CAIRO_PATH: cairo:tests:python/cairo-ec/src:python/cairo-addons/src:python/cairo-core/src:python/mpt/src:.venv/lib/python3.10/site-packages/src
-      CHAIN_RPC_URL: ${{ secrets.CHAIN_RPC_URL }}
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v3
-        with:
-          enable-cache: true
-          cache-dependency-glob: uv.lock
-      - uses: actions/setup-python@v5
-        with:
-          python-version-file: .python-version
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-      - name: Install forge deps
-        run: forge install
-      - name: Build solidity contracts
-        run: forge build
-      - name: Restore pytest cache
-        id: cache-pytest-restore
-        uses: actions/cache/restore@v4
-        with:
-          path: .pytest_cache
-          key: ${{ runner.os }}-pytest-cache-${{ github.run_id }}
-          restore-keys: ${{ runner.os }}-pytest-cache-
 
-      # TODO: remove --no-skip-cached-tests if/when we cache coverage
-      # <https://github.com/kkrt-labs/keth/issues/694>
-      - name: Run unit tests without caching
+      - uses: ./.github/actions/setup-environment
+
+      - name: Run Python tests
         run: |
-          uv run --reinstall pytest -n logical --durations=0 -v -s --log-cli-level=DEBUG --no-skip-cached-tests --ignore-glob=cairo/tests/ef_tests/
+          uv run pytest -n logical --durations=0 -v -s --log-cli-level=DEBUG --no-skip-cached-tests ${{ inputs.pytest-add-params }}
 
-      - uses: actions/cache/save@v4
-        with:
-          path: .pytest_cache
-          key: ${{ runner.os }}-pytest-cache-${{ github.run_id }}
       - name: Upload coverage
+        if: inputs.coverage-flags != ''
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
           files: ./coverage/**/*.json
-          flags: ci-unit
-
-  ef-tests-sampled:
-    name: EF-Tests Sampled
-    runs-on: ubuntu-latest-64-cores
-    env:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      CAIRO_PATH: cairo:tests:python/cairo-ec/src:python/cairo-addons/src:python/cairo-core/src:python/mpt/src:.venv/lib/python3.10/site-packages/src
-    steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v3
-        with:
-          enable-cache: true
-          cache-dependency-glob: uv.lock
-      - uses: actions/setup-python@v5
-        with:
-          python-version-file: .python-version
-      - name: Run sampled EF tests
-        run: |
-          # Runs up to ${{ inputs.max-tests }} tests, randomly sampled using the GITHUB_RUN_ID seed
-          # Use only 48 cores to avoid out of memory issues
-          uv run --reinstall pytest -n 48 -m "not slow" --timeout 300 --durations=0 -v -s --log-cli-level=DEBUG --max-tests=${{ inputs.max-tests }} --randomly-seed=$GITHUB_RUN_ID cairo/tests/ef_tests/ --ignore-glob='cairo/tests/ef_tests/fixtures/*'
-      - name: Upload coverage
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          verbose: true
-          files: ./coverage/**/*.json
-          flags: ci-ef-tests
+          flags: ${{ inputs.coverage-flags }}

--- a/.trunk/configs/.yamllint.yaml
+++ b/.trunk/configs/.yamllint.yaml
@@ -1,7 +1,6 @@
 rules:
   quoted-strings:
-    required: only-when-needed
-    extra-allowed: ["{|}"]
+    required: false
   key-duplicates: {}
   octal-values:
     forbid-implicit-octal: true

--- a/cairo/scripts/prove_block.py
+++ b/cairo/scripts/prove_block.py
@@ -89,7 +89,6 @@ def load_zkpi_fixture(zkpi_path: Path) -> Dict[str, Any]:
         FileNotFoundError: If the ZKPI file doesn't exist
         ValueError: If JSON is invalid or data conversion fails
     """
-    logger.debug(f"Loading ZKPI file: {zkpi_path}")
     with open(zkpi_path, "r") as f:
         fixture = json.load(f)
 

--- a/cairo/scripts/zkpi_to_eels.py
+++ b/cairo/scripts/zkpi_to_eels.py
@@ -80,9 +80,6 @@ def convert_accounts(
         }
 
         if account_state == EMPTY_ACCOUNT:
-            logger.debug(
-                f"empty account for address {account_proof['address']}, skipping"
-            )
             continue
 
         if account_proof["storageHash"] != EMPTY_STORAGE_ROOT:

--- a/python/mpt/src/mpt/ethereum_tries.py
+++ b/python/mpt/src/mpt/ethereum_tries.py
@@ -234,33 +234,22 @@ class EthereumTries:
         """
         Decode the account contained in the leaf node and set the account in the state.
         """
-        logger.debug(f"Processing account leaf node with path 0x{full_path.hex()}")
         address = self.address_preimages.get(full_path)
         if address is None:
-            logger.debug(
-                f"Address not found in address preimages: {full_path}, skipping"
-            )
             return
 
         account_node = AccountNode.from_rlp(node.value)
         account_code = self.get_code(account_node.code_hash, address)
         account = account_node.to_eels_account(account_code)
 
-        logger.debug(
-            f"Setting account 0x{address.hex()} with nonce {account.nonce}, balance {account.balance}, code hash 0x{keccak256(account.code).hex()}"
-        )
         set_account(state, address, account)
 
         if account_node.storage_root == EMPTY_TRIE_HASH:
-            logger.debug(f"Storage root is empty for account {address.hex()}, skipping")
             return
 
         # We need to resolve the storage root of the account
         storage_root_node = self.nodes.get(account_node.storage_root)
         if storage_root_node is None:
-            logger.debug(
-                f"Storage root node not found for account {address.hex()}, skipping"
-            )
             return
 
         self.traverse_trie_and_process_leaf(
@@ -279,12 +268,8 @@ class EthereumTries:
         """
         Decode the storage value contained in the leaf node and set the storage value in the state.
         """
-        logger.debug(f"Processing storage leaf node with path 0x{full_path.hex()}")
         storage_key = self.storage_key_preimages.get(full_path)
         if storage_key is None:
-            logger.debug(
-                f"Storage key not found in storage key preimages: {full_path}, skipping"
-            )
             return
 
         # We need to decode the value of the storage key


### PR DESCRIPTION
Caches rust builds so that the cairo-addons crate built under `./target` with `maturin` is cached

```
DEBUG     Finished `release` profile [optimized] target(s) in 3m 42s
DEBUG 📦 Built wheel for abi3 Python ≥ 3.9 to /Users/msaug/kkrt-labs/keth/target/wheels/cairo_addons-0.1.0-cp39-abi3-macosx_11_0_arm64.whl
DEBUG /Users/msaug/kkrt-labs/keth/target/wheels/cairo_addons-0.1.0-cp39-abi3-macosx_11_0_arm64.whl
DEBUG Finished building: cairo-addons @ file:///Users/msaug/kkrt-labs/keth/python/cairo-addons
      Built cairo-addons @ file:///Users/msaug/kkrt-labs/keth/python/cairo-addons
```

Normally it's built under ./target/wheels