### PR TITLE
refactor: Fq2 and G2point

### DIFF
--- a/cairo/ethereum/crypto/alt_bn128.cairo
+++ b/cairo/ethereum/crypto/alt_bn128.cairo
@@ -11,7 +11,7 @@ from cairo_core.control_flow import raise
 from cairo_ec.circuits.mod_ops_compiled import add, sub, mul
 from cairo_ec.curve.alt_bn128 import alt_bn128
 from cairo_ec.curve.g1_point import G1Point, G1PointStruct
-from cairo_ec.curve.g2_point import Fp2, Fp2Struct, fp2_add
+from cairo_ec.curve.g2_point import Fq2, Fq2Struct, fp2_add
 from cairo_ec.circuits.ec_ops_compiled import assert_on_curve
 from bn254.final_exp import final_exponentiation
 from definitions import E12D
@@ -88,7 +88,7 @@ func bnf_sub{range_check96_ptr: felt*, add_mod_ptr: ModBuiltin*, mul_mod_ptr: Mo
 // Quadratic extension field of BNF.
 // BNF elements are 2-dimensional.
 struct BNF2 {
-    value: Fp2Struct*,
+    value: Fq2Struct*,
 }
 
 func bnf2_add{range_check96_ptr: felt*, add_mod_ptr: ModBuiltin*, mul_mod_ptr: ModBuiltin*}(
@@ -96,7 +96,7 @@ func bnf2_add{range_check96_ptr: felt*, add_mod_ptr: ModBuiltin*, mul_mod_ptr: M
 ) -> BNF2 {
     tempvar modulus = U384(new UInt384(alt_bn128.P0, alt_bn128.P1, alt_bn128.P2, alt_bn128.P3));
 
-    let res_fp2 = fp2_add(Fp2(a.value), Fp2(b.value), modulus);
+    let res_fp2 = fp2_add(Fq2(a.value), Fq2(b.value), modulus);
     tempvar res = BNF2(res_fp2.value);
 
     return res;
@@ -128,14 +128,14 @@ func bnf2_sub{range_check96_ptr: felt*, add_mod_ptr: ModBuiltin*, mul_mod_ptr: M
     let res_c0 = sub(a.value.c0, b.value.c0, modulus);
     let res_c1 = sub(a.value.c1, b.value.c1, modulus);
 
-    tempvar res = BNF2(new Fp2Struct(res_c0, res_c1));
+    tempvar res = BNF2(new Fq2Struct(res_c0, res_c1));
     return res;
 }
 
 func BNF2_ZERO() -> BNF2 {
     let (u384_zero) = get_label_location(U384_ZERO);
     let u384_zero_ptr = cast(u384_zero, UInt384*);
-    tempvar res = BNF2(new Fp2Struct(U384(u384_zero_ptr), U384(u384_zero_ptr)));
+    tempvar res = BNF2(new Fq2Struct(U384(u384_zero_ptr), U384(u384_zero_ptr)));
     return res;
 }
 
@@ -144,7 +144,7 @@ func BNF2_ONE() -> BNF2 {
     let (u384_one) = get_label_location(U384_ONE);
     let u384_zero_ptr = cast(u384_zero, UInt384*);
     let u384_one_ptr = cast(u384_one, UInt384*);
-    tempvar res = BNF2(new Fp2Struct(U384(u384_one_ptr), U384(u384_zero_ptr)));
+    tempvar res = BNF2(new Fq2Struct(U384(u384_one_ptr), U384(u384_zero_ptr)));
     return res;
 }
 
@@ -196,7 +196,7 @@ func bnf2_mul{range_check96_ptr: felt*, add_mod_ptr: ModBuiltin*, mul_mod_ptr: M
     // No reduction needed for res[1] = mul[1] in BNF2 with degree 2
     let res_c1 = mul_1;
 
-    tempvar res = BNF2(new Fp2Struct(res_c0, res_c1));
+    tempvar res = BNF2(new Fq2Struct(res_c0, res_c1));
     return res;
 }
 
@@ -213,7 +213,7 @@ struct BNP2 {
 
 func BNP2_B() -> BNF2 {
     tempvar res = BNF2(
-        new Fp2Struct(
+        new Fq2Struct(
             U384(
                 new UInt384(
                     27810052284636130223308486885,
@@ -354,12 +354,12 @@ func bnp2_double{range_check96_ptr: felt*, add_mod_ptr: ModBuiltin*, mul_mod_ptr
     // Calculate 3x^2
     let (u384_zero) = get_label_location(U384_ZERO);
     let uint384_zero = cast(u384_zero, UInt384*);
-    tempvar three = BNF2(new Fp2Struct(U384(new UInt384(3, 0, 0, 0)), U384(uint384_zero)));
+    tempvar three = BNF2(new Fq2Struct(U384(new UInt384(3, 0, 0, 0)), U384(uint384_zero)));
     let x_squared = bnf2_mul(p.value.x, p.value.x);
     let three_x_squared = bnf2_mul(three, x_squared);
 
     // Calculate 2y
-    tempvar two = BNF2(new Fp2Struct(U384(new UInt384(2, 0, 0, 0)), U384(uint384_zero)));
+    tempvar two = BNF2(new Fq2Struct(U384(new UInt384(2, 0, 0, 0)), U384(uint384_zero)));
     let two_y = bnf2_mul(two, p.value.y);
     // Calculate λ = 3x^2 / 2y
     let lambda = bnf2_div(three_x_squared, two_y);

--- a/cairo/ethereum/crypto/alt_bn128.cairo
+++ b/cairo/ethereum/crypto/alt_bn128.cairo
@@ -11,7 +11,7 @@ from cairo_core.control_flow import raise
 from cairo_ec.circuits.mod_ops_compiled import add, sub, mul
 from cairo_ec.curve.alt_bn128 import alt_bn128
 from cairo_ec.curve.g1_point import G1Point, G1PointStruct
-from cairo_ec.curve.g2_point import Fq2, Fq2Struct, fp2_add
+from cairo_ec.curve.g2_point import Fq2, Fq2Struct, fq2_add, fq2_sub
 from cairo_ec.circuits.ec_ops_compiled import assert_on_curve
 from bn254.final_exp import final_exponentiation
 from definitions import E12D
@@ -96,8 +96,8 @@ func bnf2_add{range_check96_ptr: felt*, add_mod_ptr: ModBuiltin*, mul_mod_ptr: M
 ) -> BNF2 {
     tempvar modulus = U384(new UInt384(alt_bn128.P0, alt_bn128.P1, alt_bn128.P2, alt_bn128.P3));
 
-    let res_fp2 = fp2_add(Fq2(a.value), Fq2(b.value), modulus);
-    tempvar res = BNF2(res_fp2.value);
+    let res_fq2 = fq2_add(Fq2(a.value), Fq2(b.value), modulus);
+    tempvar res = BNF2(res_fq2.value);
 
     return res;
 }
@@ -125,10 +125,9 @@ func bnf2_sub{range_check96_ptr: felt*, add_mod_ptr: ModBuiltin*, mul_mod_ptr: M
 ) -> BNF2 {
     tempvar modulus = U384(new UInt384(alt_bn128.P0, alt_bn128.P1, alt_bn128.P2, alt_bn128.P3));
 
-    let res_c0 = sub(a.value.c0, b.value.c0, modulus);
-    let res_c1 = sub(a.value.c1, b.value.c1, modulus);
+    let res_fq2 = fq2_sub(Fq2(a.value), Fq2(b.value), modulus);
+    tempvar res = BNF2(res_fq2.value);
 
-    tempvar res = BNF2(new Fq2Struct(res_c0, res_c1));
     return res;
 }
 

--- a/cairo/ethereum/crypto/alt_bn128.cairo
+++ b/cairo/ethereum/crypto/alt_bn128.cairo
@@ -11,7 +11,7 @@ from cairo_core.control_flow import raise
 from cairo_ec.circuits.mod_ops_compiled import add, sub, mul
 from cairo_ec.curve.alt_bn128 import alt_bn128
 from cairo_ec.curve.g1_point import G1Point, G1PointStruct
-from cairo_ec.curve.g2_point import Fp2, Fp2Struct
+from cairo_ec.curve.g2_point import Fp2, Fp2Struct, fp2_add
 from cairo_ec.circuits.ec_ops_compiled import assert_on_curve
 from bn254.final_exp import final_exponentiation
 from definitions import E12D
@@ -96,12 +96,12 @@ func bnf2_add{range_check96_ptr: felt*, add_mod_ptr: ModBuiltin*, mul_mod_ptr: M
 ) -> BNF2 {
     tempvar modulus = U384(new UInt384(alt_bn128.P0, alt_bn128.P1, alt_bn128.P2, alt_bn128.P3));
 
-    let res_c0 = add(a.value.c0, b.value.c0, modulus);
-    let res_c1 = add(a.value.c1, b.value.c1, modulus);
+    let res_fp2 = fp2_add(Fp2(a.value), Fp2(b.value), modulus);
+    tempvar res = BNF2(res_fp2.value);
 
-    tempvar res = BNF2(new Fp2Struct(res_c0, res_c1));
     return res;
 }
+
 
 // Division of a by b is done by computing the modular inverse of b, verify it exists
 // and multiply a by this modular inverse.

--- a/cairo/ethereum/crypto/alt_bn128.cairo
+++ b/cairo/ethereum/crypto/alt_bn128.cairo
@@ -102,7 +102,6 @@ func bnf2_add{range_check96_ptr: felt*, add_mod_ptr: ModBuiltin*, mul_mod_ptr: M
     return res;
 }
 
-
 // Division of a by b is done by computing the modular inverse of b, verify it exists
 // and multiply a by this modular inverse.
 func bnf2_div{range_check96_ptr: felt*, add_mod_ptr: ModBuiltin*, mul_mod_ptr: ModBuiltin*}(

--- a/cairo/ethereum/crypto/alt_bn128.cairo
+++ b/cairo/ethereum/crypto/alt_bn128.cairo
@@ -11,6 +11,7 @@ from cairo_core.control_flow import raise
 from cairo_ec.circuits.mod_ops_compiled import add, sub, mul
 from cairo_ec.curve.alt_bn128 import alt_bn128
 from cairo_ec.curve.g1_point import G1Point, G1PointStruct
+from cairo_ec.curve.g2_point import Fp2, Fp2Struct
 from cairo_ec.circuits.ec_ops_compiled import assert_on_curve
 from bn254.final_exp import final_exponentiation
 from definitions import E12D
@@ -86,13 +87,8 @@ func bnf_sub{range_check96_ptr: felt*, add_mod_ptr: ModBuiltin*, mul_mod_ptr: Mo
 
 // Quadratic extension field of BNF.
 // BNF elements are 2-dimensional.
-struct BNF2Struct {
-    c0: U384,
-    c1: U384,
-}
-
 struct BNF2 {
-    value: BNF2Struct*,
+    value: Fp2Struct*,
 }
 
 func bnf2_add{range_check96_ptr: felt*, add_mod_ptr: ModBuiltin*, mul_mod_ptr: ModBuiltin*}(
@@ -103,7 +99,7 @@ func bnf2_add{range_check96_ptr: felt*, add_mod_ptr: ModBuiltin*, mul_mod_ptr: M
     let res_c0 = add(a.value.c0, b.value.c0, modulus);
     let res_c1 = add(a.value.c1, b.value.c1, modulus);
 
-    tempvar res = BNF2(new BNF2Struct(res_c0, res_c1));
+    tempvar res = BNF2(new Fp2Struct(res_c0, res_c1));
     return res;
 }
 
@@ -133,14 +129,14 @@ func bnf2_sub{range_check96_ptr: felt*, add_mod_ptr: ModBuiltin*, mul_mod_ptr: M
     let res_c0 = sub(a.value.c0, b.value.c0, modulus);
     let res_c1 = sub(a.value.c1, b.value.c1, modulus);
 
-    tempvar res = BNF2(new BNF2Struct(res_c0, res_c1));
+    tempvar res = BNF2(new Fp2Struct(res_c0, res_c1));
     return res;
 }
 
 func BNF2_ZERO() -> BNF2 {
     let (u384_zero) = get_label_location(U384_ZERO);
     let u384_zero_ptr = cast(u384_zero, UInt384*);
-    tempvar res = BNF2(new BNF2Struct(U384(u384_zero_ptr), U384(u384_zero_ptr)));
+    tempvar res = BNF2(new Fp2Struct(U384(u384_zero_ptr), U384(u384_zero_ptr)));
     return res;
 }
 
@@ -149,7 +145,7 @@ func BNF2_ONE() -> BNF2 {
     let (u384_one) = get_label_location(U384_ONE);
     let u384_zero_ptr = cast(u384_zero, UInt384*);
     let u384_one_ptr = cast(u384_one, UInt384*);
-    tempvar res = BNF2(new BNF2Struct(U384(u384_one_ptr), U384(u384_zero_ptr)));
+    tempvar res = BNF2(new Fp2Struct(U384(u384_one_ptr), U384(u384_zero_ptr)));
     return res;
 }
 
@@ -201,7 +197,7 @@ func bnf2_mul{range_check96_ptr: felt*, add_mod_ptr: ModBuiltin*, mul_mod_ptr: M
     // No reduction needed for res[1] = mul[1] in BNF2 with degree 2
     let res_c1 = mul_1;
 
-    tempvar res = BNF2(new BNF2Struct(res_c0, res_c1));
+    tempvar res = BNF2(new Fp2Struct(res_c0, res_c1));
     return res;
 }
 
@@ -218,7 +214,7 @@ struct BNP2 {
 
 func BNP2_B() -> BNF2 {
     tempvar res = BNF2(
-        new BNF2Struct(
+        new Fp2Struct(
             U384(
                 new UInt384(
                     27810052284636130223308486885,
@@ -359,12 +355,12 @@ func bnp2_double{range_check96_ptr: felt*, add_mod_ptr: ModBuiltin*, mul_mod_ptr
     // Calculate 3x^2
     let (u384_zero) = get_label_location(U384_ZERO);
     let uint384_zero = cast(u384_zero, UInt384*);
-    tempvar three = BNF2(new BNF2Struct(U384(new UInt384(3, 0, 0, 0)), U384(uint384_zero)));
+    tempvar three = BNF2(new Fp2Struct(U384(new UInt384(3, 0, 0, 0)), U384(uint384_zero)));
     let x_squared = bnf2_mul(p.value.x, p.value.x);
     let three_x_squared = bnf2_mul(three, x_squared);
 
     // Calculate 2y
-    tempvar two = BNF2(new BNF2Struct(U384(new UInt384(2, 0, 0, 0)), U384(uint384_zero)));
+    tempvar two = BNF2(new Fp2Struct(U384(new UInt384(2, 0, 0, 0)), U384(uint384_zero)));
     let two_y = bnf2_mul(two, p.value.y);
     // Calculate λ = 3x^2 / 2y
     let lambda = bnf2_div(three_x_squared, two_y);

--- a/python/cairo-ec/src/cairo_ec/curve/g2_point.cairo
+++ b/python/cairo-ec/src/cairo_ec/curve/g2_point.cairo
@@ -17,13 +17,11 @@ struct Fp2Struct {
 func fp2_add{range_check96_ptr: felt*, add_mod_ptr: ModBuiltin*, mul_mod_ptr: ModBuiltin*}(
     a: Fp2, b: Fp2, modulus: U384
 ) -> Fp2 {
-
     let res_c0 = add(a.value.c0, b.value.c0, modulus);
     let res_c1 = add(a.value.c1, b.value.c1, modulus);
 
     tempvar res = Fp2(new Fp2Struct(res_c0, res_c1));
     return res;
-
 }
 
 // A G2Point is a point on an elliptic curve over a quadratic extension field Fp2.

--- a/python/cairo-ec/src/cairo_ec/curve/g2_point.cairo
+++ b/python/cairo-ec/src/cairo_ec/curve/g2_point.cairo
@@ -1,4 +1,7 @@
+from starkware.cairo.common.cairo_builtins import ModBuiltin
+
 from cairo_core.numeric import U384
+from cairo_ec.circuits.mod_ops_compiled import add, sub, mul
 
 // A quadratic extension field of the finite field Fp.
 // a = c0 + i * c1
@@ -9,6 +12,18 @@ struct Fp2 {
 struct Fp2Struct {
     c0: U384,
     c1: U384,
+}
+
+func fp2_add{range_check96_ptr: felt*, add_mod_ptr: ModBuiltin*, mul_mod_ptr: ModBuiltin*}(
+    a: Fp2, b: Fp2, modulus: U384
+) -> Fp2 {
+
+    let res_c0 = add(a.value.c0, b.value.c0, modulus);
+    let res_c1 = add(a.value.c1, b.value.c1, modulus);
+
+    tempvar res = Fp2(new Fp2Struct(res_c0, res_c1));
+    return res;
+
 }
 
 // A G2Point is a point on an elliptic curve over a quadratic extension field Fp2.

--- a/python/cairo-ec/src/cairo_ec/curve/g2_point.cairo
+++ b/python/cairo-ec/src/cairo_ec/curve/g2_point.cairo
@@ -14,11 +14,21 @@ struct Fq2Struct {
     c1: U384,
 }
 
-func fp2_add{range_check96_ptr: felt*, add_mod_ptr: ModBuiltin*, mul_mod_ptr: ModBuiltin*}(
+func fq2_add{range_check96_ptr: felt*, add_mod_ptr: ModBuiltin*, mul_mod_ptr: ModBuiltin*}(
     a: Fq2, b: Fq2, modulus: U384
 ) -> Fq2 {
     let res_c0 = add(a.value.c0, b.value.c0, modulus);
     let res_c1 = add(a.value.c1, b.value.c1, modulus);
+
+    tempvar res = Fq2(new Fq2Struct(res_c0, res_c1));
+    return res;
+}
+
+func fq2_sub{range_check96_ptr: felt*, add_mod_ptr: ModBuiltin*, mul_mod_ptr: ModBuiltin*}(
+    a: Fq2, b: Fq2, modulus: U384
+) -> Fq2 {
+    let res_c0 = sub(a.value.c0, b.value.c0, modulus);
+    let res_c1 = sub(a.value.c1, b.value.c1, modulus);
 
     tempvar res = Fq2(new Fq2Struct(res_c0, res_c1));
     return res;

--- a/python/cairo-ec/src/cairo_ec/curve/g2_point.cairo
+++ b/python/cairo-ec/src/cairo_ec/curve/g2_point.cairo
@@ -1,0 +1,12 @@
+from cairo_core.numeric import U384
+
+// A quadratic extension field of the finite field Fp.
+// a = c0 + i * c1
+struct Fp2 {
+    value: Fp2Struct*,
+}
+
+struct Fp2Struct {
+    c0: U384,
+    c1: U384,
+}

--- a/python/cairo-ec/src/cairo_ec/curve/g2_point.cairo
+++ b/python/cairo-ec/src/cairo_ec/curve/g2_point.cairo
@@ -10,3 +10,14 @@ struct Fp2Struct {
     c0: U384,
     c1: U384,
 }
+
+// A G2Point is a point on an elliptic curve over a quadratic extension field Fp2.
+// Affine coordinates representation.
+struct G2Point {
+    value: G2PointStruct*,
+}
+
+struct G2PointStruct {
+    x: Fp2,
+    y: Fp2,
+}

--- a/python/cairo-ec/src/cairo_ec/curve/g2_point.cairo
+++ b/python/cairo-ec/src/cairo_ec/curve/g2_point.cairo
@@ -5,32 +5,32 @@ from cairo_ec.circuits.mod_ops_compiled import add, sub, mul
 
 // A quadratic extension field of the finite field Fp.
 // a = c0 + i * c1
-struct Fp2 {
-    value: Fp2Struct*,
+struct Fq2 {
+    value: Fq2Struct*,
 }
 
-struct Fp2Struct {
+struct Fq2Struct {
     c0: U384,
     c1: U384,
 }
 
 func fp2_add{range_check96_ptr: felt*, add_mod_ptr: ModBuiltin*, mul_mod_ptr: ModBuiltin*}(
-    a: Fp2, b: Fp2, modulus: U384
-) -> Fp2 {
+    a: Fq2, b: Fq2, modulus: U384
+) -> Fq2 {
     let res_c0 = add(a.value.c0, b.value.c0, modulus);
     let res_c1 = add(a.value.c1, b.value.c1, modulus);
 
-    tempvar res = Fp2(new Fp2Struct(res_c0, res_c1));
+    tempvar res = Fq2(new Fq2Struct(res_c0, res_c1));
     return res;
 }
 
-// A G2Point is a point on an elliptic curve over a quadratic extension field Fp2.
+// A G2Point is a point on an elliptic curve over a quadratic extension field Fq2.
 // Affine coordinates representation.
 struct G2Point {
     value: G2PointStruct*,
 }
 
 struct G2PointStruct {
-    x: Fp2,
-    y: Fp2,
+    x: Fq2,
+    y: Fq2,
 }


### PR DESCRIPTION
Closes #1184 

`alt_bn128` currently matches the EELS custom types `BNF2`, `BNP2`.
`point_evaluation` (so `kzg` uses the py_ecc library and the corresponding types `bls12_381_FQ2`..)

We need to match both these structures in Cairo, for proper diff-testing.
We'd like to avoid code duplication, so instead of copy/pasting the current `BNF2` and `BNP2` code, and update signature/modulus for BLS12-381, we considered having a more generic struct and associated functions field/curve operations with a quadratic extension field (Fq2, and G2Point).

But, it might actually be not needed, considering the smallness of the functions..
Also, for separation of concern between the various types (EELS, py_ecc...)

Note that py_ecc types used will differ from the ones we would implement (py_ecc uses projective space coordinates while we'll stay in affine coordinates space)