### PR TITLE
dev: dump coverage data as parquet file to optimize memory usage.

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,7 +18,7 @@ jobs:
     with:
       hypothesis-profile: "ci"
       coverage-flags: "ci-unit"
-      parallelism: 40
+      parallelism: logical
       # Ignore ef-test run in this job (handled in the ef-tests job)
       pytest-add-params: "-m 'not slow' --ignore-glob=cairo/tests/ef_tests/"
 
@@ -26,7 +26,7 @@ jobs:
     uses: ./.github/workflows/python_tests.yml
     with:
       hypothesis-profile: "ci"
-      parallelism: 48
+      parallelism: logical
       pytest-add-params:
         "-m 'not slow' --max-tests=5000 --randomly-seed=$GITHUB_RUN_ID
         cairo/tests/ef_tests/"

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -14,8 +14,8 @@ on:
         default: ""
       parallelism:
         required: false
-        type: number
-        default: 40
+        type: string
+        default: logical
       coverage-flags:
         required: false
         type: string

--- a/python/cairo-addons/src/cairo_addons/testing/fixtures.py
+++ b/python/cairo-addons/src/cairo_addons/testing/fixtures.py
@@ -11,8 +11,10 @@ The runner works with args_gen.py and serde.py for automatic type conversion.
 import json
 import logging
 import pickle
+import shutil  # For cleaning up temporary directory
+import uuid  # For unique filenames
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import List, Tuple
 
 import polars as pl
 import pytest
@@ -83,117 +85,225 @@ def coverage(
     request, cairo_files: List[Path], cairo_programs: List[Program], worker_id: str
 ):
     """
-    Fixture to collect and aggregate coverage from all test runs for each Cairo file.
+    Pytest fixture to collect and aggregate coverage across test runs within a module.
+
+    This fixture addresses memory issues associated with collecting coverage for many
+    tests within a single module (test file). Instead of accumulating coverage
+    DataFrames in memory on each test run, it performs the following steps:
+    1. Creates a unique temporary directory for the current worker and test module.
+    2. Yields a `_collect_coverage` function to the test runner.
+    3. The `_collect_coverage` function calculates coverage for a single test run
+       and writes the resulting DataFrame to a unique Parquet file in the temporary
+       directory.
+    4. After all tests in the module have run, the fixture's teardown logic executes.
+    5. It scans all the temporary Parquet files (lazily) using Polars.
+    6. It concatenates these lazy frames.
+    7. It merges the concatenated coverage data with the base statement information
+       for each relevant Cairo file, aggregates the counts, and calculates coverage.
+    8. The final aggregated coverage report is written to a JSON file in the
+       `coverage/<worker_id>/` directory.
+    9. The temporary directory and its Parquet files are deleted.
+
+    This approach significantly reduces peak memory usage during test execution by
+    offloading intermediate results to disk, only loading and processing the full
+    aggregated data during the final teardown phase of the module.
 
     Args:
-        request: Pytest request object for accessing config and node info.
-        cairo_files: List of Cairo file paths associated with the test session.
-        worker_id: Unique identifier for the worker in parallel test runs.
+        request: Pytest request object.
+        cairo_files: List of Cairo file paths for the session.
+        cairo_programs: List of compiled Cairo programs for the session.
+        worker_id: ID of the current pytest-xdist worker.
 
     Yields:
-        A function that collects coverage for a single test run.
-
-    After yielding, it aggregates all collected reports and dumps them as JSON files.
+        Callable: The `_collect_coverage` function.
     """
-    # Store coverage reports for each run
-    reports: List[pl.DataFrame] = []
+    # Define path for temporary report files for this worker and module
+    module_stem = Path(request.node.fspath).stem
+    temp_report_dir = Path("coverage") / worker_id / f"{module_stem}_temp_reports"
+    temp_report_dir.mkdir(parents=True, exist_ok=True)
+    report_files_generated = []  # Keep track of files to aggregate
 
     def _collect_coverage(
         cairo_file: Path,
         trace: pl.DataFrame,
-    ) -> Optional[pl.DataFrame]:
+    ) -> None:
         """
-        Collect coverage for a single test run and append it to the reports list.
-
+        Calculates coverage for a single test run and writes it to a temporary file.  We write the
+        local coverage report to a parquet file, as keeping it in memory would consume too much
+        memory when running the entire test suite.
+        This parquet file can the be loaded on demand.
         Args:
-            cairo_program: Compiled Cairo program.
-            cairo_file: Path to the Cairo source file.
-            trace: DataFrame containing the execution trace.
-            program_base: Base address of the program in memory (default: PROGRAM_BASE).
-
-        Returns:
-            The coverage DataFrame for this run, or None if debug info is missing.
+            cairo_file: Path to the Cairo source file relevant to this run.
+            trace: Polars DataFrame containing the execution trace (pc, ap, fp).
         """
