### PR TITLE
dev: added checks for unsquashed dicts in runner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -891,7 +891,7 @@ dependencies = [
 [[package]]
 name = "cairo-vm"
 version = "2.0.1"
-source = "git+https://github.com/kkrt-labs/cairo-vm?rev=f3ac2f9adf6ed62d0d1dcb008c15290bd758a80b#f3ac2f9adf6ed62d0d1dcb008c15290bd758a80b"
+source = "git+https://github.com/kkrt-labs/cairo-vm?rev=96cdc1c60d894701b9fca4231208e69c7dce383a#96cdc1c60d894701b9fca4231208e69c7dce383a"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ cairo-vm = { git = "https://github.com/lambdaclass/cairo-vm.git", tag = "v2.0.0-
 ] }
 
 [patch."https://github.com/lambdaclass/cairo-vm.git"]
-cairo-vm = { git = "https://github.com/kkrt-labs/cairo-vm", rev = "f3ac2f9adf6ed62d0d1dcb008c15290bd758a80b" }
+cairo-vm = { git = "https://github.com/kkrt-labs/cairo-vm", rev = "96cdc1c60d894701b9fca4231208e69c7dce383a" }
 
 [patch.crates-io]
 stwo-cairo-adapter = { git = "https://github.com/starkware-libs/stwo-cairo", rev = "b84e25feb38f89757eeceee005b1a1f14bdac0b5" }

