### PR TITLE
feat: enable garaga hints through RustVM

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -83,5 +83,14 @@
   "jupyter.notebookFileRoot": "${workspaceFolder}/cairo",
   "githubPullRequests.remotes": ["kakarot", "upstream"],
   "cairols.sourceDir": "cairo",
-  "rust-analyzer.cargo.features": "all"
+  "rust-analyzer.cargo.features": "all",
+  "cairols.venvCommand": ".venv/bin/activate",
+  "cairols.cairoPath": [
+    "cairo",
+    "python/cairo-ec/src",
+    "python/cairo-addons/src",
+    "python/cairo-core/src",
+    "python/mpt/src",
+    ".venv/lib/python3.10/site-packages/src"
+  ]
 }

--- a/cairo/tests/ethereum/crypto/test_alt_bn128.py
+++ b/cairo/tests/ethereum/crypto/test_alt_bn128.py
@@ -335,9 +335,9 @@ segments.load_data(ids.b_inv.address_, [bnf2_struct_ptr])
         @given(a=...)
         @settings(max_examples=10)
         @pytest.mark.slow
-        def test_bnf12_final_exponentiation(self, cairo_run_py, a: BNF12):
+        def test_bnf12_final_exponentiation(self, cairo_run, a: BNF12):
             assume(a != BNF12.zero())
