### PR TITLE
fix: add leaf extension edge case

### DIFF
--- a/python/mpt/src/mpt/trie_diff.cairo
+++ b/python/mpt/src/mpt/trie_diff.cairo
@@ -877,31 +877,76 @@ func _left_is_leaf_node{
     // (LeafNode(), ExtensionNode()) -> Explore the extension node's subtree for any new leaves,
     // comparing it to the old leaf with the same key
     if (cast(right.value.extension_node.value, felt) != 0) {
-        // remove the right node's key segment from the left leaf node
         let r_extension = right.value.extension_node;
-        let updated_path = Bytes__add__(path, r_extension.value.key_segment);
+        let r_prefix_l = Bytes__startswith__(
+            l_leaf.value.rest_of_key, r_extension.value.key_segment
+        );
+        if (r_prefix_l.value != 0) {
+            let updated_path = Bytes__add__(path, r_extension.value.key_segment);
+            let r_subnode = OptionalUnionInternalNodeExtendedImpl.from_extended(
+                r_extension.value.subnode
+            );
+            // Update the left leaf node's rest of key to remove the right node's key segment
+            tempvar l_leaf = LeafNode(
+                new LeafNodeStruct(
+                    rest_of_key=Bytes(
+                        new BytesStruct(
+                            data=l_leaf.value.rest_of_key.value.data +
+                            r_extension.value.key_segment.value.len,
+                            len=l_leaf.value.rest_of_key.value.len -
+                            r_extension.value.key_segment.value.len,
+                        ),
+                    ),
+                    value=l_leaf.value.value,
+                ),
+            );
+            let l_leaf_typed = OptionalUnionInternalNodeExtendedImpl.from_leaf(l_leaf);
+            return _compute_diff(
+                left=l_leaf_typed,
+                right=r_subnode,
+                path=updated_path,
+                account_address=account_address,
+            );
+        }
+        // else, the left leaf node is not a prefix of the right extension node
+        // we compare left with none and none with right
+        let null_node = OptionalUnionInternalNodeExtended(
+            cast(0, OptionalUnionInternalNodeExtendedEnum*)
+        );
+        // Compute diffs in the right sub-tree
+        let updated_path_right = Bytes__add__(path, r_extension.value.key_segment);
         let r_subnode = OptionalUnionInternalNodeExtendedImpl.from_extended(
             r_extension.value.subnode
         );
-        // Update the left leaf node's rest of key to remove the right node's key segment
-        // TODO(unsure): verify whether this is correct or if we need to use a prefix check.
-        tempvar l_leaf = LeafNode(
-            new LeafNodeStruct(
-                rest_of_key=Bytes(
-                    new BytesStruct(
-                        data=l_leaf.value.rest_of_key.value.data +
-                        r_extension.value.key_segment.value.len,
-                        len=l_leaf.value.rest_of_key.value.len -
-                        r_extension.value.key_segment.value.len,
-                    ),
-                ),
-                value=l_leaf.value.value,
-            ),
+        _compute_diff(
+            left=null_node,
+            right=r_subnode,
+            path=updated_path_right,
+            account_address=account_address,
         );
-        let l_leaf_typed = OptionalUnionInternalNodeExtendedImpl.from_leaf(l_leaf);
-        return _compute_diff(
-            left=l_leaf_typed, right=r_subnode, path=updated_path, account_address=account_address
+
+        // Compute deletions in the left sub-tree
+        let updated_path_left = Bytes__add__(path, l_leaf.value.rest_of_key);
+        let updated_path_left_nibbles = nibble_list_to_bytes(updated_path_left);
+        let updated_path_left_b32 = Bytes_to_Bytes32(updated_path_left_nibbles);
+        let opt_left_leaf = OptionalLeafNode(l_leaf.value);
+        let opt_right_leaf = OptionalLeafNode(cast(0, LeafNodeStruct*));
+
+        if (account_address.value == 0) {
+            _process_account_diff(
+                path=updated_path_left_b32, left=opt_left_leaf, right=opt_right_leaf
+            );
+            return ();
+        }
+
+        _process_storage_diff(
+            address=Address([account_address.value]),
+            path=updated_path_left_b32,
+            left=opt_left_leaf,
+            right=opt_right_leaf,
         );
+
+        return ();
     }
 
     // (LeafNode(), BranchNode()) -> The branch was created and replaced the single leaf.

--- a/python/mpt/src/mpt/trie_diff.cairo
+++ b/python/mpt/src/mpt/trie_diff.cairo
@@ -1004,26 +1004,70 @@ func _left_is_extension_node{
     if (cast(right.value.leaf_node.value, felt) != 0) {
         // Remove the left node's key segment from the right leaf node
         let r_leaf = right.value.leaf_node;
-        let updated_path = Bytes__add__(path, left.value.key_segment);
-        let l_subnode = OptionalUnionInternalNodeExtendedImpl.from_extended(left.value.subnode);
-
-        // Update the right leaf node's rest of key to remove the left node's key segment
-        tempvar r_leaf = LeafNode(
-            new LeafNodeStruct(
-                rest_of_key=Bytes(
-                    new BytesStruct(
-                        data=r_leaf.value.rest_of_key.value.data + left.value.key_segment.value.len,
-                        len=r_leaf.value.rest_of_key.value.len - left.value.key_segment.value.len,
+        let l_prefix_r = Bytes__startswith__(r_leaf.value.rest_of_key, left.value.key_segment);
+        if (l_prefix_r.value != 0) {
+            let updated_path = Bytes__add__(path, left.value.key_segment);
+            let l_subnode = OptionalUnionInternalNodeExtendedImpl.from_extended(left.value.subnode);
+            // Update the right leaf node's rest of key to remove the left node's key segment
+            tempvar r_leaf = LeafNode(
+                new LeafNodeStruct(
+                    rest_of_key=Bytes(
+                        new BytesStruct(
+                            data=r_leaf.value.rest_of_key.value.data +
+                            left.value.key_segment.value.len,
+                            len=r_leaf.value.rest_of_key.value.len -
+                            left.value.key_segment.value.len,
+                        ),
                     ),
+                    value=r_leaf.value.value,
                 ),
-                value=r_leaf.value.value,
-            ),
+            );
+
+            let r_leaf_typed = OptionalUnionInternalNodeExtendedImpl.from_leaf(r_leaf);
+            return _compute_diff(
+                left=l_subnode,
+                right=r_leaf_typed,
+                path=updated_path,
+                account_address=account_address,
+            );
+        }
+
+        // else, the left extension node key segment is not a prefix of the right leaf node rest of key
+        // this means that the left extension node is deleted and the right leaf node is created
+        // we explore the subnode of the left extension node to find all deleted nodes
+        // we log the right leaf node as a new leaf node
+        let null_node = OptionalUnionInternalNodeExtended(
+            cast(0, OptionalUnionInternalNodeExtendedEnum*)
+        );
+        // Compute diffs in the right sub-tree
+        let updated_path_left = Bytes__add__(path, left.value.key_segment);
+        let l_subnode = OptionalUnionInternalNodeExtendedImpl.from_extended(left.value.subnode);
+        _compute_diff(
+            left=l_subnode, right=null_node, path=updated_path_left, account_address=account_address
         );
 
-        let r_leaf_typed = OptionalUnionInternalNodeExtendedImpl.from_leaf(r_leaf);
-        return _compute_diff(
-            left=l_subnode, right=r_leaf_typed, path=updated_path, account_address=account_address
+        // Compute deletions in the left sub-tree
+        let updated_path_right = Bytes__add__(path, r_leaf.value.rest_of_key);
+        let updated_path_right_nibbles = nibble_list_to_bytes(updated_path_right);
+        let updated_path_right_b32 = Bytes_to_Bytes32(updated_path_right_nibbles);
+        let opt_left_leaf = OptionalLeafNode(cast(0, LeafNodeStruct*));
+        let opt_right_leaf = OptionalLeafNode(r_leaf.value);
+
+        if (account_address.value == 0) {
+            _process_account_diff(
+                path=updated_path_right_b32, left=opt_left_leaf, right=opt_right_leaf
+            );
+            return ();
+        }
+
+        _process_storage_diff(
+            address=Address([account_address.value]),
+            path=updated_path_right_b32,
+            left=opt_left_leaf,
+            right=opt_right_leaf,
         );
+
+        return ();
     }
 
     // (ExtensionNode(), ExtensionNode()) ->


### PR DESCRIPTION
## Summary of Changes

This PR addresses a bug in the `_compute_diff` function within `trie_diff.cairo`, specifically related to the comparison of `LeafNode` and `ExtensionNode` types.

**Key Improvements:**

* **Prefix-Based Key Segment Handling:**
    * The code now employs `Bytes__startswith__` to verify if an `ExtensionNode`'s key segment is a prefix of a `LeafNode`'s remaining key.
    * This ensures accurate key segment subtraction when comparing nodes.
* **Handling Non-Prefix Scenarios:**
    * When the `ExtensionNode`'s key segment is *not* a prefix of the `LeafNode`'s key, the PR correctly identifies this as a deletion of the extension subtree and a creation of the leaf.
    * The code now correctly recurses down the deleted extension subtree.
    * The code now correctly logs the creation of the new leaf node.
* **Accurate Path Updating:**
    * Ensures that the path is correctly updated for both the left and right trie, when the compared nodes do not share a prefix.
* **Correct calls to `_process_account_diff` and `_process_storage_diff`:**
    * The correct calls to these functions were added, to account for the deletion and creation of nodes in the trie.