### PR TITLE
ci: update setup-uv action to v5 in dependencies.yml

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -133,7 +133,7 @@ jobs:
           git config --global commit.gpgsign true
           echo "Git configured with signing key: $SIGNING_KEY"
 
-      - uses: astral-sh/setup-uv@v3
+      - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock


### PR DESCRIPTION
This PR updates the astral-sh/setup-uv action from v3 to v5 in dependencies.yml to align with the version used in action.yaml.
Using a consistent version ensures compatibility and stability across workflows.

Reference: [Official Astral docs – GitHub integration guide](https://docs.astral.sh/uv/guides/integration/github/)