+        try:
+            coverage_df = coverage_from_trace(cairo_file, trace)
 
-        coverage_df = coverage_from_trace(cairo_file, trace)
-        reports.append(coverage_df)
-        return coverage_df
+            # Generate a unique filename for this report
+            # Sanitize node name to create a valid filename component
+            sanitized_node_name = (
+                request.node.name.replace("[", "_")
+                .replace("]", "")
+                .replace("/", "_")
+                .replace(":", "_")
+                .replace(" ", "_")
+            )
+            report_filename = f"{sanitized_node_name}_{uuid.uuid4()}.parquet"
+            report_filepath = temp_report_dir / report_filename
 
-    yield _collect_coverage
+            # Write the report to the temporary file
+            coverage_df.write_parquet(report_filepath)
+            report_files_generated.append(report_filepath)
 
-    # Skip processing if no reports were collected (e.g., all tests failed early)
-    if not reports:
-        logger.info("No coverage reports collected, skipping aggregation.")
+        except Exception as e:
+            logger.exception(
+                f"Error during coverage calculation or writing for node {str(request.node)}: {e}"
+            )
+            return
+
         return
 
-    # Aggregate coverage for each Cairo file
+    # Yield the collector function to be used by the test runner
+    yield _collect_coverage
+
+    # --- Start of Fixture Teardown (runs after all tests in the module) ---
+    try:
+        if not report_files_generated:
+            logger.info(
+                f"[Coverage] Module {module_stem}: No reports generated, skipping aggregation."
+            )
+        else:
+            _aggregate_coverage(
+                cairo_files,
+                module_stem,
+                report_files_generated,
+                temp_report_dir,
+                worker_id,
+            )
+    except Exception as e:
+        logger.exception(
+            f"Error during coverage aggregation for module {module_stem}: {e}"
+        )
+    finally:
+        # --- Cleanup Phase ---
+        # Always attempt to clean up the temporary directory
+        if temp_report_dir.exists():
+            shutil.rmtree(temp_report_dir)
+
+    return
+
+
+def _aggregate_coverage(
+    cairo_files: List[Path],
+    module_stem: str,
+    report_files_generated: List[Path],
+    temp_report_dir: Path,
+    worker_id: str,
+) -> bool:
+    logger.info(
+        f"[Coverage] Worker {worker_id}, Module {module_stem}: Aggregating {len(report_files_generated)} reports from {temp_report_dir}."
+    )
+    # Scan all generated parquet files lazily
+    scanned_reports = [
+        pl.scan_parquet(report_file) for report_file in report_files_generated
+    ]
+
+    if not scanned_reports:
+        logger.info(
+            f"[Coverage] Worker {worker_id}, Module {module_stem}: Found no reports to scan in {temp_report_dir}."
+        )
+        return
+
+    # Concatenate the lazy scans
+    concatenated_lazy = pl.concat(scanned_reports)
+
+    # Aggregate coverage per relevant Cairo file for this module
     for cairo_file in cairo_files:
-        # Get all possible statements (lines) from the program's debug info
+        # Load base statement info (all executable lines)
         dump_path = get_dump_path(cairo_file)
-        if dump_path.exists():
-            dump_path = Path(str(dump_path).replace(".pickle", "_dataframes.pickle"))
-            with dump_path.open("rb") as f:
+        df_pickle_path_str = str(dump_path).replace(".pickle", "_dataframes.pickle")
+        df_pickle_path = Path(df_pickle_path_str)
+        if df_pickle_path.exists():
+            with df_pickle_path.open("rb") as f:
                 dataframes = pickle.load(f)
                 all_statements = dataframes["all_statements"]
