### PR TITLE
chore: remove duplicated list entry

### DIFF
--- a/crates/cairo-addons/src/vm/hint_definitions/maths.rs
+++ b/crates/cairo-addons/src/vm/hint_definitions/maths.rs
@@ -18,13 +18,8 @@ use num_bigint::BigUint;
 
 use crate::vm::hints::Hint;
 
-pub const HINTS: &[fn() -> Hint] = &[
-    felt252_to_bytes_le,
-    felt252_to_bytes_be,
-    value_len_mod_two,
-    is_positive_hint,
-    value_len_mod_two,
-];
+pub const HINTS: &[fn() -> Hint] =
+    &[felt252_to_bytes_le, felt252_to_bytes_be, value_len_mod_two, is_positive_hint];
 
 pub fn felt252_to_bytes_le() -> Hint {
     Hint::new(


### PR DESCRIPTION
`value_len_mod_two` was present in the list twice