### PR TITLE
fix: handle deleted accounts in a sound way

### DIFF
--- a/cairo/ethereum/cancun/fork.cairo
+++ b/cairo/ethereum/cancun/fork.cairo
@@ -671,6 +671,14 @@ func process_storage_deletions{range_check_ptr, poseidon_ptr: PoseidonBuiltin*, 
     let current = accessed_storage_keys.value.dict_ptr_start;
     let dict_ptr_stop = accessed_storage_keys.value.dict_ptr;
     if (current == dict_ptr_stop) {
+        // Squash the `accounts_to_delete` dict that was read
+        let (
+            squashed_accounts_to_delete_start, squashed_accounts_to_delete_end
+        ) = default_dict_finalize(
+            cast(accounts_to_delete.value.dict_ptr_start, DictAccess*),
+            cast(accounts_to_delete.value.dict_ptr, DictAccess*),
+            0,
+        );
         return ();
     }
 

--- a/cairo/ethereum/cancun/state.cairo
+++ b/cairo/ethereum/cancun/state.cairo
@@ -23,6 +23,9 @@ from ethereum.cancun.fork_types import (
     SetAddress,
     SetAddressStruct,
     SetAddressDictAccess,
+    SetTupleAddressBytes32,
+    SetTupleAddressBytes32Struct,
+    SetTupleAddressBytes32DictAccess,
     EMPTY_ACCOUNT,
     MappingTupleAddressBytes32U256,
     MappingTupleAddressBytes32U256Struct,
@@ -78,7 +81,6 @@ from legacy.utils.dict import (
     dict_write,
     hashdict_write,
     dict_new_empty,
-    get_keys_for_address_prefix,
     dict_update,
     dict_copy,
     default_dict_finalize,
@@ -349,11 +351,26 @@ func get_storage{poseidon_ptr: PoseidonBuiltin*, state: State}(
 
     return value;
 }
+from mpt.types import EMPTY_TRIE_HASH_LOW, EMPTY_TRIE_HASH_HIGH
 
-func destroy_account{poseidon_ptr: PoseidonBuiltin*, state: State}(address: Address) {
-    destroy_storage(address);
+// @notice Destroys an account
+// @dev This function should only be called to destroy accounts whose storage has not been mutated in the current transaction.
+//      We rely on checks on the pre-block storage root to check whether we need to do the expensive operation of iterating over all storage keys to delete them.
+func destroy_account{range_check_ptr, poseidon_ptr: PoseidonBuiltin*, state: State}(
+    address: Address
+) {
+    alloc_locals;
+    let account = get_account(address);
     let none_account = OptionalAccount(cast(0, AccountStruct*));
     set_account(address, none_account);
+    let storage_root = account.value.storage_root;
+    if (storage_root.value.low == EMPTY_TRIE_HASH_LOW and
+        storage_root.value.high == EMPTY_TRIE_HASH_HIGH) {
+        return ();
+    }
+    // If the account had storage prior to this block, we need to destroy it
+    // see eip-158, eip-161.
+    destroy_storage(address);
     return ();
 }
 
@@ -448,19 +465,54 @@ func get_storage_original{range_check_ptr, poseidon_ptr: PoseidonBuiltin*, state
     return value;
 }
 
-func destroy_storage{poseidon_ptr: PoseidonBuiltin*, state: State}(address: Address) {
+// @notice Destroys the storage of the given address.
+// @dev The implementation of this function requires iterating over all storage keys present in the state,
+// which is quite inefficient. This function should not be called outside of the unlikely case explained in
+// `process_create_message`.
+func destroy_storage{range_check_ptr, poseidon_ptr: PoseidonBuiltin*, state: State}(
+    address: Address
+) {
     alloc_locals;
 
-    let storage_tries = state.value._storage_tries;
     let fp_and_pc = get_fp_and_pc();
     local __fp__: felt* = fp_and_pc.fp_val;
 
-    let prefix_len = 1;
-    let prefix = &address.value;
-    tempvar dict_ptr = cast(storage_tries.value._data.value.dict_ptr, DictAccess*);
-    let keys = get_keys_for_address_prefix{dict_ptr=dict_ptr}(prefix_len, prefix);
+    // Squash the storage tries for more efficient iteration
+    let storage_tries = state.value._storage_tries;
+    let storage_tries_start = cast(storage_tries.value._data.value.dict_ptr_start, DictAccess*);
+    let storage_tries_end = cast(storage_tries.value._data.value.dict_ptr, DictAccess*);
+    let (squashed_storage_tries_start, squashed_storage_tries_end) = dict_squash(
+        storage_tries_start, storage_tries_end
+    );
+    tempvar squashed_storage_tries = TrieTupleAddressBytes32U256(
+        new TrieTupleAddressBytes32U256Struct(
+            secured=storage_tries.value.secured,
+            default=storage_tries.value.default,
+            _data=MappingTupleAddressBytes32U256(
+                new MappingTupleAddressBytes32U256Struct(
+                    dict_ptr_start=cast(
+                        squashed_storage_tries_start, TupleAddressBytes32U256DictAccess*
+                    ),
+                    dict_ptr=cast(squashed_storage_tries_end, TupleAddressBytes32U256DictAccess*),
+                    parent_dict=cast(0, MappingTupleAddressBytes32U256Struct*),
+                ),
+            ),
+        ),
+    );
 
-    _destroy_storage_keys{poseidon_ptr=poseidon_ptr, storage_tries_ptr=dict_ptr}(keys, 0);
+    // Gather the list of all storage keys belonging to this account and destroy them
+    let dict_ptr_start = cast(squashed_storage_tries.value._data.value.dict_ptr_start, DictAccess*);
+    let dict_ptr = cast(squashed_storage_tries.value._data.value.dict_ptr, DictAccess*);
+
+    let (storage_keys_buffer: TupleAddressBytes32*) = alloc();
+    tempvar storage_keys = ListTupleAddressBytes32(
+        new ListTupleAddressBytes32Struct(storage_keys_buffer, 0)
+    );
+    _get_storage_keys_for_address{
+        dict_ptr_start=dict_ptr_start, dict_ptr=dict_ptr, storage_keys=storage_keys
+    }(address);
+
+    _destroy_storage_keys{poseidon_ptr=poseidon_ptr, storage_tries_ptr=dict_ptr}(storage_keys, 0);
     let new_dict_ptr = cast(dict_ptr, TupleAddressBytes32U256DictAccess*);
 
     tempvar new_storage_tries_data = MappingTupleAddressBytes32U256(
@@ -486,6 +538,43 @@ func destroy_storage{poseidon_ptr: PoseidonBuiltin*, state: State}(address: Addr
     );
 
     return ();
+}
+
+// @notice Gathers all storage keys belonging to the given address.
+// @dev This is expensive as it requires iterating over all storage keys present in the state.
+//      However, this is only called when an empty account has storage, which is an unlikely event
+//      see eip-158, eip-161.
+func _get_storage_keys_for_address{
+    poseidon_ptr: PoseidonBuiltin*,
+    dict_ptr_start: DictAccess*,
+    dict_ptr: DictAccess*,
+    storage_keys: ListTupleAddressBytes32,
+}(address: Address) {
+    alloc_locals;
+
+    let current = dict_ptr_start;
+    let end = dict_ptr;
+
+    if (current == end) {
+        return ();
+    }
+
+    let key = [dict_ptr_start].key;
+    let preimage = get_tuple_address_bytes32_preimage_for_key(key, end);
+
+    if (preimage.value.address.value == address.value) {
+        assert storage_keys.value.data[storage_keys.value.len] = preimage;
+        tempvar storage_keys = ListTupleAddressBytes32(
+            new ListTupleAddressBytes32Struct(storage_keys.value.data, storage_keys.value.len + 1)
+        );
+    } else {
+        tempvar storage_keys = storage_keys;
+    }
+
+    let next = current + DictAccess.SIZE;
+    return _get_storage_keys_for_address{
+        dict_ptr_start=next, dict_ptr=end, storage_keys=storage_keys
+    }(address);
 }
 
 func _destroy_storage_keys{poseidon_ptr: PoseidonBuiltin*, storage_tries_ptr: DictAccess*}(
@@ -1028,7 +1117,10 @@ func touch_account{poseidon_ptr: PoseidonBuiltin*, state: State}(address: Addres
     return ();
 }
 
-func destroy_touched_empty_accounts{poseidon_ptr: PoseidonBuiltin*, state: State}(
+// @notice Destroys all empty accounts in the touched_accounts set.
+// @dev This typically only applies to accounts that were created pre eip-158, eip-161,
+// in which the storage is set (account exists in state) but is empty.
+func destroy_touched_empty_accounts{range_check_ptr, poseidon_ptr: PoseidonBuiltin*, state: State}(
     touched_accounts: SetAddress
 ) -> () {
     alloc_locals;
@@ -1046,22 +1138,23 @@ func destroy_touched_empty_accounts{poseidon_ptr: PoseidonBuiltin*, state: State
     let is_empty = account_exists_and_is_empty(address);
     if (is_empty.value != 0) {
         destroy_account(address);
+        tempvar range_check_ptr = range_check_ptr;
         tempvar poseidon_ptr = poseidon_ptr;
         tempvar state = state;
     } else {
+        tempvar range_check_ptr = range_check_ptr;
         tempvar poseidon_ptr = poseidon_ptr;
         tempvar state = state;
     }
 
     // Recurse with updated touched_accounts
-    return destroy_touched_empty_accounts(
-        SetAddress(
-            new SetAddressStruct(
-                dict_ptr_start=cast(current + DictAccess.SIZE, SetAddressDictAccess*),
-                dict_ptr=cast(end, SetAddressDictAccess*),
-            ),
+    tempvar next_iter = SetAddress(
+        new SetAddressStruct(
+            dict_ptr_start=cast(current + DictAccess.SIZE, SetAddressDictAccess*),
+            dict_ptr=cast(end, SetAddressDictAccess*),
         ),
     );
+    return destroy_touched_empty_accounts(next_iter);
 }
 
 func empty_transient_storage{range_check_ptr}() -> TransientStorage {

--- a/cairo/ethereum/cancun/state.cairo
+++ b/cairo/ethereum/cancun/state.cairo
@@ -494,7 +494,7 @@ func destroy_storage{range_check_ptr, poseidon_ptr: PoseidonBuiltin*, state: Sta
                         squashed_storage_tries_start, TupleAddressBytes32U256DictAccess*
                     ),
                     dict_ptr=cast(squashed_storage_tries_end, TupleAddressBytes32U256DictAccess*),
-                    parent_dict=cast(0, MappingTupleAddressBytes32U256Struct*),
+                    parent_dict=storage_tries.value._data.value.parent_dict,
                 ),
             ),
         ),
@@ -517,15 +517,17 @@ func destroy_storage{range_check_ptr, poseidon_ptr: PoseidonBuiltin*, state: Sta
 
     tempvar new_storage_tries_data = MappingTupleAddressBytes32U256(
         new MappingTupleAddressBytes32U256Struct(
-            dict_ptr_start=storage_tries.value._data.value.dict_ptr_start,
+            dict_ptr_start=squashed_storage_tries.value._data.value.dict_ptr_start,
             dict_ptr=new_dict_ptr,
-            parent_dict=storage_tries.value._data.value.parent_dict,
+            parent_dict=squashed_storage_tries.value._data.value.parent_dict,
         ),
     );
 
     tempvar new_storage_tries = TrieTupleAddressBytes32U256(
         new TrieTupleAddressBytes32U256Struct(
-            storage_tries.value.secured, storage_tries.value.default, new_storage_tries_data
+            squashed_storage_tries.value.secured,
+            squashed_storage_tries.value.default,
+            new_storage_tries_data,
         ),
     );
     tempvar state = State(

--- a/cairo/ethereum/cancun/state.cairo
+++ b/cairo/ethereum/cancun/state.cairo
@@ -30,6 +30,7 @@ from ethereum.cancun.fork_types import (
     MappingTupleAddressBytes32U256,
     MappingTupleAddressBytes32U256Struct,
     Account__eq__,
+    account_eq_without_storage_root,
     TupleAddressBytes32U256DictAccess,
     HashedTupleAddressBytes32,
     TupleAddressBytes32,
@@ -775,6 +776,9 @@ func mark_account_created{poseidon_ptr: PoseidonBuiltin*, state: State}(address:
     return ();
 }
 
+// @notice Returns whether the account exists and is empty.
+// @dev Emptiness is defined by balance(acct) == 0, code(acct) == "" and nonce(acct) == 0;
+//      emptiness of storage does not matter here. See eip-158.
 func account_exists_and_is_empty{poseidon_ptr: PoseidonBuiltin*, state: State}(
     address: Address
 ) -> bool {
@@ -784,11 +788,14 @@ func account_exists_and_is_empty{poseidon_ptr: PoseidonBuiltin*, state: State}(
 
     let _empty_account = EMPTY_ACCOUNT();
     let empty_account = OptionalAccount(_empty_account.value);
-    let is_empty_account = Account__eq__(account, empty_account);
+    let is_empty_account = account_eq_without_storage_root(account, empty_account);
 
     return is_empty_account;
 }
 
+// @notice Returns whether the account is alive.
+// @dev Emptiness is defined by balance(acct) == 0, code(acct) == "" and nonce(acct) == 0;
+//      emptiness of storage does not matter here. See eip-158.
 func is_account_alive{poseidon_ptr: PoseidonBuiltin*, state: State}(address: Address) -> bool {
     alloc_locals;
     let account = get_account_optional(address);
@@ -799,7 +806,7 @@ func is_account_alive{poseidon_ptr: PoseidonBuiltin*, state: State}(address: Add
 
     let _empty_account = EMPTY_ACCOUNT();
     let empty_account = OptionalAccount(_empty_account.value);
-    let is_empty_account = Account__eq__(account, empty_account);
+    let is_empty_account = account_eq_without_storage_root(account, empty_account);
 
     if (is_empty_account.value == 0) {
         tempvar res = bool(1);

--- a/cairo/legacy/utils/dict.cairo
+++ b/cairo/legacy/utils/dict.cairo
@@ -259,23 +259,6 @@ func prev_values{range_check_ptr}(dict_ptr_start: DictAccess*, dict_ptr_stop: Di
     return (prev_values_start=prev_values_start, prev_values_end=prev_values);
 }
 
-// @notice Returns all keys that have a prefix matching the given prefix.
-// TODO: this is unsound and soundness should be ensured at squash time.
-func get_keys_for_address_prefix{dict_ptr: DictAccess*}(
-    prefix_len: felt, prefix: felt*
-) -> ListTupleAddressBytes32 {
-    alloc_locals;
-
-    local keys_len: felt;
-    local keys: TupleAddressBytes32*;
-    %{ get_keys_for_address_prefix %}
-
-    // warning: this is unsound as the prover can return any list of keys.
-
-    tempvar res = ListTupleAddressBytes32(new ListTupleAddressBytes32Struct(keys, keys_len));
-    return res;
-}
-
 // @notice squashes the `src` dict and writes all its values to the `dst` dict.
 // @dev If the `dst` dict is not empty, the values are added to the existing values.
 // @param src: The source dict to squash.

--- a/cairo/tests/legacy/utils/test_dict.cairo
+++ b/cairo/tests/legacy/utils/test_dict.cairo
@@ -16,7 +16,6 @@ from ethereum.cancun.state import (
 from legacy.utils.dict import (
     prev_values,
     dict_update,
-    get_keys_for_address_prefix,
     squash_and_update,
     dict_squash,
     default_dict_finalize,
@@ -78,18 +77,6 @@ func test_dict_update{range_check_ptr}(
         ),
     );
     return result;
-}
-
-func test_get_keys_for_address_prefix{range_check_ptr}(
-    prefix_: Address, dict_entries: MappingTupleAddressBytes32U256
-) -> ListTupleAddressBytes32 {
-    alloc_locals;
-    let prefix_len = 1;
-    let (prefix: felt*) = alloc();
-    assert [prefix] = prefix_.value;
-    let dict_ptr = cast(dict_entries.value.dict_ptr, DictAccess*);
-    let res = get_keys_for_address_prefix{dict_ptr=dict_ptr}(prefix_len, prefix);
-    return res;
 }
 
 func test_squash_and_update{range_check_ptr}(

--- a/cairo/tests/legacy/utils/test_dict.py
+++ b/cairo/tests/legacy/utils/test_dict.py
@@ -105,17 +105,6 @@ def dict_with_prefix(draw):
     return dict_entries, prefix
 
 
-@given(dict_with_prefix=dict_with_prefix())
-def test_get_keys_for_address_prefix(cairo_run, dict_with_prefix):
-    dict_entries: Mapping[Tuple[Address, Bytes32], U256] = dict_with_prefix[0]
-    prefix: Address = dict_with_prefix[1]
-    keys = cairo_run("test_get_keys_for_address_prefix", prefix, dict_entries)
-    keys = [keys] if not isinstance(keys, list) else keys
-    assert set(tuple(k) for k in keys) == {
-        key for key in dict_entries.keys() if key[0] == prefix
-    }
-
-
 @given(src_dict=..., dst_dict=...)
 def test_squash_and_update(
     cairo_run,

--- a/crates/cairo-addons/src/vm/hint_definitions/dict.rs
+++ b/crates/cairo-addons/src/vm/hint_definitions/dict.rs
@@ -86,10 +86,18 @@ pub fn dict_squash() -> Hint {
             // all dicts were properly squashed.
             tracker.is_squashed = true;
             let copied_data = tracker.get_dictionary_copy();
+            let copied_default_value = tracker.get_default_value().cloned();
 
-            // Create new dict with copied data
-            let base = dict_manager.new_dict(vm, copied_data)?;
-
+            let base = match copied_default_value {
+                Some(default_value) => {
+                    // Create a new default dict with the copied data
+                    dict_manager.new_default_dict(vm, &default_value, Some(copied_data))?
+                }
+                None => {
+                    // Create a new regular dict with the copied data
+                    dict_manager.new_dict(vm, copied_data)?
+                }
+            };
             // Insert the new dictionary's base pointer into ap
             insert_value_into_ap(vm, base)
         },

--- a/crates/cairo-addons/src/vm/hint_definitions/hashdict.rs
+++ b/crates/cairo-addons/src/vm/hint_definitions/hashdict.rs
@@ -33,7 +33,6 @@ pub const HINTS: &[fn() -> Hint] = &[
     hashdict_read_from_key,
     get_preimage_for_key,
     copy_hashdict_tracker_entry,
-    get_keys_for_address_prefix,
     get_storage_keys_for_address,
 ];
 
@@ -113,96 +112,6 @@ pub fn hashdict_write() -> Hint {
 
             let hashed_key = compute_hash_key(&dict_key, key_len);
             dict_manager.preimages.insert(hashed_key.into(), dict_key);
-            Ok(())
-        },
-    )
-}
-
-pub fn get_keys_for_address_prefix() -> Hint {
-    Hint::new(
-        String::from("get_keys_for_address_prefix"),
-        |vm: &mut VirtualMachine,
-         exec_scopes: &mut ExecutionScopes,
-         ids_data: &HashMap<String, HintReference>,
-         ap_tracking: &ApTracking,
-         _constants: &HashMap<String, Felt252>|
-         -> Result<(), HintError> {
-            // Get dictionary tracker
-            let dict_ptr = get_ptr_from_var_name("dict_ptr", vm, ids_data, ap_tracking)?;
-            let dict_manager_ref = exec_scopes.get_dict_manager()?;
-            let dict = dict_manager_ref.borrow();
-            let tracker = dict.get_tracker(dict_ptr)?;
-
-            // Build prefix from memory
-            let prefix_ptr = get_ptr_from_var_name("prefix", vm, ids_data, ap_tracking)?;
-            let prefix_len_felt: Felt252 =
-                get_integer_from_var_name("prefix_len", vm, ids_data, ap_tracking)?;
-            let prefix_len: usize = prefix_len_felt
-                .try_into()
-                .map_err(|_| MathError::Felt252ToUsizeConversion(Box::new(prefix_len_felt)))?;
-
-            let prefix: Vec<MaybeRelocatable> = (0..prefix_len)
-                .map(|i| {
-                    let addr = (prefix_ptr + i)?;
-                    vm.get_maybe(&addr).ok_or_else(|| {
-                        HintError::Memory(MemoryError::UnknownMemoryCell(Box::new(addr)))
-                    })
-                })
-                .collect::<Result<_, _>>()?;
-
-            // Find matching preimages
-            let matching_preimages: Vec<&Vec<MaybeRelocatable>> = tracker
-                .get_dictionary_ref()
-                .keys()
-                .filter_map(|key| {
-                    if let DictKey::Compound(values) = key {
-                        // Check if values starts with prefix
-                        if values.len() >= prefix.len() && values[..prefix.len()] == prefix[..] {
-                            Some(values)
-                        } else {
-                            None
-                        }
-                    } else {
-                        None
-                    }
-                })
-                .collect();
-
-            // Allocate memory segments and write results
-            let base = vm.add_memory_segment();
-            for (i, preimage) in matching_preimages.iter().enumerate() {
-                let ptr = vm.add_memory_segment();
-                let bytes32_base = vm.add_memory_segment();
-
-                // Write the rest of preimage (excluding first element) to bytes32_base
-                for (j, value) in preimage[1..].iter().enumerate() {
-                    vm.insert_value((bytes32_base + j)?, value.clone())?;
-                }
-
-                // Write [first_element, bytes32_base] to ptr
-                vm.insert_value(ptr, preimage[0].clone())?;
-                vm.insert_value((ptr + 1)?, MaybeRelocatable::from(bytes32_base))?;
-
-                // Write ptr to base[i]
-                vm.insert_value((base + i)?, MaybeRelocatable::from(ptr))?;
-            }
-
-            // Set output values
-            insert_value_from_var_name(
-                "keys_len",
-                Felt252::from(matching_preimages.len()),
-                vm,
-                ids_data,
-                ap_tracking,
-            )?;
-            insert_value_from_var_name(
-                "keys",
-                MaybeRelocatable::from(base),
-                vm,
-                ids_data,
-                ap_tracking,
-            )?;
-
             Ok(())
         },
     )

--- a/python/cairo-addons/src/cairo_addons/hints/dict.py
+++ b/python/cairo-addons/src/cairo_addons/hints/dict.py
@@ -26,9 +26,13 @@ def dict_squash(
     memory: MemoryDict,
     ap: RelocatableValue,
 ):
+    from collections import defaultdict
+
     from starkware.cairo.common.dict import DictTracker
 
     data = dict_manager.get_dict(ids.dict_accesses_end).copy()
+    if isinstance(data, defaultdict):
+        data = defaultdict(data.default_factory, data)
     base = segments.add()
     assert base.segment_index not in dict_manager.trackers
     dict_manager.trackers[base.segment_index] = DictTracker(data=data, current_ptr=base)

--- a/python/cairo-addons/src/cairo_addons/hints/hashdict.py
+++ b/python/cairo-addons/src/cairo_addons/hints/hashdict.py
@@ -59,29 +59,6 @@ def hashdict_write(dict_manager: DictManager, ids: VmConsts, memory: MemoryDict)
 
 
 @register_hint
-def get_keys_for_address_prefix(
-    dict_manager: DictManager,
-    ids: VmConsts,
-    segments: MemorySegmentManager,
-    memory: MemoryDict,
-):
-    dict_tracker = dict_manager.get_tracker(ids.dict_ptr)
-    prefix = tuple([memory[ids.prefix + i] for i in range(ids.prefix_len)])
-    matching_preimages = [
-        key for key in dict_tracker.data.keys() if key[: len(prefix)] == prefix
-    ]
-    base = segments.add()
-    for i, preimage in enumerate(matching_preimages):
-        ptr = segments.add()
-        bytes32_base = segments.add()
-        segments.load_data(bytes32_base, preimage[1:])
-        segments.load_data(ptr, [preimage[0], bytes32_base])
-        memory[base + i] = ptr
-    ids.keys_len = len(matching_preimages)
-    ids.keys = base
-
-
-@register_hint
 def get_storage_keys_for_address(
     dict_manager: DictManager,
     ids: VmConsts,

--- a/python/keth-types/src/keth_types/patches.py
+++ b/python/keth-types/src/keth_types/patches.py
@@ -57,6 +57,7 @@ from keth_types.types import (
     Message,
     MessageCallOutput,
     Node,
+    account_exists_and_is_empty,
     encode_account,
     is_account_alive,
     set_code,
@@ -75,6 +76,7 @@ PATCHES: Dict[str, Dict[str, Any]] = {
         "encode_account": encode_account,
     },
     ethereum.cancun.state: {
+        "account_exists_and_is_empty": account_exists_and_is_empty,
         "is_account_alive": is_account_alive,
         "set_code": set_code,
     },

--- a/python/keth-types/src/keth_types/types.py
+++ b/python/keth-types/src/keth_types/types.py
@@ -294,12 +294,9 @@ def is_account_alive(state: State, address: Address) -> bool:
     if account is None:
         return False
     else:
-        # Modified to use EMPTY_ACCOUNT - we want to make sure the storage root and code_hash are
-        # empty.
-        # Remember: Account__eq__ does not take into account the storage root.
-        return (
-            not account == EMPTY_ACCOUNT or not account.storage_root == EMPTY_TRIE_HASH
-        )
+        # Modified to use EMPTY_ACCOUNT - we want to make sure the code_hash is empty instead.
+        # Remember: Account__eq__ does not take into account the storage root. (intended, see eip-158)
+        return not account == EMPTY_ACCOUNT
 
 
 def set_code(state: State, address: Address, code: Bytes) -> None:

--- a/python/keth-types/src/keth_types/types.py
+++ b/python/keth-types/src/keth_types/types.py
@@ -278,6 +278,14 @@ def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
     )
 
 
+def account_exists_and_is_empty(state: State, address: Address) -> bool:
+    from ethereum.cancun.state import get_account_optional
+
+    account = get_account_optional(state, address)
+    # The storage root is intended not to be taken into account here.
+    return account is not None and account == EMPTY_ACCOUNT
+
+
 # TODO PR in EELS?
 def is_account_alive(state: State, address: Address) -> bool:
     from ethereum.cancun.state import get_account_optional

--- a/python/keth-types/src/keth_types/types.py
+++ b/python/keth-types/src/keth_types/types.py
@@ -1,6 +1,6 @@
 import functools
 from collections import defaultdict
-from dataclasses import dataclass, fields, make_dataclass
+from dataclasses import dataclass, field, fields, make_dataclass
 from typing import (
     ClassVar,
     List,
@@ -158,11 +158,14 @@ class MessageCallOutput(
         namespace={"__doc__": MessageCallOutputBase.__doc__},
     )
 ):
+
+    accessed_storage_keys: Set[Tuple[Address, Bytes32]] = field(default_factory=set)
+
     def __eq__(self, other):
         return all(
             getattr(self, field.name) == getattr(other, field.name)
             for field in fields(self)
-            if field.name != "error"
+            if field.name != "error" and field.name != "accessed_storage_keys"
         ) and type(self.error) is type(other.error)
 
 

--- a/python/mpt/src/mpt/trie_diff.cairo
+++ b/python/mpt/src/mpt/trie_diff.cairo
@@ -108,11 +108,10 @@ from mpt.types import (
     AddressAccountDiffEntry,
     OptionalUnionInternalNodeExtended,
     OptionalUnionInternalNodeExtendedEnum,
+    EMPTY_TRIE_HASH_LOW,
+    EMPTY_TRIE_HASH_HIGH,
 )
 from legacy.utils.dict import dict_squash
-
-const EMPTY_TRIE_HASH_LOW = 0x6ef8c092e64583ffa655cc1b171fe856;
-const EMPTY_TRIE_HASH_HIGH = 0x21b463e3b52f6201c0ad6c991be0485b;
 
 // / @notice Implementation details for OptionalUnionInternalNodeExtended.
 namespace OptionalUnionInternalNodeExtendedImpl {

--- a/python/mpt/src/mpt/types.cairo
+++ b/python/mpt/src/mpt/types.cairo
@@ -10,6 +10,9 @@ from ethereum.cancun.fork_types import Address, HashedTupleAddressBytes32, Accou
 from ethereum_types.numeric import U256, Uint, Bool
 from ethereum.crypto.hash import Hash32
 
+const EMPTY_TRIE_HASH_LOW = 0x6ef8c092e64583ffa655cc1b171fe856;
+const EMPTY_TRIE_HASH_HIGH = 0x21b463e3b52f6201c0ad6c991be0485b;
+
 // NodeStore is a mapping of node hashes to their corresponding InternalNode
 // In the world state DB given as input to the program
 // This is used to store state and storage MPT nodes


### PR DESCRIPTION
Closes https://github.com/kkrt-labs/keth/issues/1108
Closes https://github.com/kkrt-labs/keth/issues/1382 (necessary fix in this pr)

Several things addressed in this PR. The main goal is to fix the way we handle deleted account, which currently is unsound. I started by identifying all such cases where we might encounter these cases of deletions. One thing to be careful about are rules remnant from outdated EVM forks, and the blocks >= Cancun we're going to prove. 

**Note:** It has been confirmed that, Post-Merge, there exists no account in the ethereum state that is empty but has storage.

### Remove storage destructions on empty accounts

As per [EIP-161](https://eips.ethereum.org/EIPS/eip-161)

>  Notes
> In the present Ethereum protocol, it should be noted that very few state changes can ultimately result in accounts that are empty following the execution of the transaction. In fact there are only four contexts that current implementations need track:
> 
> an empty account has zero value transferred to it through CALL;
> an empty account has zero value transferred to it through SUICIDE;
> an empty account has zero value transferred to it through a message-call transaction;
> an empty account has zero value transferred to it through a zero-gas-price fees transfer.

Related to: calling `destroy_account` on `coinbase` and `touched_empty_accounts`:
a. `get_account_optional` can return None or an Account
b. `trie_set` called with an EMPTY_ACCOUNT will delete this account from the trie
-> Thus, `get_account_optional` should theoritically never return an EMPTY_ACCOUNT, but always either None or an existing account.

**EXCEPT IF**: the account was created before [EIP-156](https://eips.ethereum.org/EIPS/eip-158) in which case it can be empty and have some storage, in which case, the storage is cleared.
Because we have access to the storage roots, we can include them in our check for EMPTY_ACCOUNT, which will make sure that, if the account is empty but has a non-empty storage root, we must destroy its storage.

It would be interesting to know whether some of these accounts still exist or not. Basically, this is a "self-cleaning" mechanism for the ethereum protocol to remove these old accounts.


### Handling storage deletions for SELFDESTRUCT-same-tx accounts

Accounts that are created in a TX and destructed in the same TX do not produce any state diff - and storage ends up being cleared. This means that:
- Any eventually touched storage key is in `accessed_storage_keys` of that transaction
- Instead of looking for the storage keys associated to this account in the State, we can look for them in `accessed_storage_keys`.
- This will reduce the amount of iterations performed.

### Handling of CREATE on contracts that already have storage (remnants of EIP-161, EIP-158)

As we saw previously, there exists accounts that are empty, BUT have state. As such,  the behavior of `process_create_message` is to, by default, erase any existing state associated to an account. 
An empty account can only have storage if it's a remnant of an old fork, meaning that it had not been created in the current block. As such, we have access to its storage root as per ZKPI inputs. Meaning that:
- If that storage root is the empty root, we can simply do nothing
- If that storage root is not empty, we must delete the existing storage.


From all these conditions, we can identify two distinct conditions:

- Storage destruction on empty accounts with storage that were created **before** the current block
- Storage destructions on accounts created in the same TX, and then selfdestructed.

For 1. 
- If the account has a storage root, then, we need to iterate on the state to delete any associated storage key. We're ensured these keys are present in the state, because ZKPI provides them (as they're _all_ deleted)
- If the account doesn't have a storage root, then, we have nothing to do, besides setting the account to `None`.

For 2.
- We can simply iterate of `accessed_storage_keys` and set the storage value to 0.