-
-        # Concatenate all reports and merge with all statements
-        all_coverages = (
-            pl.concat([all_statements.lazy(), pl.concat(reports).lazy()])
-            .filter(
-                ~pl.col("filename").str.contains(".venv")
-            )  # Exclude virtual env files
-            .filter(~pl.col("filename").str.contains("test_"))  # Exclude test files
-            .group_by(pl.col("filename"), pl.col("line_number"))
-            .agg(pl.col("count").sum())
-            .collect()
-        )
-        # Filter for the current Cairo file and prepare missed lines report
-        with pl.Config(tbl_rows=100, fmt_str_lengths=90):
-            missed = (
-                all_coverages.filter(pl.col("filename") == str(cairo_file))
-                .with_columns(pl.col("filename").str.replace(str(Path.cwd()) + "/", ""))
-                .filter(pl.col("count") == 0)
-                .sort("line_number", descending=False)
-                .with_columns(
-                    pl.col("filename") + ":" + pl.col("line_number").cast(pl.String)
-                )
-                .drop("line_number", "count")
+        else:
+            raise Exception(
+                f"[Coverage] Worker {worker_id}: Dataframes pickle not found: {df_pickle_path}"
             )
 
-        # Log coverage results
-        with pl.Config(tbl_rows=100, fmt_str_lengths=90):
+        # Combine base statements with concatenated coverage data lazily
+        all_coverages_lazy = (
+            pl.concat(
+                [all_statements.lazy(), concatenated_lazy]
+            )  # Ensure both are lazy
+            .filter(~pl.col("filename").str.contains(".venv"))  # Exclude venv
+            .filter(~pl.col("filename").str.contains("test_"))  # Exclude test files
+            .group_by(pl.col("filename"), pl.col("line_number"))
+            .agg(pl.col("count").sum())  # Sum counts for each line
+        )
+
+        # Collect the final aggregated data (potential memory peak)
+        all_coverages_df = all_coverages_lazy.collect()
+
+        # --- Reporting and JSON Dump ---
+        with pl.Config(tbl_rows=100, fmt_str_lengths=120):
+            # Calculate missed lines for the specific cairo_file
+            missed = (
+                all_coverages_df.lazy()
+                .filter(pl.col("filename") == str(cairo_file))
+                .filter(pl.col("count") == 0)  # Lines with 0 hits
+                .select(  # Select filename and line number for missed report
+                    (
+                        pl.col("filename").str.replace(str(Path.cwd()) + "/", "")
+                        + ":"
+                        + pl.col("line_number").cast(pl.String)
+                    ).alias("missed_line")
+                )
+                .sort("missed_line")  # Sort alphabetically
+            ).collect()
+
+            # Log coverage results
             if missed.height > 0:
+                # Use print for cleaner output of missed lines report in CI logs
                 print(f"Missed lines in {cairo_file}:\n{missed}")
             else:
                 logger.info(f"{cairo_file}: 100% coverage ✅")
 
-        all_coverages = (
-            all_coverages.group_by("filename")
+        # Prepare data structure for JSON dump
+        # Aggregate line numbers and counts per filename for the final JSON
+        all_coverages_dict = (
+            all_coverages_df.lazy()  # Start lazy again for efficient grouping
+            .group_by("filename")
             .agg(pl.col("line_number"), pl.col("count"))
+            .collect()
             .to_dict(as_series=False)
         )
-        # Convert to dictionary for JSON dumping
+
         coverage_data = {
             "coverage": {
-                filename: dict(zip(line_number, count))
+                filename: dict(
+                    zip(line_number, count)
+                )  # Combine lines and counts into {line: count} dict
                 for filename, line_number, count in zip(
-                    all_coverages["filename"],
-                    all_coverages["line_number"],
-                    all_coverages["count"],
+                    all_coverages_dict["filename"],
+                    all_coverages_dict["line_number"],
+                    all_coverages_dict["count"],
                 )
             }
         }
 
-        # Dump coverage to a JSON file
-        dump_path = (
+        # Define final output path and dump JSON
+        final_dump_path = (
             Path("coverage")
             / worker_id
             / cairo_file.relative_to(Path.cwd()).with_suffix(".json")
         )
-        dump_path.parent.mkdir(parents=True, exist_ok=True)
-        logger.info(f"Dumping coverage to {dump_path}")
-        with open(dump_path, "w") as f:
+        final_dump_path.parent.mkdir(parents=True, exist_ok=True)
+        logger.info(f"Dumping final coverage JSON to {final_dump_path}")
+        with open(final_dump_path, "w") as f:
             json.dump(coverage_data, f, indent=4)
+    return
 
 
 @pytest.fixture(scope="module")

--- a/python/cairo-addons/src/cairo_addons/testing/fixtures.py
+++ b/python/cairo-addons/src/cairo_addons/testing/fixtures.py
@@ -199,7 +199,7 @@ def _aggregate_coverage(
     report_files_generated: List[Path],
     temp_report_dir: Path,
     worker_id: str,
-) -> bool:
+):
     logger.info(
         f"[Coverage] Worker {worker_id}, Module {module_stem}: Aggregating {len(report_files_generated)} reports from {temp_report_dir}."
     )

--- a/python/cairo-addons/src/cairo_addons/testing/runner.py
+++ b/python/cairo-addons/src/cairo_addons/testing/runner.py
@@ -311,7 +311,8 @@ def run_python_vm(
             runner.end_run(disable_trace_padding=False)
             runner.relocate()
             trace = pl.DataFrame(
-                [{"pc": x.pc, "ap": x.ap, "fp": x.fp} for x in runner.relocated_trace]
+                [{"pc": x.pc, "ap": x.ap, "fp": x.fp} for x in runner.relocated_trace],
+                schema=[("pc", pl.UInt32), ("ap", pl.UInt32), ("fp", pl.UInt32)],
             )
             if not request.config.getoption("no_coverage"):
                 coverage(cairo_file, trace)
@@ -355,7 +356,8 @@ def run_python_vm(
         # STEP 7: GENERATE OUTPUT FILES AND TRACE (IF REQUESTED)
         # ============================================================================
         trace = pl.DataFrame(
-            [{"pc": x.pc, "ap": x.ap, "fp": x.fp} for x in runner.relocated_trace]
+            [{"pc": x.pc, "ap": x.ap, "fp": x.fp} for x in runner.relocated_trace],
+            schema=[("pc", pl.UInt32), ("ap", pl.UInt32), ("fp", pl.UInt32)],
         )
         if not request.config.getoption("no_coverage"):
             coverage(cairo_file, trace)


### PR DESCRIPTION
Closes #1153

## PR Summary: Fix High Memory Usage During Coverage Collection

**Context:**

Running tests in CI with high parallelism (e.g., -n 40 or more) was leading to excessive memory consumption per worker, often causing crashes due to Out-Of-Memory errors. Initial investigation suspected that the handling of coverage data was inefficient.

**Investigation & Problem:**

Analysis confirmed that the primary cause was the `coverage` pytest fixture (`fixtures.py`). Its original implementation worked as follows:
1.  For each test function executed within a test module (`test_*.py`), it calculated a coverage report (a Polars DataFrame).
2.  It appended *each* of these DataFrames to an in-memory list (`reports`).
3.  After all tests in the module finished, it concatenated *all* collected DataFrames (`pl.concat(reports)`) and performed aggregation.

This approach led to:
*   **Linear Memory Growth:** The `reports` list grew with every test run within a module, holding potentially hundreds of DataFrames in RAM simultaneously.
*   **Large Memory Spike:** The final `pl.concat(reports)` operation required loading all data into memory at once for concatenation and aggregation, causing a significant peak in memory usage at the end of each module's execution.

**Solution:**

To address this, the `coverage` fixture was refactored to avoid holding intermediate reports in memory:

1.  **Temporary File Storage:**
    *   A unique temporary directory (`coverage/<worker_id>/<module_name>_temp_reports/`) is created for each worker and test module.
    *   The `_collect_coverage` function (yielded by the fixture) now calculates the coverage DataFrame for a single test run and immediately writes it to a unique `.parquet` file within this temporary directory. The DataFrame is not stored in memory beyond this point.
2.  **Lazy Aggregation:**
    *   In the fixture's teardown phase (after all tests in the module complete), instead of concatenating in-memory DataFrames, the code now uses `pl.scan_parquet` to lazily scan all the generated `.parquet` files from the temporary directory.
    *   These lazy frames are then concatenated (`pl.concat(scanned_reports)`), still maintaining laziness.
    *   The final aggregation (joining with base statements, grouping, summing counts) is performed on this lazy frame, with `.collect()` only called at the end to materialize the final result for reporting and JSON dumping.
3.  **Robust Cleanup:**
    *   A `finally` block was added to the fixture's teardown to ensure the temporary directory (`temp_report_dir`) and all its contents are reliably deleted using `shutil.rmtree`, even if errors occur during the aggregation process.
4.  **Code Structure:**
    *   The aggregation logic was factorized into a helper function `_aggregate_coverage` for better readability within the fixture.
    *   Docstrings were updated to clearly explain the new strategy and its rationale.

**Key File Changes:**

*   **`python/cairo-addons/src/cairo_addons/testing/fixtures.py`:** Major refactoring of the `coverage` fixture to implement the temporary file strategy, lazy aggregation, and robust cleanup. Added `_aggregate_coverage` helper.
*   **`python/cairo-addons/src/cairo_addons/testing/coverage.py`:** Ensured `coverage_from_trace` returns a collected DataFrame (needed for `write_parquet`). Added type hints and schema definitions for clarity and robustness.

**Other Changes (from Diff):**

*   **`python/cairo-addons/src/cairo_addons/testing/runner.py`:** Added schema definitions during trace DataFrame creation.
*   **`.github/workflows/*.yml`:** Updated parallelism settings to `logical`.

**Impact:**

This change significantly reduces the memory footprint of each test worker by preventing the accumulation of coverage reports in RAM. Intermediate data is offloaded to disk (temporary Parquet files), and lazy processing is used during aggregation to minimize peak memory usage. This should allow for higher, more stable parallelism in CI.