### PR TITLE
fix: transient storage finalization

### DIFF
--- a/cairo/ethereum/cancun/vm/env_impl.cairo
+++ b/cairo/ethereum/cancun/vm/env_impl.cairo
@@ -1,4 +1,9 @@
-from ethereum.cancun.state import State, TransientStorage
+from ethereum.cancun.state import (
+    State,
+    TransientStorage,
+    finalize_state,
+    finalize_transient_storage,
+)
 from ethereum.cancun.fork_types import Address, ListHash32, TupleVersionedHash
 from ethereum_types.numeric import Uint, U256, U64
 from ethereum_types.bytes import Bytes32


### PR DESCRIPTION
Closes #1309. The `transient_storage` gets finalized each time the `evm` is.

Also fixes an issue where not _all_ fields of the State were squashed properly.