### PR TITLE
dev: optimize Bytes__eq__

### DIFF
--- a/cairo/ethereum/utils/bytes.cairo
+++ b/cairo/ethereum/utils/bytes.cairo
@@ -71,9 +71,7 @@ func Bytes__eq__(_self: Bytes, other: Bytes) -> bool {
 
     if (is_diff == 1) {
         // Assert that the bytes are different at the first different index
-        with_attr error_message("Bytes__eq__: bytes at provided index are equal") {
-            assert_not_equal(_self.value.data[diff_index], other.value.data[diff_index]);
-        }
+        assert_not_equal(_self.value.data[diff_index], other.value.data[diff_index]);
         tempvar res = bool(0);
         return res;
     }
@@ -91,11 +89,10 @@ func Bytes__eq__(_self: Bytes, other: Bytes) -> bool {
     tempvar res = bool(1);
     jmp end if is_end != 0;
 
-    let is_eq = is_zero(self_value.data[index] - other_value.data[index]);
+    assert self_value.data[index] = other_value.data[index];
 
     tempvar i = i + 1;
-    jmp loop if is_eq != 0;
-    tempvar res = bool(0);
+    jmp loop;
 
     end:
     let res = bool([ap - 1]);

--- a/cairo/tests/ethereum/utils/test_bytes.py
+++ b/cairo/tests/ethereum/utils/test_bytes.py
@@ -5,6 +5,7 @@ from hypothesis import given
 from hypothesis import strategies as st
 
 from cairo_addons.testing.errors import strict_raises
+from cairo_addons.testing.hints import patch_hint
 
 
 class TestBytes:
@@ -21,6 +22,38 @@ class TestBytes:
     @given(a=..., b=...)
     def test_Bytes__eq__(self, cairo_run, a: Bytes, b: Bytes):
         assert (a == b) == cairo_run("Bytes__eq__", a, b)
+
+    def test_Bytes__eq__should_fail_when_not_equal_and_bad_prover_hint(
+        self, cairo_run_py, cairo_programs
+    ):
+        a = Bytes(b"a")
+        b = Bytes(b"b")
+        with patch_hint(
+            cairo_programs,
+            "Bytes__eq__",
+            """
+ids.is_diff = 0
+ids.diff_index = 0
+""",
+        ):
+            with strict_raises(AssertionError):
+                cairo_run_py("Bytes__eq__", a, b)
+
+    def test_Bytes__eq__should_fail_when_equal_and_bad_prover_hint(
+        self, cairo_run_py, cairo_programs
+    ):
+        a = Bytes(b"a")
+        b = Bytes(b"a")
+        with patch_hint(
+            cairo_programs,
+            "Bytes__eq__",
+            """
+ids.is_diff = 1
+ids.diff_index = 0
+""",
+        ):
+            with strict_raises(AssertionError):
+                cairo_run_py("Bytes__eq__", a, b)
 
     @given(a=..., b=...)
     def test_Bytes__startswith__(self, cairo_run, a: Bytes, b: Bytes):

--- a/python/cairo-addons/src/cairo_addons/testing/errors.py
+++ b/python/cairo-addons/src/cairo_addons/testing/errors.py
@@ -70,7 +70,10 @@ def map_to_python_exception(e: Exception):
     except Exception:
         pass
 
-    if "An ASSERT_EQ instruction failed" in error_type:
+    if (
+        "An ASSERT_EQ instruction failed" in error_type
+        or "AssertionError" in error_type
+    ):
         raise AssertionError(error_str) from e
 
     # Get the exception class from python's builtins or ethereum's exceptions


### PR DESCRIPTION
Empirically, this decreases the step usage of this function of ~30% (4.3M -> 3.3M) on sample block 22188088, from 520 to 400 per-call.

Closes #1316

