### PR TITLE
fix: state rebinding issue after get_account_code

### DIFF
--- a/cairo/ethereum/cancun/vm/instructions/system.cairo
+++ b/cairo/ethereum/cancun/vm/instructions/system.cairo
@@ -133,11 +133,10 @@ func generic_call{
     let env = evm.value.env;
     let state = env.value.state;
     let account = get_account{state=state}(code_address);
+    let account_code = get_account_code{state=state}(code_address, account);
 
     EnvImpl.set_state{env=env}(state);
     EvmImpl.set_env(env);
-
-    let account_code = get_account_code{state=state}(code_address, account);
 
     let is_static = bool(is_staticcall.value + evm.value.message.value.is_static.value);
 


### PR DESCRIPTION
Closes https://github.com/kkrt-labs/keth/issues/1319

The issue was that we were calling `get_account_code`, mutating the `state`, but not properly re-binding the `state` to the `environment`.  Shifting the lines orders fixes that.