### PR TITLE
feat: Improve jumpdest_check_push_last_32_bytes rust hint

### DIFF
--- a/crates/cairo-addons/src/vm/hint_definitions/utils.rs
+++ b/crates/cairo-addons/src/vm/hint_definitions/utils.rs
@@ -323,13 +323,12 @@ pub fn jumpdest_check_push_last_32_bytes() -> Hint {
             // Build a vector of bytes from the range [bytecode_data_addr + valid_jumpdest_key - i -
             // 1] for i belonging to [0, max_len - 1]
             let bytecode_start_addr = (bytecode_data_addr + valid_jumpdest_key)?;
-            let last_32_bytes: Vec<u8> = (0..max_len)
+            let last_32_bytes = (0..max_len)
                 .map(|i| {
                     let value_addr = ((bytecode_start_addr - i).unwrap() - 1).unwrap();
-                    vm.get_integer(value_addr).map(|b| b.into_owned()).unwrap()
+                    vm.get_integer(value_addr).unwrap().into_owned().try_into().unwrap()
                 })
-                .map(|b| b.try_into().unwrap())
-                .collect::<Vec<_>>();
+                .collect::<Vec<u8>>();
 
             // Check if any PUSH may prevent this to be a JUMPDEST
             let is_no_push_case = !last_32_bytes.iter().enumerate().any(|(i, &byte)| {

--- a/crates/cairo-addons/src/vm/hint_definitions/utils.rs
+++ b/crates/cairo-addons/src/vm/hint_definitions/utils.rs
@@ -320,8 +320,8 @@ pub fn jumpdest_check_push_last_32_bytes() -> Hint {
             let bytecode_addr = get_ptr_from_var_name("bytecode", vm, ids_data, ap_tracking)?;
             let bytecode_data_addr = vm.get_relocatable(bytecode_addr)?;
 
-            // For each byte at address (bytecode_start_addr - i, i = 0..max_len),
-            // get the value and convert it to a u8, then collect the bytes into a vector
+            // Build a vector of bytes from the range [bytecode_data_addr + valid_jumpdest_key - i -
+            // 1] for i belonging to [0, max_len - 1]
             let bytecode_start_addr = (bytecode_data_addr + valid_jumpdest_key)?;
             let last_32_bytes: Vec<u8> = (0..max_len)
                 .map(|i| {
@@ -331,6 +331,7 @@ pub fn jumpdest_check_push_last_32_bytes() -> Hint {
                 .map(|b| b.try_into().unwrap())
                 .collect::<Vec<_>>();
 
+            // Check if any PUSH may prevent this to be a JUMPDEST
             let is_no_push_case = !last_32_bytes.iter().enumerate().any(|(i, &byte)| {
                 // Check if the byte is within the PUSH opcode range for its position (0x60 + i to
                 // 0x7f)

--- a/crates/cairo-addons/src/vm/hint_definitions/utils.rs
+++ b/crates/cairo-addons/src/vm/hint_definitions/utils.rs
@@ -322,10 +322,10 @@ pub fn jumpdest_check_push_last_32_bytes() -> Hint {
 
             // Build a vector of bytes from the range [bytecode_data_addr + valid_jumpdest_key - i -
             // 1] for i belonging to [0, max_len - 1]
-            let bytecode_start_addr = (bytecode_data_addr + valid_jumpdest_key)?;
+            let bytecode_start_addr = ((bytecode_data_addr + valid_jumpdest_key)? - 1)?;
             let last_32_bytes = (0..max_len)
                 .map(|i| {
-                    let value_addr = ((bytecode_start_addr - i).unwrap() - 1).unwrap();
+                    let value_addr = (bytecode_start_addr - i).unwrap();
                     vm.get_integer(value_addr).unwrap().into_owned().try_into().unwrap()
                 })
                 .collect::<Vec<u8>>();

--- a/crates/cairo-addons/src/vm/hint_definitions/utils.rs
+++ b/crates/cairo-addons/src/vm/hint_definitions/utils.rs
@@ -320,17 +320,15 @@ pub fn jumpdest_check_push_last_32_bytes() -> Hint {
             let bytecode_addr = get_ptr_from_var_name("bytecode", vm, ids_data, ap_tracking)?;
             let bytecode_data_addr = vm.get_relocatable(bytecode_addr)?;
 
-            // For each byte at address (bytecode_start_addr + i, i = 0..max_len),
+            // For each byte at address (bytecode_start_addr - i, i = 0..max_len),
             // get the value and convert it to a u8, then collect the bytes into a vector
-            let bytecode_start_addr =
-                (((bytecode_data_addr + valid_jumpdest_key)? - max_len)? - 1)?;
+            let bytecode_start_addr = (bytecode_data_addr + valid_jumpdest_key)?;
             let last_32_bytes: Vec<u8> = (0..max_len)
                 .map(|i| {
-                    let value_addr = (bytecode_start_addr + i).unwrap();
+                    let value_addr = ((bytecode_start_addr - i).unwrap() - 1).unwrap();
                     vm.get_integer(value_addr).map(|b| b.into_owned()).unwrap()
                 })
                 .map(|b| b.try_into().unwrap())
-                .rev()
                 .collect::<Vec<_>>();
 
             let is_no_push_case = !last_32_bytes.iter().enumerate().any(|(i, &byte)| {


### PR DESCRIPTION
Closes #1295 

New flamegraph: (jumpdest_check_push_last_32_bytes has now approx. ~0.01% of total samples of the program (same block)

![flamegraph](https://github.com/user-attachments/assets/3f9e3c60-59f1-46a0-ab9d-8e0e3b9e6520)


## Execution time

```
(master) $ cargo clean; uv run --reinstall compile_keth; time uv run prove-block 22223972
uv run prove-block 22223972  **63.86s user 19.82s system 90% cpu 1:32.89 total**

(feat/simplify_jumpdest_check_push_last_32_bytes) $ cargo clean; uv run --reinstall compile_keth; time uv run prove-block 22223972
uv run prove-block 22223972  **60.70s user 19.12s system 89% cpu 1:28.81 total**
```