### PR TITLE
ci: use shared rust-cache key

### DIFF
--- a/.github/actions/setup-environment/action.yaml
+++ b/.github/actions/setup-environment/action.yaml
@@ -32,6 +32,7 @@ runs:
       uses: Swatinem/rust-cache@v2
       with:
         cache-on-failure: ${{ inputs.cache-on-failure }}
+        shared-key: "rust-cache"
 
     - name: Setup uv
       uses: astral-sh/setup-uv@v3

--- a/.github/workflows/rust_tests.yml
+++ b/.github/workflows/rust_tests.yml
@@ -20,6 +20,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: "true"
+          shared-key: "rust-cache"
 
       - name: Run tests
         run: cargo test --all-features


### PR DESCRIPTION
As per https://github.com/Swatinem/rust-cache the `shared-key` option overrides the default job-based key, so that rust caches can be reused among jobs. This should significantly reduce the size of rust caches, which should be divided by 3 (ef-tests, python_unit, rust_unit) 