### PR TITLE
dev: allow small decrease in coverage on ethereum_rlp

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -10,6 +10,7 @@ coverage:
       ethereum_rlp:
         paths:
           - cairo/ethereum_rlp
+        threshold: 1.5%
       ethereum_types:
         paths:
           - cairo/ethereum_types

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,16 +1,19 @@
+codecov:
+  notify:
+    wait_for_ci: true
+
 coverage:
   status:
     project: #add everything under here, more options at https://docs.codecov.com/docs/commit-status
       default:
         target: auto
-        threshold: 0%
+        threshold: 2%
       ethereum:
         paths:
           - cairo/ethereum
       ethereum_rlp:
         paths:
           - cairo/ethereum_rlp
-        threshold: 1.5%
       ethereum_types:
         paths:
           - cairo/ethereum_types
@@ -26,3 +29,7 @@ coverage:
       mpt:
         paths:
           - python/mpt
+    patch:
+      default:
+        target: 90%
+        threshold: 0%


### PR DESCRIPTION
closes #1198 

strategy choice (very lean strategy, can be improved later):
- allow for slight decrease in coverage for ethereum_rlp package (indirect decrease) as I've noticed that over the last 5 PRs, the CI fails from an indirect decrease in coverage of ethereum_rlp package due to fuzzing framework being random