-            assert cairo_run_py("bnf12_final_exponentiation", a) == a ** (
+            assert cairo_run("bnf12_final_exponentiation", a) == a ** (
                 ((ALT_BN128_PRIME**12 - 1) // ALT_BN128_CURVE_ORDER) * GARAGA_COFACTOR
             )
 
@@ -375,36 +375,33 @@ segments.load_data(ids.b_inv.address_, [bnf2_struct_ptr])
         @pytest.mark.slow
         # Currently, running on the Python CairoVM,
         # this test takes about 20 minutes per example...
-        def test_miller_loop(self, cairo_run_py, p: BNP12, q: BNP12):
+        def test_miller_loop(self, cairo_run, p: BNP12, q: BNP12):
             assume(p.x != BNF12.zero())
             assume(q.x != BNF12.zero())
             try:
                 expected = miller_loop(q, p) ** GARAGA_COFACTOR
             except OverflowError:  # fails for large points
                 with cairo_error(message="OverflowError"):  # Hint error
-                    cairo_run_py("miller_loop", q, p)
+                    cairo_run("miller_loop", q, p)
                 return
-            assert cairo_run_py("miller_loop", q, p) == expected
+            assert cairo_run("miller_loop", q, p) == expected
 
         @given(p=...)
         @settings(max_examples=10)
-        def test_miller_loop_zero(self, cairo_run_py, p: BNP12):
+        def test_miller_loop_zero(self, cairo_run, p: BNP12):
             q = BNP12(BNF12.zero(), BNF12.zero())
-            assert cairo_run_py("miller_loop", q, p) == BNF12.from_int(1)
-            assert cairo_run_py("miller_loop", p, q) == BNF12.from_int(1)
+            assert cairo_run("miller_loop", q, p) == BNF12.from_int(1)
+            assert cairo_run("miller_loop", p, q) == BNF12.from_int(1)
 
         @given(p=..., q=...)
-        @settings(max_examples=1)
         @pytest.mark.slow
-        # Currently, running on the Python CairoVM,
-        # this test takes about 20 minutes per example...
-        def test_pairing(self, cairo_run_py, p: BNP, q: BNP2):
+        def test_pairing(self, cairo_run, p: BNP, q: BNP2):
             assume(p.x != BNF.zero())
             assume(q.x != BNF2.zero())
             try:
                 expected = pairing(q, p) ** GARAGA_COFACTOR
             except OverflowError:  # fails for large points
                 with cairo_error(message="OverflowError"):  # Hint error
-                    cairo_run_py("pairing", q, p)
+                    cairo_run("pairing", q, p)
                 return
-            assert cairo_run_py("pairing", q, p) == expected
+            assert cairo_run("pairing", q, p) == expected

--- a/cairo/tests/ethereum/crypto/test_alt_bn128.py
+++ b/cairo/tests/ethereum/crypto/test_alt_bn128.py
@@ -13,7 +13,7 @@ from ethereum.crypto.alt_bn128 import (
     miller_loop,
     pairing,
 )
-from hypothesis import assume, given, settings
+from hypothesis import assume, given, reproduce_failure, settings
 
 from cairo_addons.testing.errors import cairo_error, strict_raises
 from cairo_addons.testing.hints import patch_hint
@@ -196,6 +196,7 @@ segments.load_data(ids.b_inv.address_, [bnf2_struct_ptr])
             assert cairo_run("bnp2_add", p, q) == p + q
 
         @given(p=..., n=...)
+        @pytest.mark.slow
         def test_bnp2_mul_by(self, cairo_run, p: BNP2, n: U384):
             assert cairo_run("bnp2_mul_by", p, n) == p.mul_by(int(n))
 
@@ -260,6 +261,7 @@ segments.load_data(ids.b_inv.address_, [bnf2_struct_ptr])
             assert cairo_result == a * b
 
         @given(a=..., b=...)
+        @settings(max_examples=30)
         @pytest.mark.slow
         def test_bnf12_pow(self, cairo_run, a: BNF12, b: U384):
             assert cairo_run("bnf12_pow", a, b) == a ** int(b)
@@ -319,6 +321,7 @@ segments.load_data(ids.b_inv.address_, [bnf2_struct_ptr])
 
         @given(p=..., n=...)
         @settings(max_examples=30)
+        @pytest.mark.slow
         def test_bnp12_mul_by(self, cairo_run, p: BNP12, n: U384):
             try:
                 expected = p.mul_by(int(n))
@@ -371,10 +374,12 @@ segments.load_data(ids.b_inv.address_, [bnf2_struct_ptr])
             assert cairo_run("linefunc", p1, p2, t) == expected
 
         @given(p=..., q=...)
-        @settings(max_examples=1)
+        @settings(max_examples=10)
         @pytest.mark.slow
-        # Currently, running on the Python CairoVM,
-        # this test takes about 20 minutes per example...
+        @reproduce_failure(
+            "6.128.2", b"AEECXyAm9N39CTY/GvYc/2lHES3hM3sK3MLjoH2tIBeYviBhRkECQiuP"
+        )
+        @pytest.xfail(reason="https://github.com/kkrt-labs/keth/issues/1217")
         def test_miller_loop(self, cairo_run, p: BNP12, q: BNP12):
             assume(p.x != BNF12.zero())
             assume(q.x != BNF12.zero())
@@ -387,13 +392,14 @@ segments.load_data(ids.b_inv.address_, [bnf2_struct_ptr])
             assert cairo_run("miller_loop", q, p) == expected
 
         @given(p=...)
-        @settings(max_examples=10)
+        @pytest.mark.slow
         def test_miller_loop_zero(self, cairo_run, p: BNP12):
             q = BNP12(BNF12.zero(), BNF12.zero())
             assert cairo_run("miller_loop", q, p) == BNF12.from_int(1)
             assert cairo_run("miller_loop", p, q) == BNF12.from_int(1)
 
         @given(p=..., q=...)
+        @settings(max_examples=10)
         @pytest.mark.slow
         def test_pairing(self, cairo_run, p: BNP, q: BNP2):
             assume(p.x != BNF.zero())

--- a/crates/cairo-addons/src/vm/mod.rs
+++ b/crates/cairo-addons/src/vm/mod.rs
@@ -9,6 +9,7 @@ mod hints;
 mod layout;
 mod maybe_relocatable;
 mod memory_segments;
+mod mod_builtin_runner;
 mod program;
 mod pythonic_hint;
 mod relocatable;
@@ -22,6 +23,7 @@ mod vm_consts;
 
 use dict_manager::{PyDictManager, PyDictTracker};
 use memory_segments::PyMemorySegmentManager;
+use mod_builtin_runner::PyModBuiltinRunner;
 use program::PyProgram;
 use relocatable::PyRelocatable;
 use relocated_trace::PyRelocatedTraceEntry;
@@ -44,5 +46,6 @@ fn vm(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_function(wrap_pyfunction!(runner::run_proof_mode, module)?).unwrap();
     module.add_class::<PyVmConst>()?;
     module.add_class::<PyVmConstsDict>()?;
+    module.add_class::<PyModBuiltinRunner>()?;
     Ok(())
 }

--- a/crates/cairo-addons/src/vm/mod_builtin_runner.rs
+++ b/crates/cairo-addons/src/vm/mod_builtin_runner.rs
@@ -1,0 +1,141 @@
+//! Python bindings for Cairo VM's `ModBuiltinRunner`.
+//!
+//! This module bridges Rust and Python via PyO3, managing complex lifetime and ownership
+//! scenarios. Notably, we use `Bound<'py, T>` to tie Python references to the GIL,
+//! extracting them early to ensure validity across calls - ensuring we can use a reference to the
+//! `ModBuiltinRunner` object throughout the lifetime of the `fill_memory` call.
+
+use cairo_vm::vm::runners::builtin_runner::ModBuiltinRunner;
+use pyo3::{
+    exceptions::{PyTypeError, PyValueError},
+    pyclass, pymethods,
+    types::{PyAny, PyAnyMethods, PyTuple},
+    Bound, FromPyObject, PyResult, Python,
+};
+
+use super::{memory_segments::PyMemoryWrapper, relocatable::PyRelocatable};
+
+/// Argument for `ModBuiltinRunner::fill_memory` function.
+///
+/// Holds GIL-bound references for safe lifetime management in Python-Rust interop.
+/// Fields are extracted from Python tuples and tied to the GIL via `Bound<'py, T>`.
+#[derive(Debug)]
+struct PyFillMemoryArgs<'py> {
+    rel: Bound<'py, PyRelocatable>,
+    runner: Bound<'py, PyModBuiltinRunner>,
+    size: usize,
+}
+
+/// Extracts the individual objects from of `PyFillMemoryArgs` into a tuple.
+impl<'py> FromPyObject<'py> for PyFillMemoryArgs<'py> {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+        // Ensure the input Python object is a tuple
+        let tuple = ob
+            .downcast::<PyTuple>()
+            .map_err(|_| PyTypeError::new_err("Argument must be a 3-tuple or None"))?;
+
+        // Should receive a tuple of length 3
+        let len = tuple.len()?;
+        if len != 3 {
+            return Err(PyValueError::new_err(format!("Expected a tuple of length 3, got {}", len)));
+        }
+
+        // Extract elements from the tuple:
+        // - Use downcast to get Bound references for pyclass types, so as to ensure they remain
+        //   valid for the duration of the `fill_memory` call.
+        // - Use extract for standard types like usize
+        let binding_rel = tuple.get_item(0)?;
+        let rel_bound = binding_rel.downcast::<PyRelocatable>().map_err(|e| {
+            PyTypeError::new_err(format!("Tuple element 0 is not PyRelocatable: {}", e))
+        })?;
+
+        let binding_runner = tuple.get_item(1)?;
+        let runner_bound = binding_runner.downcast::<PyModBuiltinRunner>().map_err(|e| {
+            PyTypeError::new_err(format!("Tuple element 1 is not PyModBuiltinRunner: {}", e))
+        })?;
+
+        let size = tuple
+            .get_item(2)?
+            .extract::<usize>()
+            .map_err(|e| PyTypeError::new_err(format!("Tuple element 2 is not usize: {}", e)))?;
+        Ok(PyFillMemoryArgs { rel: rel_bound.to_owned(), runner: runner_bound.to_owned(), size })
+    }
+}
+
+/// Python wrapper for `ModBuiltinRunner`.
+///
+/// Ensures thread-safety (`unsendable`) and immutability (`frozen`) in Python.
+#[pyclass(name = "ModBuiltinRunner", unsendable, frozen)]
+#[derive(Debug, Clone)]
+pub struct PyModBuiltinRunner {
+    pub inner: ModBuiltinRunner,
+}
+
+#[pymethods]
+impl PyModBuiltinRunner {
+    /// Fills memory with modular operations.
+    ///
+    /// # Arguments
+    /// - `memory`: Mutable memory wrapper.
+    /// - `add_mod`: Optional `(PyRelocatable, PyModBuiltinRunner, size)` tuple for addition.
+    /// - `mul_mod`: Optional `(PyRelocatable, PyModBuiltinRunner, size)` tuple for multiplication.
+    ///
+    /// # Notes
+    /// - Extracts references outside closures to extend lifetimes.
+    /// - Direct `fill_memory` call is a compatibility workaround - the recommended way is to use
+    /// the `vm` object instead.
+    #[pyo3(signature = (memory, add_mod=None, mul_mod=None))]
+    #[staticmethod]
+    fn fill_memory<'py>(
+        _py: Python<'py>,
+        memory: &PyMemoryWrapper,
+        add_mod: Option<PyFillMemoryArgs<'py>>,
+        mul_mod: Option<PyFillMemoryArgs<'py>>,
+    ) -> PyResult<()> {
+        let memory_inner = unsafe { &mut *memory.inner }; // Assuming memory.inner is *mut Memory
+
+        // Extract references with proper lifetime management.
+        let add_mod_runner_ref = add_mod
+            .as_ref()
+            .map(|args| (args.rel.get().inner, &args.runner.get().inner, args.size));
+        let mul_mod_runner_ref = mul_mod
+            .as_ref()
+            .map(|args| (args.rel.get().inner, &args.runner.get().inner, args.size));
+
+        // Note: It is not recommended to call fill_memory on the ModBuiltinRunner, directly, but
+        // because we're working in compatibility mode with python, we don't have access to
+        // the `vm` object here.
+        ModBuiltinRunner::fill_memory(memory_inner, add_mod_runner_ref, mul_mod_runner_ref)
+            .map_err(|e| PyValueError::new_err(format!("Error filling memory: {}", e)))?;
+
+        Ok(())
+    }
+
+    #[getter]
+    fn instance_def(&self) -> PyModBuiltinInstanceDef {
+        PyModBuiltinInstanceDef { ratio: self.inner.ratio(), batch_size: self.inner.batch_size() }
+    }
+}
+// A wrapper around the fields of the ModInstanceDef struct, which is private in the
+// ModBuiltinRunner struct. We need to expose these fields from `mod_builtin_runner.instance_def` to
+// the Python bindings. Note: word_bit_len is not included in the wrapper, because it is not
+// accessible (nor required, for now.)
+#[pyclass(name = "ModBuiltinInstanceDef", unsendable, frozen)]
+#[derive(Debug, Clone)]
+pub struct PyModBuiltinInstanceDef {
+    ratio: Option<u32>,
+    batch_size: usize,
+}
+
+#[pymethods]
+impl PyModBuiltinInstanceDef {
+    #[getter]
+    fn ratio(&self) -> Option<u32> {
+        self.ratio
+    }
+
+    #[getter]
+    fn batch_size(&self) -> usize {
+        self.batch_size
+    }
+}

