### PR TITLE
fix: remove unused revm dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,7 +53,6 @@ checksum = "0069cf0642457f87a01a014f6dc29d5d893cd4fd8fddf0c3cdfad1bb3ebafc41"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "serde",
 ]
 
 [[package]]
@@ -65,7 +64,6 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "k256",
- "serde",
  "thiserror 2.0.11",
 ]
 
@@ -814,8 +812,7 @@ dependencies = [
  "pyo3",
  "pyo3-build-config",
  "pyo3-polars",
- "revm",
- "revm-precompile 17.0.0-alpha.1",
+ "revm-precompile",
  "serde_json",
  "starknet-crypto 0.7.4",
  "starknet-types-core",
@@ -3220,28 +3217,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a35e8a6bf28cd121053a66aa2e6a2e3eaffad4a60012179f0e864aa5ffeff215"
 
 [[package]]
-name = "revm"
-version = "19.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc5bef3c95fadf3b6a24a253600348380c169ef285f9780a793bb7090c8990d"
-dependencies = [
- "auto_impl",
- "cfg-if",
- "dyn-clone",
- "revm-interpreter",
- "revm-precompile 16.1.0",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "revm-bytecode"
 version = "1.0.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd9de895a8e07d390eefcd30fc19fd7b62519ee20d0a9d11c205081936f2b360"
 dependencies = [
  "bitvec",
- "revm-primitives 16.0.0-alpha.1",
+ "revm-primitives",
  "revm-specification",
 ]
 
@@ -3255,7 +3237,7 @@ dependencies = [
  "alloy-eip7702",
  "auto_impl",
  "revm-database-interface",
- "revm-primitives 16.0.0-alpha.1",
+ "revm-primitives",
  "revm-specification",
  "revm-state",
 ]
@@ -3267,37 +3249,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fd69db9a9b6dc96e6476e9af23f77255492a2f700e97be129d7c1b0f7488fe5"
 dependencies = [
  "auto_impl",
- "revm-primitives 16.0.0-alpha.1",
+ "revm-primitives",
  "revm-state",
-]
-
-[[package]]
-name = "revm-interpreter"
-version = "15.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dcab7ef2064057acfc84731205f4bc77f4ec1b35630800b26ff6a185731c5ab"
-dependencies = [
- "revm-primitives 15.2.0",
- "serde",
-]
-
-[[package]]
-name = "revm-precompile"
-version = "16.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6caa1a7ff2cc4a09a263fcf9de99151706f323d30f33d519ed329f017a02b046"
-dependencies = [
- "aurora-engine-modexp",
- "blst",
- "c-kzg",
- "cfg-if",
- "k256",
- "once_cell",
- "revm-primitives 15.2.0",
- "ripemd",
- "secp256k1",
- "sha2 0.10.8",
- "substrate-bn",
 ]
 
 [[package]]
@@ -3314,32 +3267,12 @@ dependencies = [
  "libsecp256k1",
  "once_cell",
  "revm-context-interface",
- "revm-primitives 16.0.0-alpha.1",
+ "revm-primitives",
  "revm-specification",
  "ripemd",
  "secp256k1",
  "sha2 0.10.8",
  "substrate-bn",
-]
-
-[[package]]
-name = "revm-primitives"
-version = "15.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f987564210317706def498421dfba2ae1af64a8edce82c6102758b48133fcb"
-dependencies = [
- "alloy-eip2930",
- "alloy-eip7702",
- "alloy-primitives",
- "auto_impl",
- "bitflags",
- "bitvec",
- "c-kzg",
- "cfg-if",
- "dyn-clone",
- "enumn",
- "hex",
- "serde",
 ]
 
 [[package]]
@@ -3358,7 +3291,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd8e98462b56a7443d344d309c407d4b37fc42239af599c615d8bfa3b6115a3"
 dependencies = [
  "enumn",
- "revm-primitives 16.0.0-alpha.1",
+ "revm-primitives",
 ]
 
 [[package]]
@@ -3369,7 +3302,7 @@ checksum = "18c8b01cd8901b6663805e65982e2c8c6264e00688cf4fd4e3b1f9e8ab4d1c37"
 dependencies = [
  "bitflags",
  "revm-bytecode",
- "revm-primitives 16.0.0-alpha.1",
+ "revm-primitives",
  "revm-specification",
 ]
 
@@ -3644,7 +3577,6 @@ version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44f86c3acccc9c65b153fe1b85a3be07fe5515274ec9f0653b4a0875731c72a6"
 dependencies = [
- "indexmap",
  "itoa",
  "memchr",
  "ryu",

--- a/crates/cairo-addons/Cargo.toml
+++ b/crates/cairo-addons/Cargo.toml
@@ -24,7 +24,6 @@ cairo-air = { workspace = true }
 num-traits = "0.2.18"
 num-bigint = "0.4.6"
 starknet-crypto = "0.7.4"
-revm = "19.4.0"
 revm-precompile = "17.0.0-alpha.1"
 lazy_static = "1.5.0"
 starknet-types-core = "0.1.7"


### PR DESCRIPTION
Removed unused revm dependency from cairo_addons crate that was detected by cargo-udeps. The revm-precompile library is used in the project, but revm itself is not.