### PR TITLE
ci: reduce n workers in ef-test to avoid OOM sigkill

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -26,7 +26,7 @@ jobs:
     uses: ./.github/workflows/python_tests.yml
     with:
       hypothesis-profile: "ci"
-      parallelism: logical
+      parallelism: "48"
       pytest-add-params:
         "-m 'not slow' --max-tests=5000 --randomly-seed=$GITHUB_RUN_ID
         cairo/tests/ef_tests/"


### PR DESCRIPTION
reduces to 48 workers on ef-test job, as we're hitting RAM usage limits, causing sigkill of the job