--- a/crates/cairo-addons/src/vm/pythonic_hint.rs
+++ b/crates/cairo-addons/src/vm/pythonic_hint.rs
@@ -306,7 +306,13 @@ impl PythonicHintExecutor {
 
             // Run the hint code
             py.run(&hint_code_c_string, Some(bounded_context), None).map_err(|e| {
-                DynamicHintError::PythonExecution(e.traceback(py).unwrap().format().unwrap())
+                let traceback = e.traceback(py).unwrap();
+                let error_message = e.to_string();
+                DynamicHintError::PythonExecution(format!(
+                    "{}\nTraceback:\n{}",
+                    error_message,
+                    traceback.format().unwrap()
+                ))
             })?;
 
             Ok(())

--- a/crates/cairo-addons/src/vm/relocatable.rs
+++ b/crates/cairo-addons/src/vm/relocatable.rs
@@ -5,7 +5,7 @@ use pyo3::prelude::*;
 
 use super::maybe_relocatable::PyMaybeRelocatable;
 
-#[pyclass(name = "Relocatable")]
+#[pyclass(name = "Relocatable", frozen)]
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct PyRelocatable {
     pub(crate) inner: RustRelocatable,

--- a/crates/cairo-addons/src/vm/runner.rs
+++ b/crates/cairo-addons/src/vm/runner.rs
@@ -259,7 +259,7 @@ except Exception as e:
 
     #[getter]
     fn segments(&mut self) -> PyMemorySegmentManager {
-        PyMemorySegmentManager { vm: &mut self.inner.vm }
+        PyMemorySegmentManager { inner: &mut self.inner.vm.segments }
     }
 
     /// Loads data into memory at the specified base address.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ cairo-ec = { workspace = true }
 cairo-core = { workspace = true }
 eth-rpc = { workspace = true }
 mpt = { workspace = true }
-garaga-zero = { git = "https://github.com/kkrt-labs/garaga-zero" }
+garaga-zero = { git = "https://github.com/kkrt-labs/garaga-zero", rev = "c01503e804c36ab71d5aa46acb676603e79f5204" }
 
 [tool.uv.workspace]
 members = ["python/*"]

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version == '3.11.*'",
@@ -381,7 +382,7 @@ name = "blessed"
 version = "1.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jinxed", marker = "platform_system == 'Windows'" },
+    { name = "jinxed", marker = "sys_platform == 'win32'" },
     { name = "six" },
     { name = "wcwidth" },
 ]