--- a/cairo/ethereum/cancun/bloom.cairo
+++ b/cairo/ethereum/cancun/bloom.cairo
@@ -98,9 +98,6 @@ func logs_bloom{range_check_ptr, bitwise_ptr: BitwiseBuiltin*, keccak_ptr: Kecca
 ) -> Bloom {
     alloc_locals;
     let (local mutable_bloom_start) = default_dict_new(0);
-    tempvar dict_ptr = mutable_bloom_start;
-    tempvar name = 'logs_bloom';
-    %{ attach_name %}
     let mutable_bloom_end = mutable_bloom_start;
 
     tempvar mutable_bloom = MutableBloom(

--- a/cairo/ethereum/cancun/bloom.cairo
+++ b/cairo/ethereum/cancun/bloom.cairo
@@ -98,6 +98,9 @@ func logs_bloom{range_check_ptr, bitwise_ptr: BitwiseBuiltin*, keccak_ptr: Kecca
 ) -> Bloom {
     alloc_locals;
     let (local mutable_bloom_start) = default_dict_new(0);
+    tempvar dict_ptr = mutable_bloom_start;
+    tempvar name = 'logs_bloom';
+    %{ attach_name %}
     let mutable_bloom_end = mutable_bloom_start;
 
     tempvar mutable_bloom = MutableBloom(

--- a/cairo/ethereum/cancun/fork.cairo
+++ b/cairo/ethereum/cancun/fork.cairo
@@ -484,9 +484,6 @@ func process_transaction{
 
     // Create preaccessed addresses and write coinbase
     let (preaccessed_addresses_ptr) = default_dict_new(0);
-    tempvar dict_ptr = preaccessed_addresses_ptr;
-    tempvar name = 'preaccessed_addresses';
-    %{ attach_name %}
     tempvar preaccessed_addresses_ptr_start = preaccessed_addresses_ptr;
     let address = env.value.coinbase;
     hashdict_write{dict_ptr=preaccessed_addresses_ptr}(1, &address.value, 1);
@@ -498,9 +495,6 @@ func process_transaction{
     );
     // Create preaccessed storage keys
     let (preaccessed_storage_keys_ptr) = default_dict_new(0);
-    tempvar dict_ptr = preaccessed_storage_keys_ptr;
-    tempvar name = 'preaccessed_storage_keys';
-    %{ attach_name %}
     tempvar preaccessed_storage_keys = SetTupleAddressBytes32(
         new SetTupleAddressBytes32Struct(
             dict_ptr_start=cast(preaccessed_storage_keys_ptr, SetTupleAddressBytes32DictAccess*),
@@ -989,9 +983,6 @@ func apply_body{
     let gas_available = block_gas_limit;
 
     let (transaction_ptr) = default_dict_new(0);
-    tempvar dict_ptr = transaction_ptr;
-    tempvar name = 'transactions';
-    %{ attach_name %}
     tempvar transactions_trie_data = MappingBytesOptionalUnionBytesLegacyTransaction(
         new MappingBytesOptionalUnionBytesLegacyTransactionStruct(
             dict_ptr_start=cast(
@@ -1010,9 +1001,6 @@ func apply_body{
     );
 
     let (receipt_ptr) = default_dict_new(0);
-    tempvar dict_ptr = receipt_ptr;
-    tempvar name = 'receipts';
-    %{ attach_name %}
     tempvar receipts_trie_data = MappingBytesOptionalUnionBytesReceipt(
         new MappingBytesOptionalUnionBytesReceiptStruct(
             dict_ptr_start=cast(receipt_ptr, BytesOptionalUnionBytesReceiptDictAccess*),
@@ -1029,9 +1017,6 @@ func apply_body{
     );
 
     let (withdrawals_ptr) = default_dict_new(0);
-    tempvar dict_ptr = withdrawals_ptr;
-    tempvar name = 'withdrawals';
-    %{ attach_name %}
     tempvar withdrawals_trie_data = MappingBytesOptionalUnionBytesWithdrawal(
         new MappingBytesOptionalUnionBytesWithdrawalStruct(
             dict_ptr_start=cast(withdrawals_ptr, BytesOptionalUnionBytesWithdrawalDictAccess*),
@@ -1060,9 +1045,6 @@ func apply_body{
     let code_address = OptionalAddress(&beacon_roots_address);
 
     let (empty_data_ptr) = default_dict_new(0);
-    tempvar dict_ptr = empty_data_ptr;
-    tempvar name = 'accessed_addresses';
-    %{ attach_name %}
     tempvar accessed_addresses = SetAddress(
         new SetAddressStruct(
             dict_ptr_start=cast(empty_data_ptr, SetAddressDictAccess*),
@@ -1071,9 +1053,6 @@ func apply_body{
     );
 
     let (empty_data_ptr) = default_dict_new(0);
-    tempvar dict_ptr = empty_data_ptr;
-    tempvar name = 'accessed_storage_keys';
-    %{ attach_name %}
     tempvar accessed_storage_keys = SetTupleAddressBytes32(
         new SetTupleAddressBytes32Struct(
             dict_ptr_start=cast(empty_data_ptr, SetTupleAddressBytes32DictAccess*),

--- a/cairo/ethereum/cancun/fork.cairo
+++ b/cairo/ethereum/cancun/fork.cairo
@@ -484,6 +484,9 @@ func process_transaction{
 
     // Create preaccessed addresses and write coinbase
     let (preaccessed_addresses_ptr) = default_dict_new(0);
+    tempvar dict_ptr = preaccessed_addresses_ptr;
+    tempvar name = 'preaccessed_addresses';
+    %{ attach_name %}
     tempvar preaccessed_addresses_ptr_start = preaccessed_addresses_ptr;
     let address = env.value.coinbase;
     hashdict_write{dict_ptr=preaccessed_addresses_ptr}(1, &address.value, 1);
@@ -495,6 +498,9 @@ func process_transaction{
     );
     // Create preaccessed storage keys
     let (preaccessed_storage_keys_ptr) = default_dict_new(0);
+    tempvar dict_ptr = preaccessed_storage_keys_ptr;
+    tempvar name = 'preaccessed_storage_keys';
+    %{ attach_name %}
     tempvar preaccessed_storage_keys = SetTupleAddressBytes32(
         new SetTupleAddressBytes32Struct(
             dict_ptr_start=cast(preaccessed_storage_keys_ptr, SetTupleAddressBytes32DictAccess*),
@@ -983,6 +989,9 @@ func apply_body{
     let gas_available = block_gas_limit;
 
     let (transaction_ptr) = default_dict_new(0);
+    tempvar dict_ptr = transaction_ptr;
+    tempvar name = 'transactions';
+    %{ attach_name %}
     tempvar transactions_trie_data = MappingBytesOptionalUnionBytesLegacyTransaction(
         new MappingBytesOptionalUnionBytesLegacyTransactionStruct(
             dict_ptr_start=cast(
@@ -1001,6 +1010,9 @@ func apply_body{
     );
 
     let (receipt_ptr) = default_dict_new(0);
+    tempvar dict_ptr = receipt_ptr;
+    tempvar name = 'receipts';
+    %{ attach_name %}
     tempvar receipts_trie_data = MappingBytesOptionalUnionBytesReceipt(
         new MappingBytesOptionalUnionBytesReceiptStruct(
             dict_ptr_start=cast(receipt_ptr, BytesOptionalUnionBytesReceiptDictAccess*),
@@ -1017,6 +1029,9 @@ func apply_body{
     );
 
     let (withdrawals_ptr) = default_dict_new(0);
+    tempvar dict_ptr = withdrawals_ptr;
+    tempvar name = 'withdrawals';
+    %{ attach_name %}
     tempvar withdrawals_trie_data = MappingBytesOptionalUnionBytesWithdrawal(
         new MappingBytesOptionalUnionBytesWithdrawalStruct(
             dict_ptr_start=cast(withdrawals_ptr, BytesOptionalUnionBytesWithdrawalDictAccess*),
@@ -1045,6 +1060,9 @@ func apply_body{
     let code_address = OptionalAddress(&beacon_roots_address);
 
     let (empty_data_ptr) = default_dict_new(0);
+    tempvar dict_ptr = empty_data_ptr;
+    tempvar name = 'accessed_addresses';
+    %{ attach_name %}
     tempvar accessed_addresses = SetAddress(
         new SetAddressStruct(
             dict_ptr_start=cast(empty_data_ptr, SetAddressDictAccess*),
@@ -1053,6 +1071,9 @@ func apply_body{
     );
 
     let (empty_data_ptr) = default_dict_new(0);
+    tempvar dict_ptr = empty_data_ptr;
+    tempvar name = 'accessed_storage_keys';
+    %{ attach_name %}
     tempvar accessed_storage_keys = SetTupleAddressBytes32(
         new SetTupleAddressBytes32Struct(
             dict_ptr_start=cast(empty_data_ptr, SetTupleAddressBytes32DictAccess*),

--- a/cairo/ethereum/cancun/state.cairo
+++ b/cairo/ethereum/cancun/state.cairo
@@ -738,6 +738,9 @@ func begin_transaction{
             cast(storage_tries.value._data.value.dict_ptr_start, DictAccess*),
             cast(storage_tries.value._data.value.dict_ptr, DictAccess*),
         );
+        tempvar dict_ptr = new_dict_ptr_end;
+        tempvar name = 'original_storage_tries';
+        %{ attach_name %}
         tempvar original_storage_tries_data = MappingTupleAddressBytes32U256(
             new MappingTupleAddressBytes32U256Struct(
                 dict_ptr_start=cast(new_dict_ptr_start, TupleAddressBytes32U256DictAccess*),
@@ -895,6 +898,10 @@ func close_transaction{
             0,
         );
         let (new_created_accounts_ptr) = default_dict_new(0);
+        tempvar dict_ptr = new_created_accounts_ptr;
+        tempvar name = 'created_accounts';
+        %{ attach_name %}
+
         tempvar new_created_accounts = SetAddress(
             new SetAddressStruct(
                 dict_ptr_start=cast(new_created_accounts_ptr, SetAddressDictAccess*),
@@ -1067,6 +1074,9 @@ func destroy_touched_empty_accounts{poseidon_ptr: PoseidonBuiltin*, state: State
 func empty_transient_storage{range_check_ptr}() -> TransientStorage {
     let (default_value) = get_label_location(U256_ZERO);
     let (dict_ptr) = default_dict_new(cast(default_value, felt));
+    tempvar dict_ptr = dict_ptr;
+    tempvar name = 'transient_storage';
+    %{ attach_name %}
     let dict_start = cast(dict_ptr, TupleAddressBytes32U256DictAccess*);
 
     tempvar mapping = MappingTupleAddressBytes32U256(

--- a/cairo/ethereum/cancun/state.cairo
+++ b/cairo/ethereum/cancun/state.cairo
@@ -738,6 +738,9 @@ func begin_transaction{
             cast(storage_tries.value._data.value.dict_ptr_start, DictAccess*),
             cast(storage_tries.value._data.value.dict_ptr, DictAccess*),
         );
+        tempvar dict_ptr = new_dict_ptr_end;
+        tempvar name = 'original_storage_tries';
+        %{ attach_name %}
         tempvar original_storage_tries_data = MappingTupleAddressBytes32U256(
             new MappingTupleAddressBytes32U256Struct(
                 dict_ptr_start=cast(new_dict_ptr_start, TupleAddressBytes32U256DictAccess*),
@@ -890,6 +893,9 @@ func close_transaction{
     if (is_root_state != 0) {
         // Clear created accounts
         let (new_created_accounts_ptr) = default_dict_new(0);
+        tempvar dict_ptr = new_created_accounts_ptr;
+        tempvar name = 'created_accounts';
+        %{ attach_name %}
         tempvar new_created_accounts = SetAddress(
             new SetAddressStruct(
                 dict_ptr_start=cast(new_created_accounts_ptr, SetAddressDictAccess*),
@@ -1056,6 +1062,9 @@ func destroy_touched_empty_accounts{poseidon_ptr: PoseidonBuiltin*, state: State
 func empty_transient_storage{range_check_ptr}() -> TransientStorage {
     let (default_value) = get_label_location(U256_ZERO);
     let (dict_ptr) = default_dict_new(cast(default_value, felt));
+    tempvar dict_ptr = dict_ptr;
+    tempvar name = 'transient_storage';
+    %{ attach_name %}
     let dict_start = cast(dict_ptr, TupleAddressBytes32U256DictAccess*);
 
     tempvar mapping = MappingTupleAddressBytes32U256(

--- a/cairo/ethereum/cancun/state.cairo
+++ b/cairo/ethereum/cancun/state.cairo
@@ -738,9 +738,6 @@ func begin_transaction{
             cast(storage_tries.value._data.value.dict_ptr_start, DictAccess*),
             cast(storage_tries.value._data.value.dict_ptr, DictAccess*),
         );
-        tempvar dict_ptr = new_dict_ptr_end;
-        tempvar name = 'original_storage_tries';
-        %{ attach_name %}
         tempvar original_storage_tries_data = MappingTupleAddressBytes32U256(
             new MappingTupleAddressBytes32U256Struct(
                 dict_ptr_start=cast(new_dict_ptr_start, TupleAddressBytes32U256DictAccess*),
@@ -898,10 +895,6 @@ func close_transaction{
             0,
         );
         let (new_created_accounts_ptr) = default_dict_new(0);
-        tempvar dict_ptr = new_created_accounts_ptr;
-        tempvar name = 'created_accounts';
-        %{ attach_name %}
-
         tempvar new_created_accounts = SetAddress(
             new SetAddressStruct(
                 dict_ptr_start=cast(new_created_accounts_ptr, SetAddressDictAccess*),
@@ -1074,9 +1067,6 @@ func destroy_touched_empty_accounts{poseidon_ptr: PoseidonBuiltin*, state: State
 func empty_transient_storage{range_check_ptr}() -> TransientStorage {
     let (default_value) = get_label_location(U256_ZERO);
     let (dict_ptr) = default_dict_new(cast(default_value, felt));
-    tempvar dict_ptr = dict_ptr;
-    tempvar name = 'transient_storage';
-    %{ attach_name %}
     let dict_start = cast(dict_ptr, TupleAddressBytes32U256DictAccess*);
 
     tempvar mapping = MappingTupleAddressBytes32U256(

--- a/cairo/ethereum/cancun/trie.cairo
+++ b/cairo/ethereum/cancun/trie.cairo
@@ -638,6 +638,9 @@ func copy_TrieAddressOptionalAccount{range_check_ptr, trie: TrieAddressOptionalA
     local new_dict_ptr: AddressAccountDictAccess*;
     tempvar parent_dict_end = trie.value._data.value.dict_ptr;
     %{ copy_tracker_to_new_ptr %}
+    tempvar dict_ptr = new_dict_ptr;
+    tempvar name = 'TrieAddressOptionalAccount';
+    %{ attach_name %}
 
     tempvar res = TrieAddressOptionalAccount(
         new TrieAddressOptionalAccountStruct(
@@ -659,6 +662,9 @@ func copy_TrieTupleAddressBytes32U256{range_check_ptr, trie: TrieTupleAddressByt
     local new_dict_ptr: TupleAddressBytes32U256DictAccess*;
     tempvar parent_dict_end = trie.value._data.value.dict_ptr;
     %{ copy_tracker_to_new_ptr %}
+    tempvar dict_ptr = new_dict_ptr;
+    tempvar name = 'TrieTupleAddressBytes32U256';
+    %{ attach_name %}
 
     tempvar res = TrieTupleAddressBytes32U256(
         new TrieTupleAddressBytes32U256Struct(
@@ -1185,6 +1191,9 @@ func _prepare_trie{
     alloc_locals;
 
     let (local mapping_ptr_start: BytesBytesDictAccess*) = default_dict_new(0);
+    tempvar dict_ptr = mapping_ptr_start;
+    tempvar name = 'mapping_ptr_start';
+    %{ attach_name %}
 
     tempvar is_account = cast(trie_union.value.account.value, felt);
     jmp account if is_account != 0;
@@ -1852,6 +1861,9 @@ func _get_branch_for_nibble_at_level{poseidon_ptr: PoseidonBuiltin*}(
     let (branch_start_: DictAccess*) = dict_new_empty();
     let branch_start = cast(branch_start_, BytesBytesDictAccess*);
     let dict_ptr_stop = obj.value.dict_ptr;
+    tempvar dict_ptr = branch_start_;
+    tempvar name = 'branch_start';
+    %{ attach_name %}
 
     tempvar empty_value = Bytes(new BytesStruct(cast(0, felt*), 0));
 

--- a/cairo/ethereum/cancun/trie.cairo
+++ b/cairo/ethereum/cancun/trie.cairo
@@ -640,9 +640,6 @@ func copy_TrieAddressOptionalAccount{range_check_ptr, trie: TrieAddressOptionalA
     local new_dict_ptr: AddressAccountDictAccess*;
     tempvar parent_dict_end = trie.value._data.value.dict_ptr;
     %{ copy_tracker_to_new_ptr %}
-    tempvar dict_ptr = new_dict_ptr;
-    tempvar name = 'TrieAddressOptionalAccount';
-    %{ attach_name %}
 
     tempvar res = TrieAddressOptionalAccount(
         new TrieAddressOptionalAccountStruct(
@@ -664,9 +661,6 @@ func copy_TrieTupleAddressBytes32U256{range_check_ptr, trie: TrieTupleAddressByt
     local new_dict_ptr: TupleAddressBytes32U256DictAccess*;
     tempvar parent_dict_end = trie.value._data.value.dict_ptr;
     %{ copy_tracker_to_new_ptr %}
-    tempvar dict_ptr = new_dict_ptr;
-    tempvar name = 'TrieTupleAddressBytes32U256';
-    %{ attach_name %}
 
     tempvar res = TrieTupleAddressBytes32U256(
         new TrieTupleAddressBytes32U256Struct(
@@ -1193,9 +1187,6 @@ func _prepare_trie{
     alloc_locals;
 
     let (local mapping_ptr_start: BytesBytesDictAccess*) = default_dict_new(0);
-    tempvar dict_ptr = mapping_ptr_start;
-    tempvar name = 'mapping_ptr_start';
-    %{ attach_name %}
 
     tempvar is_account = cast(trie_union.value.account.value, felt);
     jmp account if is_account != 0;
@@ -1869,9 +1860,6 @@ func _get_branch_for_nibble_at_level{poseidon_ptr: PoseidonBuiltin*}(
     let (branch_start_: DictAccess*) = dict_new_empty();
     let branch_start = cast(branch_start_, BytesBytesDictAccess*);
     let dict_ptr_stop = obj.value.dict_ptr;
-    tempvar dict_ptr = branch_start_;
-    tempvar name = 'branch_start';
-    %{ attach_name %}
 
     tempvar empty_value = Bytes(new BytesStruct(cast(0, felt*), 0));
 

--- a/cairo/ethereum/cancun/trie.cairo
+++ b/cairo/ethereum/cancun/trie.cairo
@@ -640,6 +640,9 @@ func copy_TrieAddressOptionalAccount{range_check_ptr, trie: TrieAddressOptionalA
     local new_dict_ptr: AddressAccountDictAccess*;
     tempvar parent_dict_end = trie.value._data.value.dict_ptr;
     %{ copy_tracker_to_new_ptr %}
+    tempvar dict_ptr = new_dict_ptr;
+    tempvar name = 'TrieAddressOptionalAccount';
+    %{ attach_name %}
 
     tempvar res = TrieAddressOptionalAccount(
         new TrieAddressOptionalAccountStruct(
@@ -661,6 +664,9 @@ func copy_TrieTupleAddressBytes32U256{range_check_ptr, trie: TrieTupleAddressByt
     local new_dict_ptr: TupleAddressBytes32U256DictAccess*;
     tempvar parent_dict_end = trie.value._data.value.dict_ptr;
     %{ copy_tracker_to_new_ptr %}
+    tempvar dict_ptr = new_dict_ptr;
+    tempvar name = 'TrieTupleAddressBytes32U256';
+    %{ attach_name %}
 
     tempvar res = TrieTupleAddressBytes32U256(
         new TrieTupleAddressBytes32U256Struct(
@@ -1187,6 +1193,9 @@ func _prepare_trie{
     alloc_locals;
 
     let (local mapping_ptr_start: BytesBytesDictAccess*) = default_dict_new(0);
+    tempvar dict_ptr = mapping_ptr_start;
+    tempvar name = 'mapping_ptr_start';
+    %{ attach_name %}
 
     tempvar is_account = cast(trie_union.value.account.value, felt);
     jmp account if is_account != 0;
@@ -1860,6 +1869,9 @@ func _get_branch_for_nibble_at_level{poseidon_ptr: PoseidonBuiltin*}(
     let (branch_start_: DictAccess*) = dict_new_empty();
     let branch_start = cast(branch_start_, BytesBytesDictAccess*);
     let dict_ptr_stop = obj.value.dict_ptr;
+    tempvar dict_ptr = branch_start_;
+    tempvar name = 'branch_start';
+    %{ attach_name %}
 
     tempvar empty_value = Bytes(new BytesStruct(cast(0, felt*), 0));
 

--- a/cairo/ethereum/cancun/trie.cairo
+++ b/cairo/ethereum/cancun/trie.cairo
@@ -5,13 +5,13 @@ from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.math_cmp import is_le
 from starkware.cairo.common.math import assert_not_zero
 from starkware.cairo.common.bitwise import BitwiseBuiltin
-from starkware.cairo.common.dict import DictAccess, dict_new
+from starkware.cairo.common.dict import DictAccess
 from starkware.cairo.lang.compiler.lib.registers import get_fp_and_pc
 from starkware.cairo.common.cairo_builtins import KeccakBuiltin
 from starkware.cairo.common.memcpy import memcpy
 
 from legacy.utils.bytes import uint256_to_bytes32_little
-from legacy.utils.dict import hashdict_read, hashdict_write, dict_new_empty, dict_read
+from legacy.utils.dict import hashdict_read, hashdict_write, dict_new_empty, dict_read, dict_squash
 from ethereum.crypto.hash import keccak256
 from ethereum.utils.numeric import min
 from ethereum_rlp.rlp import encode, _encode_bytes, _encode, Extended__eq__
@@ -84,6 +84,8 @@ from ethereum_rlp.rlp import (
 )
 from ethereum.utils.numeric import divmod
 from ethereum.utils.bytes import Bytes32_to_Bytes, Bytes20_to_Bytes, Bytes_to_Bytes32, Bytes__eq__
+
+from legacy.utils.dict import default_dict_finalize
 
 from cairo_core.comparison import is_zero
 from cairo_core.control_flow import raise
@@ -1260,13 +1262,19 @@ func _prepare_trie{
     let poseidon_ptr = cast([ap - 2], PoseidonBuiltin*);
     let mapping_ptr_end = cast([ap - 1], BytesBytesDictAccess*);
 
+    // The mapping will no longer be mutated (read or write) - as we'll only be iterating over the segment.
+    let (squashed_ptr_start, squashed_ptr_end) = default_dict_finalize(
+        cast(mapping_ptr_start, DictAccess*), cast(mapping_ptr_end, DictAccess*), 0
+    );
+
     tempvar result = MappingBytesBytes(
         new MappingBytesBytesStruct(
-            cast(mapping_ptr_start, BytesBytesDictAccess*),
-            cast(mapping_ptr_end, BytesBytesDictAccess*),
+            cast(squashed_ptr_start, BytesBytesDictAccess*),
+            cast(squashed_ptr_end, BytesBytesDictAccess*),
             cast(0, MappingBytesBytesStruct*),
         ),
     );
+
     return result;
 }
 
@@ -2012,6 +2020,44 @@ func _get_branches{poseidon_ptr: PoseidonBuiltin*}(obj: MappingBytesBytes, level
     return (branches_tuple, value);
 }
 
+func _squash_branches{range_check_ptr}(branches: TupleMappingBytesBytes) {
+    alloc_locals;
+
+    let branch_0 = branches.value.data[0].value;
+    dict_squash(cast(branch_0.dict_ptr_start, DictAccess*), cast(branch_0.dict_ptr, DictAccess*));
+    let branch_1 = branches.value.data[1].value;
+    dict_squash(cast(branch_1.dict_ptr_start, DictAccess*), cast(branch_1.dict_ptr, DictAccess*));
+    let branch_2 = branches.value.data[2].value;
+    dict_squash(cast(branch_2.dict_ptr_start, DictAccess*), cast(branch_2.dict_ptr, DictAccess*));
+    let branch_3 = branches.value.data[3].value;
+    dict_squash(cast(branch_3.dict_ptr_start, DictAccess*), cast(branch_3.dict_ptr, DictAccess*));
+    let branch_4 = branches.value.data[4].value;
+    dict_squash(cast(branch_4.dict_ptr_start, DictAccess*), cast(branch_4.dict_ptr, DictAccess*));
+    let branch_5 = branches.value.data[5].value;
+    dict_squash(cast(branch_5.dict_ptr_start, DictAccess*), cast(branch_5.dict_ptr, DictAccess*));
+    let branch_6 = branches.value.data[6].value;
+    dict_squash(cast(branch_6.dict_ptr_start, DictAccess*), cast(branch_6.dict_ptr, DictAccess*));
+    let branch_7 = branches.value.data[7].value;
+    dict_squash(cast(branch_7.dict_ptr_start, DictAccess*), cast(branch_7.dict_ptr, DictAccess*));
+    let branch_8 = branches.value.data[8].value;
+    dict_squash(cast(branch_8.dict_ptr_start, DictAccess*), cast(branch_8.dict_ptr, DictAccess*));
+    let branch_9 = branches.value.data[9].value;
+    dict_squash(cast(branch_9.dict_ptr_start, DictAccess*), cast(branch_9.dict_ptr, DictAccess*));
+    let branch_10 = branches.value.data[10].value;
+    dict_squash(cast(branch_10.dict_ptr_start, DictAccess*), cast(branch_10.dict_ptr, DictAccess*));
+    let branch_11 = branches.value.data[11].value;
+    dict_squash(cast(branch_11.dict_ptr_start, DictAccess*), cast(branch_11.dict_ptr, DictAccess*));
+    let branch_12 = branches.value.data[12].value;
+    dict_squash(cast(branch_12.dict_ptr_start, DictAccess*), cast(branch_12.dict_ptr, DictAccess*));
+    let branch_13 = branches.value.data[13].value;
+    dict_squash(cast(branch_13.dict_ptr_start, DictAccess*), cast(branch_13.dict_ptr, DictAccess*));
+    let branch_14 = branches.value.data[14].value;
+    dict_squash(cast(branch_14.dict_ptr_start, DictAccess*), cast(branch_14.dict_ptr, DictAccess*));
+    let branch_15 = branches.value.data[15].value;
+    dict_squash(cast(branch_15.dict_ptr_start, DictAccess*), cast(branch_15.dict_ptr, DictAccess*));
+    return ();
+}
+
 // @notice Given a key (inside `dict_ptr`), returns the preimage of the key registered in the tracker.
 // The preimage is validated to be correctly provided by the prover by hashing it and comparing it to the key.
 // @param key - The key to get the preimage for. Either a hashed or non-hashed key - but it must be a felt.
@@ -2177,6 +2223,9 @@ func patricialize{
     let encoded_14 = encode_internal_node(patricialized_14);
     let patricialized_15 = patricialize(branches.value.data[15], next_level);
     let encoded_15 = encode_internal_node(patricialized_15);
+
+    // Squash the dicts for all the branches
+    _squash_branches(branches);
 
     tempvar subnodes = Subnodes(
         new SubnodesStruct(

--- a/cairo/ethereum/cancun/vm/interpreter.cairo
+++ b/cairo/ethereum/cancun/vm/interpreter.cairo
@@ -487,6 +487,7 @@ func process_message_call{
         if (has_collision.value + has_storage.value != FALSE) {
             // Return early with collision error
             tempvar collision_error = new EthereumException(AddressCollision);
+            finalize_message(message);
             let msg = create_empty_message_call_output(Uint(0), collision_error);
             return msg;
         }
@@ -655,8 +656,32 @@ func create_empty_message_call_output(
     return msg;
 }
 
-// @dev Finalizes an `Evm` struct by squashing all of its fields except for the `state`'s main_trie
+// @notice Finalizes a `Message` struct by squashing its inner dicts
+func finalize_message{range_check_ptr}(message: Message) {
+    alloc_locals;
+
+    // INVARIANT: this should always be 0 as finalize_message can only be called on a create_tx that has a collision.
+    assert cast(message.value.parent_evm.value, felt) = 0;
+
+    let accessed_addresses = message.value.accessed_addresses;
+    let accessed_addresses_start = accessed_addresses.value.dict_ptr_start;
+    let accessed_addresses_end = cast(accessed_addresses.value.dict_ptr, DictAccess*);
+    default_dict_finalize(cast(accessed_addresses_start, DictAccess*), accessed_addresses_end, 0);
+
+    let accessed_storage_keys = message.value.accessed_storage_keys;
+    let accessed_storage_keys_start = accessed_storage_keys.value.dict_ptr_start;
+    let accessed_storage_keys_end = cast(accessed_storage_keys.value.dict_ptr, DictAccess*);
+    default_dict_finalize(
+        cast(accessed_storage_keys_start, DictAccess*), accessed_storage_keys_end, 0
+    );
+
+    return ();
+}
+
+// @notice Finalizes an `Evm` struct by squashing all of its fields except for the `state`'s main_trie
 // and storage_tries inside the Environment - which is only finalized after processing full blocks.
+// There's no need to finalize the inner `message` as well - as its dicts (accessed_addresses, accessed_storage_keys, etc)
+// are inlined in the `Evm` struct already - and the message is not consumed again after the `Evm` is finalized.
 func finalize_evm{range_check_ptr, evm: Evm}() {
     alloc_locals;
 
@@ -780,7 +805,7 @@ func finalize_evm{range_check_ptr, evm: Evm}() {
     // Consequently, we must also set back the `parent_dict` of the `main_trie` to `0`
     let state = env.value.state;
     let original_storage_tries = state.value.original_storage_tries;
-    let (new_original_storage_tries_start, new_original_storage_tries_end) = dict_squash(
+    dict_squash(
         cast(original_storage_tries.value._data.value.dict_ptr_start, DictAccess*),
         cast(original_storage_tries.value._data.value.dict_ptr, DictAccess*),
     );

--- a/cairo/ethereum/cancun/vm/interpreter.cairo
+++ b/cairo/ethereum/cancun/vm/interpreter.cairo
@@ -264,9 +264,7 @@ func execute_code{
 
     // Create empty stack
     let (dict_start: DictAccess*) = default_dict_new(0);
-    tempvar dict_ptr = dict_start;
-    tempvar name = 'stack';
-    %{ attach_name %}
+    let dict_ptr = dict_start;
     tempvar empty_stack = Stack(
         new StackStruct(
             dict_ptr_start=cast(dict_start, StackDictAccess*),
@@ -276,9 +274,7 @@ func execute_code{
     );
     // Create empty memory
     let (dict_start: DictAccess*) = default_dict_new(0);
-    tempvar dict_ptr = dict_start;
-    tempvar name = 'memory';
-    %{ attach_name %}
+    let dict_ptr = dict_start;
     tempvar empty_memory = Memory(
         new MemoryStruct(
             dict_ptr_start=cast(dict_start, Bytes1DictAccess*),
@@ -291,9 +287,7 @@ func execute_code{
     tempvar tuple_log_struct = TupleLog(new TupleLogStruct(data=empty_logs, len=0));
     // Create empty accounts_to_delete and touched_accounts
     let (dict_start: DictAccess*) = default_dict_new(0);
-    tempvar dict_ptr = dict_start;
-    tempvar name = 'accounts_to_delete';
-    %{ attach_name %}
+    let dict_ptr = dict_start;
     tempvar empty_accounts_to_delete = SetAddress(
         new SetAddressStruct(
             dict_ptr_start=cast(dict_start, SetAddressDictAccess*),
@@ -301,9 +295,7 @@ func execute_code{
         ),
     );
     let (dict_start: DictAccess*) = default_dict_new(0);
-    tempvar dict_ptr = dict_start;
-    tempvar name = 'touched_accounts';
-    %{ attach_name %}
+    let dict_ptr = dict_start;
     tempvar empty_touched_accounts = SetAddress(
         new SetAddressStruct(
             dict_ptr_start=cast(dict_start, SetAddressDictAccess*),
@@ -619,10 +611,7 @@ func create_empty_message_call_output(
 
     // Create first empty set for accounts_to_delete
     let (dict_start1: DictAccess*) = default_dict_new(0);
-    tempvar dict_ptr = dict_start1;
-    tempvar name = 'accounts_to_delete_empty';
-    %{ attach_name %}
-    let dict_ptr1 = dict_ptr;
+    let dict_ptr1 = dict_start1;
     tempvar empty_set1 = SetAddress(
         new SetAddressStruct(
             dict_ptr_start=cast(dict_start1, SetAddressDictAccess*),
@@ -632,10 +621,7 @@ func create_empty_message_call_output(
 
     // Create second empty set for touched_accounts
     let (dict_start2: DictAccess*) = default_dict_new(0);
-    tempvar dict_ptr = dict_start2;
-    tempvar name = 'touched_accounts_empty';
-    %{ attach_name %}
-    let dict_ptr2 = dict_ptr;
+    let dict_ptr2 = dict_start2;
     tempvar empty_set2 = SetAddress(
         new SetAddressStruct(
             dict_ptr_start=cast(dict_start2, SetAddressDictAccess*),

--- a/cairo/ethereum/cancun/vm/interpreter.cairo
+++ b/cairo/ethereum/cancun/vm/interpreter.cairo
@@ -264,7 +264,9 @@ func execute_code{
 
     // Create empty stack
     let (dict_start: DictAccess*) = default_dict_new(0);
-    let dict_ptr = dict_start;
+    tempvar dict_ptr = dict_start;
+    tempvar name = 'stack';
+    %{ attach_name %}
     tempvar empty_stack = Stack(
         new StackStruct(
             dict_ptr_start=cast(dict_start, StackDictAccess*),
@@ -274,7 +276,9 @@ func execute_code{
     );
     // Create empty memory
     let (dict_start: DictAccess*) = default_dict_new(0);
-    let dict_ptr = dict_start;
+    tempvar dict_ptr = dict_start;
+    tempvar name = 'memory';
+    %{ attach_name %}
     tempvar empty_memory = Memory(
         new MemoryStruct(
             dict_ptr_start=cast(dict_start, Bytes1DictAccess*),
@@ -287,7 +291,9 @@ func execute_code{
     tempvar tuple_log_struct = TupleLog(new TupleLogStruct(data=empty_logs, len=0));
     // Create empty accounts_to_delete and touched_accounts
     let (dict_start: DictAccess*) = default_dict_new(0);
-    let dict_ptr = dict_start;
+    tempvar dict_ptr = dict_start;
+    tempvar name = 'accounts_to_delete';
+    %{ attach_name %}
     tempvar empty_accounts_to_delete = SetAddress(
         new SetAddressStruct(
             dict_ptr_start=cast(dict_start, SetAddressDictAccess*),
@@ -295,7 +301,9 @@ func execute_code{
         ),
     );
     let (dict_start: DictAccess*) = default_dict_new(0);
-    let dict_ptr = dict_start;
+    tempvar dict_ptr = dict_start;
+    tempvar name = 'touched_accounts';
+    %{ attach_name %}
     tempvar empty_touched_accounts = SetAddress(
         new SetAddressStruct(
             dict_ptr_start=cast(dict_start, SetAddressDictAccess*),
@@ -610,7 +618,10 @@ func create_empty_message_call_output(
 
     // Create first empty set for accounts_to_delete
     let (dict_start1: DictAccess*) = default_dict_new(0);
-    let dict_ptr1 = dict_start1;
+    tempvar dict_ptr = dict_start1;
+    tempvar name = 'accounts_to_delete_empty';
+    %{ attach_name %}
+    let dict_ptr1 = dict_ptr;
     tempvar empty_set1 = SetAddress(
         new SetAddressStruct(
             dict_ptr_start=cast(dict_start1, SetAddressDictAccess*),
@@ -620,7 +631,10 @@ func create_empty_message_call_output(
 
     // Create second empty set for touched_accounts
     let (dict_start2: DictAccess*) = default_dict_new(0);
-    let dict_ptr2 = dict_start2;
+    tempvar dict_ptr = dict_start2;
+    tempvar name = 'touched_accounts_empty';
+    %{ attach_name %}
+    let dict_ptr2 = dict_ptr;
     tempvar empty_set2 = SetAddress(
         new SetAddressStruct(
             dict_ptr_start=cast(dict_start2, SetAddressDictAccess*),

--- a/cairo/ethereum/cancun/vm/interpreter.cairo
+++ b/cairo/ethereum/cancun/vm/interpreter.cairo
@@ -264,9 +264,7 @@ func execute_code{
 
     // Create empty stack
     let (dict_start: DictAccess*) = default_dict_new(0);
-    tempvar dict_ptr = dict_start;
-    tempvar name = 'stack';
-    %{ attach_name %}
+    let dict_ptr = dict_start;
     tempvar empty_stack = Stack(
         new StackStruct(
             dict_ptr_start=cast(dict_start, StackDictAccess*),
@@ -276,9 +274,7 @@ func execute_code{
     );
     // Create empty memory
     let (dict_start: DictAccess*) = default_dict_new(0);
-    tempvar dict_ptr = dict_start;
-    tempvar name = 'memory';
-    %{ attach_name %}
+    let dict_ptr = dict_start;
     tempvar empty_memory = Memory(
         new MemoryStruct(
             dict_ptr_start=cast(dict_start, Bytes1DictAccess*),
@@ -291,9 +287,7 @@ func execute_code{
     tempvar tuple_log_struct = TupleLog(new TupleLogStruct(data=empty_logs, len=0));
     // Create empty accounts_to_delete and touched_accounts
     let (dict_start: DictAccess*) = default_dict_new(0);
-    tempvar dict_ptr = dict_start;
-    tempvar name = 'accounts_to_delete';
-    %{ attach_name %}
+    let dict_ptr = dict_start;
     tempvar empty_accounts_to_delete = SetAddress(
         new SetAddressStruct(
             dict_ptr_start=cast(dict_start, SetAddressDictAccess*),
@@ -301,9 +295,7 @@ func execute_code{
         ),
     );
     let (dict_start: DictAccess*) = default_dict_new(0);
-    tempvar dict_ptr = dict_start;
-    tempvar name = 'touched_accounts';
-    %{ attach_name %}
+    let dict_ptr = dict_start;
     tempvar empty_touched_accounts = SetAddress(
         new SetAddressStruct(
             dict_ptr_start=cast(dict_start, SetAddressDictAccess*),
@@ -618,10 +610,7 @@ func create_empty_message_call_output(
 
     // Create first empty set for accounts_to_delete
     let (dict_start1: DictAccess*) = default_dict_new(0);
-    tempvar dict_ptr = dict_start1;
-    tempvar name = 'accounts_to_delete_empty';
-    %{ attach_name %}
-    let dict_ptr1 = dict_ptr;
+    let dict_ptr1 = dict_start1;
     tempvar empty_set1 = SetAddress(
         new SetAddressStruct(
             dict_ptr_start=cast(dict_start1, SetAddressDictAccess*),
@@ -631,10 +620,7 @@ func create_empty_message_call_output(
 
     // Create second empty set for touched_accounts
     let (dict_start2: DictAccess*) = default_dict_new(0);
-    tempvar dict_ptr = dict_start2;
-    tempvar name = 'touched_accounts_empty';
-    %{ attach_name %}
-    let dict_ptr2 = dict_ptr;
+    let dict_ptr2 = dict_start2;
     tempvar empty_set2 = SetAddress(
         new SetAddressStruct(
             dict_ptr_start=cast(dict_start2, SetAddressDictAccess*),

--- a/cairo/ethereum/cancun/vm/interpreter.cairo
+++ b/cairo/ethereum/cancun/vm/interpreter.cairo
@@ -262,7 +262,9 @@ func execute_code{
 
     // Create empty stack
     let (dict_start: DictAccess*) = default_dict_new(0);
-    let dict_ptr = dict_start;
+    tempvar dict_ptr = dict_start;
+    tempvar name = 'stack';
+    %{ attach_name %}
     tempvar empty_stack = Stack(
         new StackStruct(
             dict_ptr_start=cast(dict_start, StackDictAccess*),
@@ -272,7 +274,9 @@ func execute_code{
     );
     // Create empty memory
     let (dict_start: DictAccess*) = default_dict_new(0);
-    let dict_ptr = dict_start;
+    tempvar dict_ptr = dict_start;
+    tempvar name = 'memory';
+    %{ attach_name %}
     tempvar empty_memory = Memory(
         new MemoryStruct(
             dict_ptr_start=cast(dict_start, Bytes1DictAccess*),
@@ -285,7 +289,9 @@ func execute_code{
     tempvar tuple_log_struct = TupleLog(new TupleLogStruct(data=empty_logs, len=0));
     // Create empty accounts_to_delete and touched_accounts
     let (dict_start: DictAccess*) = default_dict_new(0);
-    let dict_ptr = dict_start;
+    tempvar dict_ptr = dict_start;
+    tempvar name = 'accounts_to_delete';
+    %{ attach_name %}
     tempvar empty_accounts_to_delete = SetAddress(
         new SetAddressStruct(
             dict_ptr_start=cast(dict_start, SetAddressDictAccess*),
@@ -293,7 +299,9 @@ func execute_code{
         ),
     );
     let (dict_start: DictAccess*) = default_dict_new(0);
-    let dict_ptr = dict_start;
+    tempvar dict_ptr = dict_start;
+    tempvar name = 'touched_accounts';
+    %{ attach_name %}
     tempvar empty_touched_accounts = SetAddress(
         new SetAddressStruct(
             dict_ptr_start=cast(dict_start, SetAddressDictAccess*),
@@ -608,7 +616,10 @@ func create_empty_message_call_output(
 
     // Create first empty set for accounts_to_delete
     let (dict_start1: DictAccess*) = default_dict_new(0);
-    let dict_ptr1 = dict_start1;
+    tempvar dict_ptr = dict_start1;
+    tempvar name = 'accounts_to_delete_empty';
+    %{ attach_name %}
+    let dict_ptr1 = dict_ptr;
     tempvar empty_set1 = SetAddress(
         new SetAddressStruct(
             dict_ptr_start=cast(dict_start1, SetAddressDictAccess*),
@@ -618,7 +629,10 @@ func create_empty_message_call_output(
 
     // Create second empty set for touched_accounts
     let (dict_start2: DictAccess*) = default_dict_new(0);
-    let dict_ptr2 = dict_start2;
+    tempvar dict_ptr = dict_start2;
+    tempvar name = 'touched_accounts_empty';
+    %{ attach_name %}
+    let dict_ptr2 = dict_ptr;
     tempvar empty_set2 = SetAddress(
         new SetAddressStruct(
             dict_ptr_start=cast(dict_start2, SetAddressDictAccess*),

--- a/cairo/ethereum/cancun/vm/precompiled_contracts/ripemd160.cairo
+++ b/cairo/ethereum/cancun/vm/precompiled_contracts/ripemd160.cairo
@@ -71,6 +71,9 @@ func ripemd160{
 
     // 2. Compress data
     let (x) = default_dict_new(0);
+    tempvar dict_ptr = x;
+    tempvar name = 'ripemd_x';
+    %{ attach_name %}
     let start = x;
     let (res, rsize, new_msg) = compress_data{dict_ptr=x, bitwise_ptr=bitwise_ptr}(
         buf, 5, input_len, input.value.data
@@ -82,6 +85,9 @@ func ripemd160{
 
     // 4. Convert words to bytes
     let (hash) = default_dict_new(0);
+    tempvar dict_ptr = hash;
+    tempvar name = 'ripemd_hash';
+    %{ attach_name %}
     let h0 = hash;
     buf2hash{dict_ptr=hash, bitwise_ptr=bitwise_ptr}(res, 0);
     dict_to_array{dict_ptr=hash}(arr_x, 20);
@@ -447,6 +453,9 @@ func finish{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}(
 ) -> (res: felt*, rsize: felt) {
     alloc_locals;
     let (x) = default_dict_new(0);
+    tempvar dict_ptr = x;
+    tempvar name = 'ripemd_finish';
+    %{ attach_name %}
     tempvar start = x;
 
     // put data into x.
@@ -488,6 +497,9 @@ func finish{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}(
     default_dict_finalize(start, x, 0);
     let (x) = default_dict_new(0);
     tempvar start = x;
+    tempvar dict_ptr = x;
+    tempvar name = 'ripemd_finish';
+    %{ attach_name %}
 
     dict_write{dict_ptr=x}(14, val);
     dict_write{dict_ptr=x}(15, val_15);

--- a/cairo/ethereum/cancun/vm/precompiled_contracts/ripemd160.cairo
+++ b/cairo/ethereum/cancun/vm/precompiled_contracts/ripemd160.cairo
@@ -13,12 +13,14 @@ from starkware.cairo.common.math import assert_nn_le, unsigned_div_rem
 from starkware.cairo.common.math_cmp import is_nn_le, is_nn
 from starkware.cairo.common.bitwise import bitwise_and, bitwise_xor, bitwise_or
 from starkware.cairo.common.dict_access import DictAccess
-from starkware.cairo.common.default_dict import default_dict_new, default_dict_finalize
+from starkware.cairo.common.default_dict import default_dict_new
 from starkware.cairo.common.dict import dict_read, dict_write
 from starkware.cairo.common.registers import get_label_location
 from starkware.cairo.common.bool import FALSE
 from starkware.cairo.common.memset import memset
 from starkware.cairo.common.memcpy import memcpy
+
+from legacy.utils.dict import default_dict_finalize
 
 from legacy.utils.utils import Helpers
 

--- a/cairo/ethereum/cancun/vm/precompiled_contracts/ripemd160.cairo
+++ b/cairo/ethereum/cancun/vm/precompiled_contracts/ripemd160.cairo
@@ -69,6 +69,9 @@ func ripemd160{
 
     // 2. Compress data
     let (x) = default_dict_new(0);
+    tempvar dict_ptr = x;
+    tempvar name = 'ripemd_x';
+    %{ attach_name %}
     let start = x;
     let (res, rsize, new_msg) = compress_data{dict_ptr=x, bitwise_ptr=bitwise_ptr}(
         buf, 5, input_len, input.value.data
@@ -80,6 +83,9 @@ func ripemd160{
 
     // 4. Convert words to bytes
     let (hash) = default_dict_new(0);
+    tempvar dict_ptr = hash;
+    tempvar name = 'ripemd_hash';
+    %{ attach_name %}
     let h0 = hash;
     buf2hash{dict_ptr=hash, bitwise_ptr=bitwise_ptr}(res, 0);
     dict_to_array{dict_ptr=hash}(arr_x, 20);
@@ -445,6 +451,9 @@ func finish{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}(
 ) -> (res: felt*, rsize: felt) {
     alloc_locals;
     let (x) = default_dict_new(0);
+    tempvar dict_ptr = x;
+    tempvar name = 'ripemd_finish';
+    %{ attach_name %}
     tempvar start = x;
 
     // put data into x.
@@ -486,6 +495,9 @@ func finish{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}(
     default_dict_finalize(start, x, 0);
     let (x) = default_dict_new(0);
     tempvar start = x;
+    tempvar dict_ptr = x;
+    tempvar name = 'ripemd_finish';
+    %{ attach_name %}
 
     dict_write{dict_ptr=x}(14, val);
     dict_write{dict_ptr=x}(15, val_15);

--- a/cairo/ethereum/cancun/vm/precompiled_contracts/ripemd160.cairo
+++ b/cairo/ethereum/cancun/vm/precompiled_contracts/ripemd160.cairo
@@ -71,9 +71,6 @@ func ripemd160{
 
     // 2. Compress data
     let (x) = default_dict_new(0);
-    tempvar dict_ptr = x;
-    tempvar name = 'ripemd_x';
-    %{ attach_name %}
     let start = x;
     let (res, rsize, new_msg) = compress_data{dict_ptr=x, bitwise_ptr=bitwise_ptr}(
         buf, 5, input_len, input.value.data
@@ -85,9 +82,6 @@ func ripemd160{
 
     // 4. Convert words to bytes
     let (hash) = default_dict_new(0);
-    tempvar dict_ptr = hash;
-    tempvar name = 'ripemd_hash';
-    %{ attach_name %}
     let h0 = hash;
     buf2hash{dict_ptr=hash, bitwise_ptr=bitwise_ptr}(res, 0);
     dict_to_array{dict_ptr=hash}(arr_x, 20);
@@ -453,9 +447,6 @@ func finish{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}(
 ) -> (res: felt*, rsize: felt) {
     alloc_locals;
     let (x) = default_dict_new(0);
-    tempvar dict_ptr = x;
-    tempvar name = 'ripemd_finish';
-    %{ attach_name %}
     tempvar start = x;
 
     // put data into x.
@@ -497,9 +488,6 @@ func finish{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}(
     default_dict_finalize(start, x, 0);
     let (x) = default_dict_new(0);
     tempvar start = x;
-    tempvar dict_ptr = x;
-    tempvar name = 'ripemd_finish';
-    %{ attach_name %}
 
     dict_write{dict_ptr=x}(14, val);
     dict_write{dict_ptr=x}(15, val_15);

--- a/cairo/ethereum/crypto/alt_bn128.cairo
+++ b/cairo/ethereum/crypto/alt_bn128.cairo
@@ -549,9 +549,6 @@ func bnf12_mul{
     let (zero) = get_label_location(U384_ZERO);
     let zero_u384 = cast(zero, UInt384*);
     let (mul_dict) = default_dict_new(cast(zero_u384, felt));
-    tempvar dict_ptr = mul_dict;
-    tempvar name = 'bnf12_mul';
-    %{ attach_name %}
     let mul_dict_start = mul_dict;
 
     // Step 2: Perform polynomial multiplication

--- a/cairo/ethereum/crypto/alt_bn128.cairo
+++ b/cairo/ethereum/crypto/alt_bn128.cairo
@@ -550,9 +550,6 @@ func bnf12_mul{
     let (zero) = get_label_location(U384_ZERO);
     let zero_u384 = cast(zero, UInt384*);
     let (mul_dict) = default_dict_new(cast(zero_u384, felt));
-    tempvar dict_ptr = mul_dict;
-    tempvar name = 'bnf12_mul';
-    %{ attach_name %}
     let mul_dict_start = mul_dict;
 
     // Step 2: Perform polynomial multiplication

--- a/cairo/ethereum/crypto/alt_bn128.cairo
+++ b/cairo/ethereum/crypto/alt_bn128.cairo
@@ -550,6 +550,9 @@ func bnf12_mul{
     let (zero) = get_label_location(U384_ZERO);
     let zero_u384 = cast(zero, UInt384*);
     let (mul_dict) = default_dict_new(cast(zero_u384, felt));
+    tempvar dict_ptr = mul_dict;
+    tempvar name = 'bnf12_mul';
+    %{ attach_name %}
     let mul_dict_start = mul_dict;
 
     // Step 2: Perform polynomial multiplication

--- a/cairo/ethereum/crypto/alt_bn128.cairo
+++ b/cairo/ethereum/crypto/alt_bn128.cairo
@@ -13,7 +13,6 @@ from starkware.cairo.common.registers import get_label_location
 
 from legacy.utils.dict import default_dict_finalize
 
-from cairo_core.control_flow import raise
 from cairo_ec.circuits.mod_ops_compiled import add, sub, mul
 from cairo_ec.curve.alt_bn128 import alt_bn128
 from definitions import G1G2Pair, G1Point as G1PointGaraga, G2Point as G2PointGaraga

--- a/cairo/ethereum/crypto/alt_bn128.cairo
+++ b/cairo/ethereum/crypto/alt_bn128.cairo
@@ -547,6 +547,9 @@ func bnf12_mul{
     let (zero) = get_label_location(U384_ZERO);
     let zero_u384 = cast(zero, UInt384*);
     let (mul_dict) = default_dict_new(cast(zero_u384, felt));
+    tempvar dict_ptr = mul_dict;
+    tempvar name = 'bnf12_mul';
+    %{ attach_name %}
     let mul_dict_start = mul_dict;
 
     // Step 2: Perform polynomial multiplication

--- a/cairo/ethereum/crypto/alt_bn128.cairo
+++ b/cairo/ethereum/crypto/alt_bn128.cairo
@@ -6,11 +6,14 @@ from starkware.cairo.common.cairo_builtins import (
     BitwiseBuiltin,
 )
 from starkware.cairo.lang.compiler.lib.registers import get_fp_and_pc
-from starkware.cairo.common.default_dict import default_dict_new, default_dict_finalize
+from starkware.cairo.common.default_dict import default_dict_new
 from starkware.cairo.common.dict import dict_read, dict_write
 from starkware.cairo.common.dict_access import DictAccess
 from starkware.cairo.common.registers import get_label_location
 
+from legacy.utils.dict import default_dict_finalize
+
+from cairo_core.control_flow import raise
 from cairo_ec.circuits.mod_ops_compiled import add, sub, mul
 from cairo_ec.curve.alt_bn128 import alt_bn128
 from definitions import G1G2Pair, G1Point as G1PointGaraga, G2Point as G2PointGaraga

--- a/cairo/ethereum/crypto/bls12_381.cairo
+++ b/cairo/ethereum/crypto/bls12_381.cairo
@@ -294,6 +294,9 @@ func blsf12_mul{
     let (zero) = get_label_location(U384_ZERO);
     let zero_u384 = cast(zero, UInt384*);
     let (mul_dict) = default_dict_new(cast(zero_u384, felt));
+    tempvar dict_ptr = mul_dict;
+    tempvar name = 'blsf12_mul';
+    %{ attach_name %}
     let mul_dict_start = mul_dict;
 
     // Step 2: Perform polynomial multiplication

--- a/cairo/ethereum/crypto/bls12_381.cairo
+++ b/cairo/ethereum/crypto/bls12_381.cairo
@@ -4,7 +4,9 @@ from starkware.cairo.lang.compiler.lib.registers import get_fp_and_pc
 from starkware.cairo.common.dict import dict_read, dict_write
 from starkware.cairo.common.registers import get_label_location
 from starkware.cairo.common.dict_access import DictAccess
-from starkware.cairo.common.default_dict import default_dict_new, default_dict_finalize
+from starkware.cairo.common.default_dict import default_dict_new
+
+from legacy.utils.dict import default_dict_finalize
 
 from cairo_ec.circuits.mod_ops_compiled import add, sub, mul
 from cairo_ec.curve.bls12_381 import bls12_381

--- a/cairo/ethereum/crypto/bls12_381.cairo
+++ b/cairo/ethereum/crypto/bls12_381.cairo
@@ -292,6 +292,9 @@ func blsf12_mul{
     let (zero) = get_label_location(U384_ZERO);
     let zero_u384 = cast(zero, UInt384*);
     let (mul_dict) = default_dict_new(cast(zero_u384, felt));
+    tempvar dict_ptr = mul_dict;
+    tempvar name = 'blsf12_mul';
+    %{ attach_name %}
     let mul_dict_start = mul_dict;
 
     // Step 2: Perform polynomial multiplication

--- a/cairo/ethereum/crypto/bls12_381.cairo
+++ b/cairo/ethereum/crypto/bls12_381.cairo
@@ -294,9 +294,6 @@ func blsf12_mul{
     let (zero) = get_label_location(U384_ZERO);
     let zero_u384 = cast(zero, UInt384*);
     let (mul_dict) = default_dict_new(cast(zero_u384, felt));
-    tempvar dict_ptr = mul_dict;
-    tempvar name = 'blsf12_mul';
-    %{ attach_name %}
     let mul_dict_start = mul_dict;
 
     // Step 2: Perform polynomial multiplication

--- a/cairo/legacy/utils/dict.cairo
+++ b/cairo/legacy/utils/dict.cairo
@@ -72,6 +72,8 @@ func dict_copy{range_check_ptr}(dict_start: DictAccess*, dict_end: DictAccess*) 
 }
 
 // @dev Copied from the standard library with an updated dict_new() implementation.
+//      and updates the `squashed` attribute of the DictTracker to mark this dict as properly squashed.
+// `squash_dict` should never be called directly, but only through `dict_squash`.
 func dict_squash{range_check_ptr}(
     dict_accesses_start: DictAccess*, dict_accesses_end: DictAccess*
 ) -> (squashed_dict_start: DictAccess*, squashed_dict_end: DictAccess*) {
@@ -83,7 +85,6 @@ func dict_squash{range_check_ptr}(
     tempvar dict_ptr = squashed_dict_start;
     tempvar name = 'squashed_dict_start';
     %{ attach_name %}
-
     let (squashed_dict_end) = squash_dict(
         dict_accesses=dict_accesses_start,
         dict_accesses_end=dict_accesses_end,
@@ -187,9 +188,8 @@ func dict_update{range_check_ptr}(
 
     if (drop != FALSE) {
         // No need to merge a dict tracker, because we revert to the previous dict.
-        let (squashed_dict_start: DictAccess*) = dict_new_empty();
-        let (squashed_dict_end) = squash_dict(dict_ptr_start, dict_ptr, squashed_dict_start);
-        tempvar dict_ptr = squashed_dict_start;
+        let (squashed_dict_start, squashed_dict_end) = dict_squash(dict_ptr_start, dict_ptr);
+        tempvar dict_ptr = squashed_dict_end;
         tempvar name = 'from_dict_update';
         %{ attach_name %}
         let (prev_values_start, prev_values_end) = prev_values(

--- a/cairo/legacy/utils/dict.cairo
+++ b/cairo/legacy/utils/dict.cairo
@@ -82,6 +82,9 @@ func dict_squash{range_check_ptr}(
     %{ dict_squash %}
     ap += 1;
     let squashed_dict_start = cast([ap - 1], DictAccess*);
+    tempvar dict_ptr = squashed_dict_start;
+    tempvar name = 'squashed_dict_start';
+    %{ attach_name %}
     let (squashed_dict_end) = squash_dict(
         dict_accesses=dict_accesses_start,
         dict_accesses_end=dict_accesses_end,
@@ -186,6 +189,9 @@ func dict_update{range_check_ptr}(
     if (drop != FALSE) {
         // No need to merge a dict tracker, because we revert to the previous dict.
         let (squashed_dict_start, squashed_dict_end) = dict_squash(dict_ptr_start, dict_ptr);
+        tempvar dict_ptr = squashed_dict_end;
+        tempvar name = 'from_dict_update';
+        %{ attach_name %}
         let (prev_values_start, prev_values_end) = prev_values(
             squashed_dict_start, squashed_dict_end
         );
@@ -225,7 +231,10 @@ func prev_values{range_check_ptr}(dict_ptr_start: DictAccess*, dict_ptr_stop: Di
 ) {
     alloc_locals;
 
-    let (local prev_values_start: DictAccess*) = alloc();
+    let (local prev_values_start: DictAccess*) = dict_new_empty();
+    tempvar dict_ptr = prev_values_start;
+    tempvar name = 'prev_values';
+    %{ attach_name %}
     if (dict_ptr_start == dict_ptr_stop) {
         return (prev_values_start, prev_values_start);
     }
@@ -255,6 +264,10 @@ func prev_values{range_check_ptr}(dict_ptr_start: DictAccess*, dict_ptr_stop: Di
     static_assert prev_values == [ap - 6];
     static_assert dict_ptr == [ap - 5];
     jmp loop if is_not_done != 0;
+
+    let current_tracker_ptr = prev_values_start;
+    let new_tracker_ptr = prev_values;
+    %{ update_dict_tracker %}
 
     return (prev_values_start=prev_values_start, prev_values_end=prev_values);
 }
@@ -329,6 +342,10 @@ func squash_and_update{range_check_ptr}(
     let current_tracker_ptr = dst;
     let new_tracker_ptr = cast([ap - 5], DictAccess*);
     %{ update_dict_tracker %}
+
+    tempvar dict_ptr = new_tracker_ptr;
+    tempvar name = 'squashed_dict_end';
+    %{ attach_name %}
 
     return new_tracker_ptr;
 }

--- a/cairo/legacy/utils/dict.cairo
+++ b/cairo/legacy/utils/dict.cairo
@@ -82,9 +82,6 @@ func dict_squash{range_check_ptr}(
     %{ dict_squash %}
     ap += 1;
     let squashed_dict_start = cast([ap - 1], DictAccess*);
-    tempvar dict_ptr = squashed_dict_start;
-    tempvar name = 'squashed_dict_start';
-    %{ attach_name %}
     let (squashed_dict_end) = squash_dict(
         dict_accesses=dict_accesses_start,
         dict_accesses_end=dict_accesses_end,
@@ -189,9 +186,6 @@ func dict_update{range_check_ptr}(
     if (drop != FALSE) {
         // No need to merge a dict tracker, because we revert to the previous dict.
         let (squashed_dict_start, squashed_dict_end) = dict_squash(dict_ptr_start, dict_ptr);
-        tempvar dict_ptr = squashed_dict_end;
-        tempvar name = 'from_dict_update';
-        %{ attach_name %}
         let (prev_values_start, prev_values_end) = prev_values(
             squashed_dict_start, squashed_dict_end
         );
@@ -231,10 +225,7 @@ func prev_values{range_check_ptr}(dict_ptr_start: DictAccess*, dict_ptr_stop: Di
 ) {
     alloc_locals;
 
-    let (local prev_values_start: DictAccess*) = dict_new_empty();
-    tempvar dict_ptr = prev_values_start;
-    tempvar name = 'prev_values';
-    %{ attach_name %}
+    let (local prev_values_start: DictAccess*) = alloc();
     if (dict_ptr_start == dict_ptr_stop) {
         return (prev_values_start, prev_values_start);
     }
@@ -264,10 +255,6 @@ func prev_values{range_check_ptr}(dict_ptr_start: DictAccess*, dict_ptr_stop: Di
     static_assert prev_values == [ap - 6];
     static_assert dict_ptr == [ap - 5];
     jmp loop if is_not_done != 0;
-
-    let current_tracker_ptr = prev_values_start;
-    let new_tracker_ptr = prev_values;
-    %{ update_dict_tracker %}
 
     return (prev_values_start=prev_values_start, prev_values_end=prev_values);
 }
@@ -342,10 +329,6 @@ func squash_and_update{range_check_ptr}(
     let current_tracker_ptr = dst;
     let new_tracker_ptr = cast([ap - 5], DictAccess*);
     %{ update_dict_tracker %}
-
-    tempvar dict_ptr = new_tracker_ptr;
-    tempvar name = 'squashed_dict_end';
-    %{ attach_name %}
 
     return new_tracker_ptr;
 }

--- a/cairo/tests/ef_tests/helpers/load_state_tests.py
+++ b/cairo/tests/ef_tests/helpers/load_state_tests.py
@@ -104,7 +104,7 @@ def add_block_to_chain(
 
     try:
         cairo_chain = cairo_run(
-            "state_transition", check_squashed_dicts=True, chain=chain, block=block
+            "state_transition", verify_squashed_dicts=True, chain=chain, block=block
         )
         if request.config.getoption("--log-cli-level") == "TRACE":
             # In trace mode, run EELS as well to get a side-by-side comparison

--- a/cairo/tests/ef_tests/helpers/load_state_tests.py
+++ b/cairo/tests/ef_tests/helpers/load_state_tests.py
@@ -103,7 +103,9 @@ def add_block_to_chain(
     assert rlp.encode(block) == block_rlp
 
     try:
-        cairo_chain = cairo_run("state_transition", chain, block)
+        cairo_chain = cairo_run(
+            "state_transition", check_squashed_dicts=True, chain=chain, block=block
+        )
         if request.config.getoption("--log-cli-level") == "TRACE":
             # In trace mode, run EELS as well to get a side-by-side comparison
             state_transition(chain, block)

--- a/cairo/tests/ethereum/cancun/test_fork.py
+++ b/cairo/tests/ethereum/cancun/test_fork.py
@@ -425,6 +425,8 @@ def tx_with_sender_in_state(
         st.integers(0, 10 * int(TARGET_BLOB_GAS_PER_BLOCK)).map(U64)
     )
     state = env.state
+    # Explicitly clean any snapshot in the state - as in the initial state of a tx, there are no snapshots.
+    state._snapshots = []
     tx = draw(tx_strategy)
     account = draw(account_strategy)
     private_key = draw(st.from_type(PrivateKey))

--- a/cairo/tests/ethereum/cancun/test_main.py
+++ b/cairo/tests/ethereum/cancun/test_main.py
@@ -38,7 +38,7 @@ class TestMain:
             state_storage_diff_commitment,
             trie_account_diff_commitment,
             trie_storage_diff_commitment,
-        ] = cairo_run("test_main", check_squashed_dicts=True, **program_input)
+        ] = cairo_run("test_main", verify_squashed_dicts=True, **program_input)
 
         # Program input
         actual_pre_state_root = pre_state_root_low.to_bytes(

--- a/cairo/tests/ethereum/cancun/test_main.py
+++ b/cairo/tests/ethereum/cancun/test_main.py
@@ -38,7 +38,7 @@ class TestMain:
             state_storage_diff_commitment,
             trie_account_diff_commitment,
             trie_storage_diff_commitment,
-        ] = cairo_run("test_main", **program_input)
+        ] = cairo_run("test_main", check_squashed_dicts=True, **program_input)
 
         # Program input
         actual_pre_state_root = pre_state_root_low.to_bytes(

--- a/cairo/tests/legacy/utils/test_dict.cairo
+++ b/cairo/tests/legacy/utils/test_dict.cairo
@@ -1,5 +1,5 @@
 from starkware.cairo.common.cairo_builtins import HashBuiltin
-from starkware.cairo.common.default_dict import default_dict_new, default_dict_finalize
+from starkware.cairo.common.default_dict import default_dict_new
 from starkware.cairo.common.dict import dict_write, dict_read
 from starkware.cairo.common.dict_access import DictAccess
 from starkware.cairo.common.alloc import alloc
@@ -19,6 +19,7 @@ from legacy.utils.dict import (
     get_keys_for_address_prefix,
     squash_and_update,
     dict_squash,
+    default_dict_finalize,
 )
 
 func test_prev_values{range_check_ptr}() -> (prev_values_start_ptr: felt*) {

--- a/crates/cairo-addons/src/vm/dict_manager.rs
+++ b/crates/cairo-addons/src/vm/dict_manager.rs
@@ -310,13 +310,16 @@ impl PyDictTracker {
         ))
     }
 
+    // Note: no setters are implemented for these because they would require the inner tracker to be
+    // a mutable borrow, which is not implemented yet and would require more refactoring.
+
+    #[getter]
+    fn name(&self) -> String {
+        self.inner.name.clone().unwrap_or_default()
+    }
+
     #[getter]
     fn is_squashed(&self) -> bool {
         self.inner.is_squashed
-    }
-
-    #[setter]
-    fn set_is_squashed(&mut self, is_squashed: bool) {
-        self.inner.is_squashed = is_squashed;
     }
 }

--- a/crates/cairo-addons/src/vm/dict_manager.rs
+++ b/crates/cairo-addons/src/vm/dict_manager.rs
@@ -309,4 +309,14 @@ impl PyDictTracker {
             data_str, self.inner.current_ptr.segment_index, self.inner.current_ptr.offset
         ))
     }
+
+    #[getter]
+    fn is_squashed(&self) -> bool {
+        self.inner.is_squashed
+    }
+
+    #[setter]
+    fn set_is_squashed(&mut self, is_squashed: bool) {
+        self.inner.is_squashed = is_squashed;
+    }
 }

--- a/crates/cairo-addons/src/vm/hint_definitions/dict.rs
+++ b/crates/cairo-addons/src/vm/hint_definitions/dict.rs
@@ -3,7 +3,8 @@ use std::collections::HashMap;
 use cairo_vm::{
     hint_processor::{
         builtin_hint_processor::hint_utils::{
-            get_integer_from_var_name, get_ptr_from_var_name, insert_value_from_var_name, insert_value_into_ap
+            get_integer_from_var_name, get_ptr_from_var_name, insert_value_from_var_name,
+            insert_value_into_ap,
         },
         hint_processor_definition::HintReference,
     },
@@ -27,7 +28,12 @@ pub const HINTS: &[fn() -> Hint] = &[
 pub fn attach_name() -> Hint {
     Hint::new(
         String::from("attach_name"),
-        |vm: &mut VirtualMachine, exec_scopes: &mut ExecutionScopes, ids_data: &HashMap<String, HintReference>, ap_tracking: &ApTracking, _constants: &HashMap<String, Felt252>| -> Result<(), HintError> {
+        |vm: &mut VirtualMachine,
+         exec_scopes: &mut ExecutionScopes,
+         ids_data: &HashMap<String, HintReference>,
+         ap_tracking: &ApTracking,
+         _constants: &HashMap<String, Felt252>|
+         -> Result<(), HintError> {
             let name_felt = get_integer_from_var_name("name", vm, ids_data, ap_tracking)?;
             let name_bytes = name_felt.to_bytes_be().to_vec();
             let name = String::from_utf8(name_bytes)
@@ -37,7 +43,7 @@ pub fn attach_name() -> Hint {
             let dict_ptr = get_ptr_from_var_name("dict_ptr", vm, ids_data, ap_tracking)?;
             let binding = exec_scopes.get_dict_manager()?;
             let mut binding = binding.borrow_mut();
-            let mut tracker = binding.get_tracker_mut(dict_ptr)?;
+            let tracker = binding.get_tracker_mut(dict_ptr)?;
             tracker.name = Some(name.clone());
             Ok(())
         },
@@ -75,7 +81,10 @@ pub fn dict_squash() -> Hint {
             // Get dict manager and copy data from the source dictionary
             let dict_manager_ref = exec_scopes.get_dict_manager()?;
             let mut dict_manager = dict_manager_ref.borrow_mut();
-            let tracker = dict_manager.get_tracker(dict_accesses_end)?;
+            let tracker = dict_manager.get_tracker_mut(dict_accesses_end)?;
+            // Marks the tracker as squashed - so that after the end of a run, we can assert that
+            // all dicts were properly squashed.
+            tracker.is_squashed = true;
             let copied_data = tracker.get_dictionary_copy();
 
             // Create new dict with copied data
@@ -104,6 +113,7 @@ pub fn copy_tracker_to_new_ptr() -> Hint {
             let dict_manager_ref = exec_scopes.get_dict_manager()?;
             let mut dict_manager = dict_manager_ref.borrow_mut();
             let tracker = dict_manager.get_tracker(original_dict_ptr)?;
+            let tracker_name = tracker.name.clone().unwrap_or_default();
             let copied_data = tracker.get_dictionary_copy();
             let default_value = tracker.get_default_value().cloned();
 
@@ -112,6 +122,9 @@ pub fn copy_tracker_to_new_ptr() -> Hint {
                 Some(default_value) => {
                     let new_dict_ptr =
                         dict_manager.new_default_dict(vm, &default_value, Some(copied_data))?;
+                    let new_dict_tracker =
+                        dict_manager.get_tracker_mut(new_dict_ptr.get_relocatable().unwrap())?;
+                    new_dict_tracker.name = Some(format!("{}_copy", tracker_name));
                     insert_value_from_var_name(
                         "new_dict_ptr",
                         new_dict_ptr,
@@ -122,6 +135,9 @@ pub fn copy_tracker_to_new_ptr() -> Hint {
                 }
                 None => {
                     let new_dict_ptr = dict_manager.new_dict(vm, copied_data)?;
+                    let new_dict_tracker =
+                        dict_manager.get_tracker_mut(new_dict_ptr.get_relocatable().unwrap())?;
+                    new_dict_tracker.name = Some(format!("{}_copy", tracker_name));
                     insert_value_from_var_name(
                         "new_dict_ptr",
                         new_dict_ptr,
@@ -151,8 +167,13 @@ pub fn merge_dict_tracker_with_parent() -> Hint {
             let dict_manager_ref = exec_scopes.get_dict_manager()?;
             let mut dict_manager = dict_manager_ref.borrow_mut();
 
-            let current_data = dict_manager.get_tracker(dict_ptr)?.get_dictionary_copy();
+            // If we're merging with the parent, it becomes the responsibility of the parent to
+            // finalize the dict. We can thus consider it squashed.
+            let current_tracker = dict_manager.get_tracker_mut(dict_ptr)?;
+            current_tracker.is_squashed = true;
+            let current_data = current_tracker.get_dictionary_copy();
             let parent_tracker = dict_manager.get_tracker_mut(parent_dict_end)?;
+            parent_tracker.is_squashed = false;
             for (key, value) in current_data {
                 parent_tracker.insert_value(&key, &value);
             }

--- a/crates/cairo-addons/src/vm/hint_definitions/hashdict.rs
+++ b/crates/cairo-addons/src/vm/hint_definitions/hashdict.rs
@@ -405,6 +405,11 @@ pub fn copy_hashdict_tracker_entry() -> Hint {
             // Find matching preimage from source tracker data
             let key_hash = get_integer_from_var_name("source_key", vm, ids_data, ap_tracking)?;
             let preimage = _get_preimage_for_hashed_key(key_hash.into(), preimages)?.clone();
+
+            // The default behavior of `get_value` is to mark the tracker as unsquashed, as we're
+            // accessing an internal value. However, in this specific case, we're not
+            // mutating the dict access segment - so we want to retain the squashed state.
+            let currently_squashed = source_tracker.is_squashed;
             let value = source_tracker
                 .get_value(&preimage)
                 .map_err(|_| {
@@ -413,6 +418,7 @@ pub fn copy_hashdict_tracker_entry() -> Hint {
                     )
                 })?
                 .clone();
+            source_tracker.is_squashed = currently_squashed;
 
             // Update destination tracker
             let dest_tracker = dict_manager.get_tracker_mut(dest_ptr)?;

--- a/crates/cairo-addons/src/vm/runner.rs
+++ b/crates/cairo-addons/src/vm/runner.rs
@@ -397,9 +397,11 @@ except Exception as e:
     }
 
     fn verify_squashed_dicts(&mut self) -> PyResult<()> {
-        let dict_manager_ref = self.inner.exec_scopes.get_dict_manager().map_err(|e| {
-            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string())
-        })?;
+        let dict_manager_ref = self
+            .inner
+            .exec_scopes
+            .get_dict_manager()
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
         let dict_manager = dict_manager_ref.borrow();
         let all_trackers = dict_manager.trackers.values().collect::<Vec<_>>();
         let mut unsquashed_trackers = Vec::new();
@@ -409,9 +411,12 @@ except Exception as e:
             }
         }
         if !unsquashed_trackers.is_empty() {
-            let tracker_ptrs = unsquashed_trackers.iter().map(|t| t.name.clone().unwrap_or(t.current_ptr.clone().to_string())).collect::<Vec<_>>();
+            let tracker_ptrs = unsquashed_trackers
+                .iter()
+                .map(|t| t.name.clone().unwrap_or(t.current_ptr.clone().to_string()))
+                .collect::<Vec<_>>();
             return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                "Unsquashed trackers: {:?}",
+                "unsquashed trackers: {:?}",
                 tracker_ptrs
             )));
         }

--- a/crates/cairo-addons/src/vm/runner.rs
+++ b/crates/cairo-addons/src/vm/runner.rs
@@ -403,21 +403,18 @@ except Exception as e:
             .get_dict_manager()
             .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
         let dict_manager = dict_manager_ref.borrow();
-        let all_trackers = dict_manager.trackers.values().collect::<Vec<_>>();
-        let mut unsquashed_trackers = Vec::new();
-        for tracker in all_trackers {
-            if !tracker.is_squashed {
-                unsquashed_trackers.push(tracker);
-            }
-        }
+
+        let unsquashed_trackers: Vec<String> = dict_manager
+            .trackers
+            .values()
+            .filter(|tracker| !tracker.is_squashed)
+            .map(|t| t.name.clone().unwrap_or_else(|| t.current_ptr.to_string()))
+            .collect();
+
         if !unsquashed_trackers.is_empty() {
-            let tracker_ptrs = unsquashed_trackers
-                .iter()
-                .map(|t| t.name.clone().unwrap_or(t.current_ptr.clone().to_string()))
-                .collect::<Vec<_>>();
             return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
                 "unsquashed trackers: {:?}",
-                tracker_ptrs
+                unsquashed_trackers
             )));
         }
 

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -311,3 +311,5 @@ cpython
 flamegraph
 dotenvy
 pyproject
+unsquashed
+ptrs

--- a/docs/AI-REPORT.md
+++ b/docs/AI-REPORT.md
@@ -1,5 +1,36 @@
 # AI-Reports
 
+## AI-REPORT: Dict Squashing Verification Mechanism (April 20, 2025)
+
+**Dict Squashing Soundness**: To ensure all dictionaries are properly squashed
+during block proving, we've implemented a verification mechanism in our CairoVM
+runner.
+
+- **Debugging Process**: Added `attach_name` hints in Cairo code to label
+  dictionaries, aiding in tracking and debugging squashing status. e.g:
+  attaching the name 'transactions' to the dict for the transactions trie:
+
+```cairo
+    let (transaction_ptr) = default_dict_new(0);
+    tempvar dict_ptr = transaction_ptr;
+    tempvar name = 'transactions';
+    %{ attach_name %}
+```
+
+- **Verification Logic**: In the CairoVM repo, `DictTracker` now includes
+  `is_squashed` (initialized `True`) and `name` fields (to make debugging
+  easier). Mutations (`get_value`, `insert_value`) set `is_squashed` to `False`,
+  and we modified our `dict_squash` function hint to explicitly set it to
+  `True`. As such ALL dict squash / finalizing must be done through our
+  `dict_squash` function (or our own default_dict_finalize) - in
+  `legacy.utils.dict`.
+- **End-to-End Check**: Tests in `test_main.py` use `cairo_run` with
+  `check_squashed_dicts=True` to verify all dicts are squashed post-execution,
+  ensuring soundness during proving.
+
+This mechanism helps catching unsquashed dicts are caught during testing,
+ensuring our usage of dicts is sound.
+
 ## AI-REPORT: Typing Module Union Order Issue (April 15, 2025)
 
 ### Issue with Typing Module

--- a/python/cairo-addons/src/cairo_addons/testing/runner.py
+++ b/python/cairo-addons/src/cairo_addons/testing/runner.py
@@ -352,7 +352,6 @@ def run_python_vm(
         verify_secure_runner(runner)
         runner.relocate()
 
-
         # ============================================================================
         # STEP 7: GENERATE OUTPUT FILES AND TRACE (IF REQUESTED)
         # ============================================================================
@@ -462,7 +461,7 @@ def run_rust_vm(
     request: FixtureRequest,
     coverage: Optional[Callable[[pl.DataFrame, int], pl.DataFrame]],
 ):
-    def _run(entrypoint, *args, **kwargs):
+    def _run(entrypoint, check_squashed_dicts: bool = False, *args, **kwargs):
         # ============================================================================
         # STEP 1: SELECT PROGRAM AND PREPARE ENTRYPOINT METADATA
         # - Rationale: Determine which program contains the entrypoint (main or test)
@@ -616,10 +615,11 @@ def run_rust_vm(
 
         runner.verify_secure_runner()
         runner.relocate()
-        
-        # Ensure all dicts are squashed properly
-        # (not implemented in python vm)
-        runner.verify_squashed_dicts()
+
+        if check_squashed_dicts:
+            # Ensure all dicts are squashed properly
+            # (not implemented in python vm)
+            runner.verify_squashed_dicts()
 
         # ============================================================================
         # STEP 7: GENERATE OUTPUT FILES AND TRACE (IF REQUESTED)

--- a/python/cairo-addons/src/cairo_addons/testing/runner.py
+++ b/python/cairo-addons/src/cairo_addons/testing/runner.py
@@ -352,6 +352,7 @@ def run_python_vm(
         verify_secure_runner(runner)
         runner.relocate()
 
+
         # ============================================================================
         # STEP 7: GENERATE OUTPUT FILES AND TRACE (IF REQUESTED)
         # ============================================================================
@@ -615,6 +616,10 @@ def run_rust_vm(
 
         runner.verify_secure_runner()
         runner.relocate()
+        
+        # Ensure all dicts are squashed properly
+        # (not implemented in python vm)
+        runner.verify_squashed_dicts()
 
         # ============================================================================
         # STEP 7: GENERATE OUTPUT FILES AND TRACE (IF REQUESTED)

--- a/python/cairo-addons/src/cairo_addons/testing/runner.py
+++ b/python/cairo-addons/src/cairo_addons/testing/runner.py
@@ -461,7 +461,7 @@ def run_rust_vm(
     request: FixtureRequest,
     coverage: Optional[Callable[[pl.DataFrame, int], pl.DataFrame]],
 ):
-    def _run(entrypoint, check_squashed_dicts: bool = False, *args, **kwargs):
+    def _run(entrypoint, *args, verify_squashed_dicts: bool = False, **kwargs):
         # ============================================================================
         # STEP 1: SELECT PROGRAM AND PREPARE ENTRYPOINT METADATA
         # - Rationale: Determine which program contains the entrypoint (main or test)
@@ -616,7 +616,7 @@ def run_rust_vm(
         runner.verify_secure_runner()
         runner.relocate()
 
-        if check_squashed_dicts:
+        if verify_squashed_dicts:
             # Ensure all dicts are squashed properly
             # (not implemented in python vm)
             runner.verify_squashed_dicts()

--- a/python/mpt/src/mpt/trie_diff.cairo
+++ b/python/mpt/src/mpt/trie_diff.cairo
@@ -63,7 +63,7 @@ from ethereum_rlp.rlp import (
 
 from starkware.cairo.common.builtin_poseidon.poseidon import poseidon_hash, poseidon_hash_many
 from legacy.utils.bytes import felt_to_bytes20_little
-from legacy.utils.dict import hashdict_read, hashdict_write, dict_new_empty, dict_read
+from legacy.utils.dict import hashdict_read, hashdict_write, dict_read
 from cairo_core.control_flow import raise
 from ethereum.utils.numeric import (
     ceil32,

--- a/python/mpt/src/mpt/trie_diff.cairo
+++ b/python/mpt/src/mpt/trie_diff.cairo
@@ -63,7 +63,7 @@ from ethereum_rlp.rlp import (
 
 from starkware.cairo.common.builtin_poseidon.poseidon import poseidon_hash, poseidon_hash_many
 from legacy.utils.bytes import felt_to_bytes20_little
-from legacy.utils.dict import hashdict_read, hashdict_write, dict_read
+from legacy.utils.dict import hashdict_read, hashdict_write, dict_new_empty, dict_read
 from cairo_core.control_flow import raise
 from ethereum.utils.numeric import (
     ceil32,

--- a/python/mpt/src/mpt/trie_diff.cairo
+++ b/python/mpt/src/mpt/trie_diff.cairo
@@ -109,6 +109,7 @@ from mpt.types import (
     OptionalUnionInternalNodeExtended,
     OptionalUnionInternalNodeExtendedEnum,
 )
+from legacy.utils.dict import dict_squash
 
 const EMPTY_TRIE_HASH_LOW = 0x6ef8c092e64583ffa655cc1b171fe856;
 const EMPTY_TRIE_HASH_HIGH = 0x21b463e3b52f6201c0ad6c991be0485b;
@@ -595,6 +596,20 @@ func compute_diff_entrypoint{
         parent_right=OptionalInternalNode(cast(0, InternalNodeEnum*)),
         path=path,
         account_address=account_address,
+    );
+
+    // Squash the dicts once used
+    dict_squash(
+        cast(node_store.value.dict_ptr_start, DictAccess*),
+        cast(node_store.value.dict_ptr, DictAccess*),
+    );
+    dict_squash(
+        cast(address_preimages.value.dict_ptr_start, DictAccess*),
+        cast(address_preimages.value.dict_ptr, DictAccess*),
+    );
+    dict_squash(
+        cast(storage_key_preimages.value.dict_ptr_start, DictAccess*),
+        cast(storage_key_preimages.value.dict_ptr, DictAccess*),
     );
 
     tempvar account_diff = AccountDiff(


### PR DESCRIPTION
Finally closes #535

**Dict Squashing Soundness**: To ensure all dictionaries are properly squashed
during block proving, we've implemented a verification mechanism in our CairoVM
runner.

- **Debugging Process**: Added `attach_name` hints in Cairo code to label
  dictionaries, aiding in tracking and debugging squashing status. e.g:
  attaching the name 'transactions' to the dict for the transactions trie:

```cairo
    let (transaction_ptr) = default_dict_new(0);
    tempvar dict_ptr = transaction_ptr;
    tempvar name = 'transactions';
    %{ attach_name %}
```

- **Verification Logic**: In the CairoVM repo, `DictTracker` now includes
  `is_squashed` (initialized `True`) and `name` fields (to make debugging
  easier). Mutations (`get_value`, `insert_value`) set `is_squashed` to `False`,
  and we modified our `dict_squash` function hint to explicitly set it to
  `True`. As such ALL dict squash / finalizing must be done through our
  `dict_squash` function (or our own default_dict_finalize) - in
  `legacy.utils.dict`.
- **End-to-End Check**: Tests in `test_main.py` (and EF-Tests) use `cairo_run` with
  `check_squashed_dicts=True` to verify all dicts are squashed post-execution,
  ensuring soundness during proving.

This mechanism helps catching unsquashed dicts are caught during testing,
ensuring our usage of dicts is sound.