### PR TITLE
Feat/ext subnode not extension

### DIFF
--- a/python/mpt/src/mpt/trie_diff.cairo
+++ b/python/mpt/src/mpt/trie_diff.cairo
@@ -575,8 +575,8 @@ func compute_diff_entrypoint{
 // @implicit storage_tries_end Passed down to record storage diffs.
 // @param left The node (or reference) from the previous state's trie.
 // @param right The node (or reference) from the current state's trie.
-// @param parent_left The parent of the left node.
-// @param parent_right The parent of the right node.
+// @param parent_left The parent of the left node. Used to ensure the trie traversed is well-formed.
+// @param parent_right The parent of the right node. Used to ensure the trie traversed is well-formed.
 // @param path The path (sequence of nibbles) traversed so far in the trie.
 // @param account_address The account address if processing a storage trie, otherwise 0.
 // @return Recursively updates diff lists via helper functions.

--- a/python/mpt/src/mpt/trie_diff.cairo
+++ b/python/mpt/src/mpt/trie_diff.cairo
@@ -1613,14 +1613,16 @@ func _compute_left_branch_node_diff_on_right_extension_node{
 
     let right_extension = right.value.extension_node;
     let first_nib = right_extension.value.key_segment.value.data[0];
+    local node_to_compare: OptionalUnionInternalNodeExtended;
+    local current_parent_right: OptionalInternalNode;
     if (first_nib == index) {
         // Fully consumed by this nibble: compare to the subnode
         if (right_extension.value.key_segment.value.len == 1) {
             let node_to_compare_ = OptionalUnionInternalNodeExtendedImpl.from_extended(
                 right_extension.value.subnode
             );
-            tempvar current_parent_right = right;
-            tempvar node_to_compare = node_to_compare_;
+            assert current_parent_right = right;
+            assert node_to_compare = node_to_compare_;
         } else {
             // Compare to the shortened extension node
             tempvar shortened_extension = ExtensionNode(
@@ -1637,30 +1639,20 @@ func _compute_left_branch_node_diff_on_right_extension_node{
             let node_to_compare_ = OptionalUnionInternalNodeExtendedImpl.from_extension(
                 shortened_extension
             );
-            tempvar current_parent_right = parent_right;
-            tempvar node_to_compare = node_to_compare_;
+            assert current_parent_right = parent_right;
+            assert node_to_compare = node_to_compare_;
         }
-        let current_parent_right_ = OptionalInternalNode(cast([ap - 2], InternalNodeEnum*));
-        let right_ = OptionalUnionInternalNodeExtended(
-            cast([ap - 1], OptionalUnionInternalNodeExtendedEnum*)
-        );
-        tempvar current_parent_left = current_parent_right_;
-        tempvar right_to_compare_in_iter = right_;
     } else {
         // Compare to None
-        tempvar current_parent_right = parent_right;
-        tempvar right_to_compare_in_iter = OptionalUnionInternalNodeExtended(
+        assert current_parent_right = parent_right;
+        assert node_to_compare = OptionalUnionInternalNodeExtended(
             cast(0, OptionalUnionInternalNodeExtendedEnum*)
         );
     }
-    let current_parent_right = OptionalInternalNode(cast([ap - 2], InternalNodeEnum*));
-    let right_to_compare_in_iter = OptionalUnionInternalNodeExtended(
-        cast([ap - 1], OptionalUnionInternalNodeExtendedEnum*)
-    );
 
     _compute_diff(
         left=subnode_i,
-        right=right_to_compare_in_iter,
+        right=node_to_compare,
         parent_left=parent_left,
         parent_right=current_parent_right,
         path=sub_path,
@@ -1924,14 +1916,16 @@ func _compute_left_extension_node_diff_on_right_branch_node{
 
     let l_extension = left.value.extension_node;
     let first_nib = l_extension.value.key_segment.value.data[0];
+    local node_to_compare: OptionalUnionInternalNodeExtended;
+    local current_parent_left: OptionalInternalNode;
     if (first_nib == index) {
         // Fully consumed by this nibble: compare to the subnode
         if (l_extension.value.key_segment.value.len == 1) {
             let node_to_compare_ = OptionalUnionInternalNodeExtendedImpl.from_extended(
                 l_extension.value.subnode
             );
-            tempvar current_parent_left = left;
-            tempvar node_to_compare = node_to_compare_;
+            assert current_parent_left = left;
+            assert node_to_compare = node_to_compare_;
         } else {
             // Compare to the shortened extension node
             tempvar shortened_extension = ExtensionNode(
@@ -1948,29 +1942,19 @@ func _compute_left_extension_node_diff_on_right_branch_node{
             let node_to_compare_ = OptionalUnionInternalNodeExtendedImpl.from_extension(
                 shortened_extension
             );
-            tempvar current_parent_left = parent_left;
-            tempvar node_to_compare = node_to_compare_;
+            assert current_parent_left = parent_left;
+            assert node_to_compare = node_to_compare_;
         }
-        let current_parent_left_ = OptionalInternalNode(cast([ap - 2], InternalNodeEnum*));
-        let left_ = OptionalUnionInternalNodeExtended(
-            cast([ap - 1], OptionalUnionInternalNodeExtendedEnum*)
-        );
-        tempvar current_parent_left = current_parent_left_;
-        tempvar left_to_compare_in_iter = left_;
     } else {
         // Compare to None
-        tempvar current_parent_left = parent_left;
-        tempvar left_to_compare_in_iter = OptionalUnionInternalNodeExtended(
+        assert current_parent_left = parent_left;
+        assert node_to_compare = OptionalUnionInternalNodeExtended(
             cast(0, OptionalUnionInternalNodeExtendedEnum*)
         );
     }
-    let current_parent_left = OptionalInternalNode(cast([ap - 2], InternalNodeEnum*));
-    let left_to_compare_in_iter = OptionalUnionInternalNodeExtended(
-        cast([ap - 1], OptionalUnionInternalNodeExtendedEnum*)
-    );
 
     _compute_diff(
-        left=left_to_compare_in_iter,
+        left=node_to_compare,
         right=subnode_i,
         parent_left=current_parent_left,
         parent_right=parent_right,

--- a/python/mpt/src/mpt/trie_diff.cairo
+++ b/python/mpt/src/mpt/trie_diff.cairo
@@ -575,6 +575,8 @@ func compute_diff_entrypoint{
 // @implicit storage_tries_end Passed down to record storage diffs.
 // @param left The node (or reference) from the previous state's trie.
 // @param right The node (or reference) from the current state's trie.
+// @param parent_left The parent of the left node.
+// @param parent_right The parent of the right node.
 // @param path The path (sequence of nibbles) traversed so far in the trie.
 // @param account_address The account address if processing a storage trie, otherwise 0.
 // @return Recursively updates diff lists via helper functions.
@@ -660,6 +662,8 @@ func _compute_diff{
 // @implicit storage_tries_end Passed down.
 // @param left The null node from the previous state (represented as OptionalUnionInternalNodeExtended).
 // @param right The resolved node from the current state (OptionalInternalNode).
+// @param parent_left The parent of the left node.
+// @param parent_right The parent of the right node.
 // @param path The path traversed so far.
 // @param account_address The current account address (0 for state trie).
 // @return Updates diff lists based on the type of the right node.
@@ -760,6 +764,8 @@ func _left_is_null{
 // @implicit storage_tries_end Passed down.
 // @param l_leaf The LeafNode from the previous state.
 // @param right The resolved node from the current state (OptionalInternalNode).
+// @param parent_left The parent of the left node.
+// @param parent_right The parent of the right node.
 // @param path The path traversed so far.
 // @param account_address The current account address (0 for state trie).
 // @return Updates diff lists based on the comparison results.
@@ -999,6 +1005,8 @@ func _left_is_leaf_node{
 // @implicit storage_tries_end Passed down.
 // @param left The ExtensionNode from the previous state.
 // @param right The resolved node from the current state (OptionalInternalNode).
+// @param parent_left The parent of the left node.
+// @param parent_right The parent of the right node.
 // @param path The path traversed so far.
 // @param account_address The current account address (0 for state trie).
 // @return Updates diff lists based on the comparison results.
@@ -1288,6 +1296,8 @@ func _left_is_extension_node{
 // @implicit storage_tries_end Passed down.
 // @param left The BranchNode from the previous state.
 // @param right The resolved node from the current state (OptionalInternalNode).
+// @param parent_left The parent of the left node.
+// @param parent_right The parent of the right node.
 // @param path The path traversed so far.
 // @param account_address The current account address (0 for state trie).
 // @return Updates diff lists via helper functions.
@@ -1862,6 +1872,8 @@ func _compute_left_leaf_diff_on_right_branch_node{
 // @implicit storage_tries_end Passed down.
 // @param left The Optional Extension Node from the previous state.
 // @param subnodes The subnodes structure of the right BranchNode.
+// @param parent_left The parent of the left node.
+// @param parent_right The parent of the right node.
 // @param path The path traversed so far.
 // @param account_address The current account address.
 // @param index The current branch index being processed (0-15).

--- a/python/mpt/src/mpt/trie_diff.py
+++ b/python/mpt/src/mpt/trie_diff.py
@@ -470,7 +470,7 @@ class StateDiff:
                 # Match on the corresponding nibble of the extension key segment
                 for i in range(0, 16):
                     nibble = bytes([i])
-                    # we know that l_node.key_segment is not empty
+                    # we know that r_node.key_segment is not empty
                     # as extension nodes key_segment len is at least 1
                     if r_node.key_segment[0] == nibble:
                         if len(r_node.key_segment) == 1:
@@ -479,7 +479,7 @@ class StateDiff:
                             right_parent = r_node
                         else:
                             r_node_to_compare = ExtensionNode(
-                                key_segment=Bytes(r_node.key_segment[1:]),
+                                key_segment=r_node.key_segment[1:],
                                 subnode=r_node.subnode,
                             )
                             right_parent = right_parent

--- a/python/mpt/src/mpt/utils.cairo
+++ b/python/mpt/src/mpt/utils.cairo
@@ -2,6 +2,7 @@ from starkware.cairo.common.cairo_builtins import BitwiseBuiltin
 
 from ethereum.cancun.trie import (
     InternalNode,
+    OptionalInternalNode,
     LeafNode,
     LeafNodeStruct,
     BranchNode,
@@ -242,8 +243,14 @@ func check_leaf_node(path: Bytes, node: LeafNode) {
     }
 }
 
-func check_extension_node(node: ExtensionNode) {
+func check_extension_node(node: ExtensionNode, parent_node: OptionalInternalNode) {
     alloc_locals;
+
+    if (cast(parent_node.value, felt) != 0) {
+        if (cast(parent_node.value.extension_node.value, felt) != 0) {
+            raise('ValueError');
+        }
+    }
 
     let key_segment = node.value.key_segment;
     let subnode = node.value.subnode;

--- a/python/mpt/src/mpt/utils.cairo
+++ b/python/mpt/src/mpt/utils.cairo
@@ -243,6 +243,13 @@ func check_leaf_node(path: Bytes, node: LeafNode) {
     }
 }
 
+// @notice Checks if an extension node is valid.
+// @param node The extension node to check.
+// @param parent_node The parent of the extension node
+// @dev Raises an error if:
+// - The key segment is empty
+// - The subnode is not a valid node
+// - The parent is an extension node
 func check_extension_node(node: ExtensionNode, parent_node: OptionalInternalNode) {
     alloc_locals;
 

--- a/python/mpt/src/mpt/utils.py
+++ b/python/mpt/src/mpt/utils.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Optional
 
 from ethereum.cancun.trie import (
     BranchNode,
@@ -105,14 +106,18 @@ def check_leaf_node(path: Bytes, node: LeafNode) -> None:
         raise ValueError("Invalid leaf node, expected a 32-byte path")
 
 
-def check_extension_node(node: ExtensionNode) -> None:
+def check_extension_node(node: ExtensionNode, parent: Optional[InternalNode]) -> None:
     """
     Check that an extension node is valid
      - Extension nodes must have a non-zero key segment
      - Extension nodes must have a non-zero subnode
+     - Extension nodes must have a parent that is not an extension node
     """
     if len(node.key_segment) == 0:
         raise ValueError("Invalid extension node, expected a non-zero key segment")
 
     if len(node.subnode) == 0:
         raise ValueError("Invalid extension node, expected a non-empty subnode")
+
+    if parent is not None and isinstance(parent, ExtensionNode):
+        raise ValueError("Invalid extension node, expected a non-extension parent")

--- a/python/mpt/tests/src/mpt/test_utils.py
+++ b/python/mpt/tests/src/mpt/test_utils.py
@@ -1,8 +1,9 @@
-from typing import List, Sequence, Tuple, Union
+from typing import List, Optional, Sequence, Tuple, Union
 
 from ethereum.cancun.trie import (
     BranchNode,
     ExtensionNode,
+    InternalNode,
     LeafNode,
     bytes_to_nibble_list,
     encode_internal_node,
@@ -224,13 +225,18 @@ ids.second_non_null_index = 1
 
         check_leaf_node(path, leaf_node)
 
-    @given(extension_node=extension_node_could_be_invalid_strategy())
-    def test_check_extension_node(self, cairo_run, extension_node: ExtensionNode):
+    @given(
+        extension_node=extension_node_could_be_invalid_strategy(),
+        parent=st.one_of(st.just(None), st.from_type(InternalNode)),
+    )
+    def test_check_extension_node(
+        self, cairo_run, extension_node: ExtensionNode, parent: Optional[InternalNode]
+    ):
         try:
-            cairo_run("check_extension_node", extension_node)
+            cairo_run("check_extension_node", extension_node, parent)
         except Exception as cairo_error:
             with strict_raises(type(cairo_error)):
-                check_extension_node(extension_node)
+                check_extension_node(extension_node, parent)
             return
 
     @given(data=list_address_account_node_diff_entry_strategy)

--- a/python/mpt/tests/src/mpt/test_utils.py
+++ b/python/mpt/tests/src/mpt/test_utils.py
@@ -227,7 +227,7 @@ ids.second_non_null_index = 1
 
     @given(
         extension_node=extension_node_could_be_invalid_strategy(),
-        parent=st.one_of(st.just(None), st.from_type(InternalNode)),
+        parent=st.one_of(st.none(), st.from_type(InternalNode)),
     )
     def test_check_extension_node(
         self, cairo_run, extension_node: ExtensionNode, parent: Optional[InternalNode]


### PR DESCRIPTION
closes #1269 

- fixed a bug where the behaviour between `_compute_left_branch_node_diff_on_right_extension_node` didnt behave like `_compute_left_extension_node_diff_on_right_branch_node`
- fixed a bug where `check_extension_node` wasn't used in the python version of trie_diff

One thought: how can we test the `check_X` in the flow of compute_diff? we don't have well constructed MPTs that have invalid nodes