### PR TITLE
feat: support accessing scope constants in rust hints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,7 +837,7 @@ dependencies = [
 [[package]]
 name = "cairo-vm"
 version = "2.0.1"
-source = "git+https://github.com/kkrt-labs/cairo-vm?rev=d101ee86d21a80db7b2dd17ffeca12025371cc1e#d101ee86d21a80db7b2dd17ffeca12025371cc1e"
+source = "git+https://github.com/kkrt-labs/cairo-vm?rev=008360a818ac3cecb51666d89e68abaf4fe8e151#008360a818ac3cecb51666d89e68abaf4fe8e151"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ cairo-vm = { git = "https://github.com/lambdaclass/cairo-vm.git", tag = "v2.0.0-
 ] }
 
 [patch."https://github.com/lambdaclass/cairo-vm.git"]
-cairo-vm = { git = "https://github.com/kkrt-labs/cairo-vm", rev = "d101ee86d21a80db7b2dd17ffeca12025371cc1e" }
+cairo-vm = { git = "https://github.com/kkrt-labs/cairo-vm", rev = "008360a818ac3cecb51666d89e68abaf4fe8e151" }
 
 [patch.crates-io]
 stwo-cairo-adapter = { git = "https://github.com/starkware-libs/stwo-cairo", rev = "c9a4ea197077c07df218bf0e088a636db052525d" }

--- a/cairo/tests/test_hint_runner.cairo
+++ b/cairo/tests/test_hint_runner.cairo
@@ -1,7 +1,6 @@
 from ethereum_types.numeric import U256, U256Struct
 from starkware.cairo.common.alloc import alloc
 
-from cairo_ec.curve.alt_bn128 import alt_bn128
 from ethereum.exceptions import ValueError
 
 func test__ap_accessible() {

--- a/cairo/tests/test_hint_runner.cairo
+++ b/cairo/tests/test_hint_runner.cairo
@@ -1,6 +1,9 @@
 from ethereum_types.numeric import U256, U256Struct
 from starkware.cairo.common.alloc import alloc
 
+from cairo_ec.curve.alt_bn128 import alt_bn128
+from ethereum.exceptions import ValueError
+
 func test__ap_accessible() {
     tempvar x = 100;
     %{ assert memory[ap-1] == 100 %}
@@ -128,5 +131,21 @@ func test__access_let_relocatable() {
         # simple access
         ids.x
     %}
+    ret;
+}
+
+const MY_CONST = 100;
+func test__access_local_const() {
+    %{ assert ids.MY_CONST == 100 %}
+    ret;
+}
+
+func test__access_non_imported_const_should_fail() {
+    %{ ids.HALF_SHIFT %}
+    ret;
+}
+
+func test__access_imported_const() {
+    %{ assert ids.ValueError == int.from_bytes('ValueError'.encode("ascii"), "big") %}
     ret;
 }

--- a/cairo/tests/test_hint_runner.py
+++ b/cairo/tests/test_hint_runner.py
@@ -70,3 +70,17 @@ class TestRunner:
     def test__access_let_relocatable(self, cairo_run, cairo_run_py):
         cairo_run("test__access_let_relocatable")
         cairo_run_py("test__access_let_relocatable")
+
+    def test__access_const(self, cairo_run, cairo_run_py):
+        cairo_run("test__access_local_const")
+        cairo_run_py("test__access_local_const")
+
+    def test__access_non_imported_const_should_fail(self, cairo_run, cairo_run_py):
+        with pytest.raises(Exception):
+            cairo_run("test__access_non_imported_const_should_fail")
+        with pytest.raises(Exception):
+            cairo_run_py("test__access_non_imported_const_should_fail")
+
+    def test__access_imported_const(self, cairo_run, cairo_run_py):
+        cairo_run("test__access_imported_const")
+        cairo_run_py("test__access_imported_const")

--- a/crates/cairo-addons/src/vm/hints.rs
+++ b/crates/cairo-addons/src/vm/hints.rs
@@ -167,6 +167,12 @@ impl HintProcessorLogic for HintProcessor {
                     }
                     exec_scopes.assign_or_update_variable("__hint_code__", Box::new(hint_code));
 
+                    // Dump the accessible scopes in an execution scope object to access in the hint
+                    let hint_accessible_scopes = hint_data.accessible_scopes.clone();
+                    exec_scopes.assign_or_update_variable(
+                        "__hint_accessible_scopes__",
+                        Box::new(hint_accessible_scopes),
+                    );
                     // Execute the dynamic hint
                     let pythonic_hint_func = pythonic_hint_func.0.as_ref();
                     let dynamic_result = pythonic_hint_func(


### PR DESCRIPTION
Closes #1191

Uses the newly added hint data in the cairo vm to resolve the imported constants ("alias") and the local constant, making them available in the `ids` object.