@@ -728,7 +729,7 @@ name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
@@ -1353,7 +1354,7 @@ dependencies = [
 [[package]]
 name = "garaga-zero"
 version = "0.0.1"
-source = { git = "https://github.com/kkrt-labs/garaga-zero#091ef80efe9b0b29ff70a24f49b8f617c9dac288" }
+source = { git = "https://github.com/kkrt-labs/garaga-zero?rev=c01503e804c36ab71d5aa46acb676603e79f5204#c01503e804c36ab71d5aa46acb676603e79f5204" }
 dependencies = [
     { name = "cairo-lang" },
     { name = "garaga" },
@@ -1504,7 +1505,7 @@ name = "ipykernel"
 version = "6.29.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "appnope", marker = "platform_system == 'Darwin'" },
+    { name = "appnope", marker = "sys_platform == 'darwin'" },
     { name = "comm" },
     { name = "debugpy" },
     { name = "ipython", version = "8.34.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -1645,7 +1646,7 @@ name = "jinxed"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ansicon", marker = "platform_system == 'Windows'" },
+    { name = "ansicon", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/20/d0/59b2b80e7a52d255f9e0ad040d2e826342d05580c4b1d7d7747cfb8db731/jinxed-1.3.0.tar.gz", hash = "sha256:1593124b18a41b7a3da3b078471442e51dbad3d77b4d4f2b0c26ab6f7d660dbf", size = 80981 }
 wheels = [
@@ -1965,7 +1966,7 @@ requires-dist = [
     { name = "eth-rpc", editable = "python/eth-rpc" },
     { name = "ethereum" },
     { name = "garaga", git = "https://github.com/keep-starknet-strange/garaga.git?rev=hydra_upd" },
-    { name = "garaga-zero", git = "https://github.com/kkrt-labs/garaga-zero" },
+    { name = "garaga-zero", git = "https://github.com/kkrt-labs/garaga-zero?rev=c01503e804c36ab71d5aa46acb676603e79f5204" },
     { name = "marshmallow-dataclass", specifier = ">=8.6.1" },
     { name = "mpt", editable = "python/mpt" },
     { name = "pytest-randomly", specifier = ">=3.16.0" },
@@ -2896,8 +2897,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/39/1b/d0b013bf7d1af7cf0a6a4fce13f5fe5813ab225313755367b36e714a63f8/pycryptodome-3.21.0-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:18caa8cfbc676eaaf28613637a89980ad2fd96e00c564135bf90bc3f0b34dd93", size = 2254397 },
     { url = "https://files.pythonhosted.org/packages/14/71/4cbd3870d3e926c34706f705d6793159ac49d9a213e3ababcdade5864663/pycryptodome-3.21.0-cp36-abi3-win32.whl", hash = "sha256:280b67d20e33bb63171d55b1067f61fbd932e0b1ad976b3a184303a3dad22764", size = 1775641 },
     { url = "https://files.pythonhosted.org/packages/43/1d/81d59d228381576b92ecede5cd7239762c14001a828bdba30d64896e9778/pycryptodome-3.21.0-cp36-abi3-win_amd64.whl", hash = "sha256:b7aa25fc0baa5b1d95b7633af4f5f1838467f1815442b22487426f94e0d66c53", size = 1812863 },
-    { url = "https://files.pythonhosted.org/packages/25/b3/09ff7072e6d96c9939c24cf51d3c389d7c345bf675420355c22402f71b68/pycryptodome-3.21.0-pp27-pypy_73-manylinux2010_x86_64.whl", hash = "sha256:2cb635b67011bc147c257e61ce864879ffe6d03342dc74b6045059dfbdedafca", size = 1691593 },
-    { url = "https://files.pythonhosted.org/packages/a8/91/38e43628148f68ba9b68dedbc323cf409e537fd11264031961fd7c744034/pycryptodome-3.21.0-pp27-pypy_73-win32.whl", hash = "sha256:4c26a2f0dc15f81ea3afa3b0c87b87e501f235d332b7f27e2225ecb80c0b1cdd", size = 1765997 },
     { url = "https://files.pythonhosted.org/packages/08/16/ae464d4ac338c1dd41f89c41f9488e54f7d2a3acf93bb920bb193b99f8e3/pycryptodome-3.21.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:d5ebe0763c982f069d3877832254f64974139f4f9655058452603ff559c482e8", size = 1615855 },
     { url = "https://files.pythonhosted.org/packages/1e/8c/b0cee957eee1950ce7655006b26a8894cee1dc4b8747ae913684352786eb/pycryptodome-3.21.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ee86cbde706be13f2dec5a42b52b1c1d1cbb90c8e405c68d0755134735c8dc6", size = 1650018 },
     { url = "https://files.pythonhosted.org/packages/93/4d/d7138068089b99f6b0368622e60f97a577c936d75f533552a82613060c58/pycryptodome-3.21.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0fd54003ec3ce4e0f16c484a10bc5d8b9bd77fa662a12b85779a2d2d85d67ee0", size = 1687977 },
@@ -3959,7 +3958,7 @@ dependencies = [
     { name = "hexbytes" },
     { name = "pydantic" },
     { name = "pyunormalize" },
-    { name = "pywin32", marker = "platform_system == 'Windows'" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "requests" },
     { name = "types-requests" },
     { name = "typing-extensions" },


### PR DESCRIPTION
### PR Summary

#### Key Changes
- **VSCode Settings**: Added `cairols.venvCommand` and expanded `cairols.cairoPath` to include multiple Python source dirs, required for the LS to work with Garaga
- **Test Updates**: Replaced `cairo_run_py` with `cairo_run` in `test_alt_bn128.py`, using the RustVM instead of PythoNVM. Removed outdated performance comments and adjusted test settings (e.g., dropped `max_examples=1`).
- **Memory Management**: Refactored `PyMemorySegmentManager` and `PyMemoryWrapper` in `memory_segments.rs` to use raw pointers to `MemorySegmentManager` and `Memory` directly, bypassing `VirtualMachine`. Added a custom `memory_get` helper to handle relocatable/integer retrieval until upstream PR on cairo-vm merges.
- **ModBuiltinRunner**: Introduced `mod_builtin_runner.rs` with Python bindings for `ModBuiltinRunner`. Extracts references outside closures for lifetime safety, uses `Bound<'py, T>` for GIL-bound refs, and exposes it via `builtin_runners` dict in `pythonic_hint.rs`.
- **Hint Adjustments**: In `pythonic_hint.rs`, updated `PythonCodeInjector` to take `hint_code` and added a `replace_hint_code_chunk` method to swap Python `ModBuiltinRunner` imports with Rust bindings.

#### Patterns Used
- **Raw Pointers**: Shifted from `VirtualMachine` wrappers to direct `*mut` access for finer control and compatibility with new VM structures.
- **Lifetime Management**: Extracted GIL-bound references early (e.g., in `fill_memory`) to ensure validity across Rust-Python calls, avoiding closure lifetime issues.
- **Error Propagation**: Consistently used `PyResult` with descriptive errors for Python-side exception handling.

#### Notes
- Speeds up tests for ecpairing by leveraging Rust VM backend.