### PR TITLE
feat: decompress g2

### DIFF
--- a/cairo/ethereum/crypto/bls12_381.cairo
+++ b/cairo/ethereum/crypto/bls12_381.cairo
@@ -427,6 +427,19 @@ func blsp_mul_by_bits{
     return blsp_mul_by_bits(doubled_p, bits_ptr, bits_len, current_bit + 1, new_result);
 }
 
+// G2Compressed is the Cairo equivalent of Tuple[int, int] from py_ecc.
+// Where each int is 48 bytes long.
+struct G2CompressedStruct {
+    c0: U384,
+    c1: U384,
+}
+
+struct G2Compressed {
+    value: G2CompressedStruct*,
+}
+
+using G2Uncompressed = BLSP2;
+
 // BLSP2 represents a point on the BLSP2 curve
 // BLSF2 is the base field of the curve
 struct BLSP2Struct {

--- a/cairo/ethereum/crypto/kzg.cairo
+++ b/cairo/ethereum/crypto/kzg.cairo
@@ -160,7 +160,9 @@ func decompress_G1{
     }
 
     // Check if the point is at infinity
-    tempvar zero_u384 = OptionalU384(new U384Struct(0, 0, 0, 0));
+    let (u384_zero) = get_label_location(U384_ZERO);
+    let u384_zero_ptr = cast(u384_zero, UInt384*);
+    tempvar zero_u384 = OptionalU384(u384_zero_ptr);
     let is_inf_pt = is_point_at_infinity(z, zero_u384);
 
     // Validate b_flag
@@ -169,7 +171,7 @@ func decompress_G1{
     }
 
     // If point is at infinity
-    if (is_inf_pt.value == 1) {
+    if (is_inf_pt.value != 0) {
         // Validate a_flag is 0
         with_attr error_message("ValueError") {
             assert a_flag.value = 0;

--- a/cairo/tests/test_serde.py
+++ b/cairo/tests/test_serde.py
@@ -62,6 +62,8 @@ from tests.utils.args_gen import (
     AddressAccountDiffEntry,
     G1Compressed,
     G1Uncompressed,
+    G2Compressed,
+    G2Uncompressed,
     Memory,
     Stack,
     StorageDiffEntry,
@@ -128,7 +130,7 @@ def get_type(instance: Any) -> Type:
 
     if isinstance(
         instance,
-        (BNF2, BNF12, BNF, BNP, BNP2, BNP12, BLSF, BLSF2, G1Compressed),
+        (BNF2, BNF12, BNF, BNP, BNP2, BNP12, BLSF, BLSF2, G1Compressed, G2Compressed),
     ):
         return instance.__class__
 
@@ -344,6 +346,8 @@ class TestSerde:
             Optimized_Point3D[BLSF2],
             G1Compressed,
             G1Uncompressed,
+            G2Compressed,
+            G2Uncompressed,
         ],
     ):
         assume(no_empty_sequence(b))

--- a/cairo/tests/utils/serde.py
+++ b/cairo/tests/utils/serde.py
@@ -88,6 +88,7 @@ from tests.utils.args_gen import (
     FlatState,
     FlatTransientStorage,
     G1Compressed,
+    G2Compressed,
     Memory,
     MutableBloom,
     Stack,
@@ -456,7 +457,7 @@ class Serde:
             # The BNF and BLSF constructors accept int only, not tuples or U384.
             return python_cls(int(value["c0"]))
 
-        if python_cls in (BNF2, BNF12, BLSF2):
+        if python_cls in (BNF2, BNF12, BLSF2, G2Compressed):
             # The BNF<N> and BLSF<N> constructors don't accept named tuples
             # and values are integers, not U384.
             values = [int(v) for v in value.values()]

--- a/cairo/tests/utils/strategies.py
+++ b/cairo/tests/utils/strategies.py
@@ -64,7 +64,7 @@ from py_ecc.bls.hash_to_curve import (
     map_to_curve_G1,
     map_to_curve_G2,
 )
-from py_ecc.bls.point_compression import compress_G1
+from py_ecc.bls.point_compression import compress_G1, compress_G2
 from py_ecc.fields import optimized_bls12_381_FQ as BLSF
 from py_ecc.fields import optimized_bls12_381_FQ2 as BLSF2
 from py_ecc.optimized_bls12_381.optimized_curve import Z1, Z2
@@ -83,6 +83,7 @@ from tests.utils.args_gen import (  # noqa
     Environment,
     Evm,
     G1Compressed,
+    G2Compressed,
     Memory,
     Message,
     MutableBloom,
@@ -265,6 +266,7 @@ blsp2_strategy = st.one_of(
 )
 
 blsG1_compressed = blsp_strategy.map(compress_G1).map(G1Compressed)
+bls_g2_compressed = blsp2_strategy.map(compress_G2).map(G2Compressed)
 
 
 def tuple_strategy(thing):
@@ -826,3 +828,4 @@ def register_type_strategies():
     st.register_type_strategy(KZGCommitment, bytes48.map(KZGCommitment))
     st.register_type_strategy(Bytes48, bytes48)
     st.register_type_strategy(G1Compressed, blsG1_compressed)
+    st.register_type_strategy(G2Compressed, bls_g2_compressed)

--- a/python/cairo-addons/src/cairo_addons/hints/crypto.py
+++ b/python/cairo-addons/src/cairo_addons/hints/crypto.py
@@ -154,3 +154,33 @@ def decompress_G1_hint(ids: VmConsts, segments: MemorySegmentManager):
     blsf_y_struct_ptr = segments.add()
     segments.load_data(blsf_y_struct_ptr, [y_ptr])
     segments.load_data(ids.y_blsf.address_, [blsf_y_struct_ptr])
+
+
+@register_hint
+def decompress_g2_hint(ids: VmConsts, segments: MemorySegmentManager):
+    from py_ecc.bls.point_compression import decompress_G2
+    from py_ecc.bls.typing import G2Compressed
+    from py_ecc.optimized_bls12_381.optimized_curve import normalize
+
+    from cairo_addons.utils.uint384 import int_to_uint384, uint384_to_int
+
+    z1 = uint384_to_int(
+        ids.z.value.c0.value.d0,
+        ids.z.value.c0.value.d1,
+        ids.z.value.c0.value.d2,
+        ids.z.value.c0.value.d3,
+    )
+    z2 = uint384_to_int(
+        ids.z.value.c1.value.d0,
+        ids.z.value.c1.value.d1,
+        ids.z.value.c1.value.d2,
+        ids.z.value.c1.value.d3,
+    )
+    point = normalize(decompress_G2(G2Compressed((z1, z2))))
+    y = point[1]
+    y_c0_ptr = segments.gen_arg(int_to_uint384(y.coeffs[0]))
+    y_c1_ptr = segments.gen_arg(int_to_uint384(y.coeffs[1]))
+    # breakpoint()
+    blsf2_y_struct_ptr = segments.add()
+    segments.load_data(blsf2_y_struct_ptr, [y_c0_ptr, y_c1_ptr])
+    segments.load_data(ids.y_blsf2.address_, [blsf2_y_struct_ptr])


### PR DESCRIPTION
Closes #1180 
Closes #1182 

The `decompress_g2_hint` calls `decompress_G2` from py_ecc, which computes the modular square root of $`x^3 + b`$ in $`\mathbb{F}_q^2`$ and chooses the "right" `y` among the two possibilities.

This specific part (modular sqrt + choosing y) could be inlined, but previous checks are not expensive and provides additional checks on the input values of the hint.