### PR TITLE
ci: bump astral-sh/setup-uv action to v6

### DIFF
--- a/.github/actions/setup-environment/action.yaml
+++ b/.github/actions/setup-environment/action.yaml
@@ -35,7 +35,7 @@ runs:
         shared-key: "rust-cache"
 
     - name: Setup uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v6
       with:
         enable-cache: ${{ inputs.enable-uv-cache }}
         cache-dependency-glob: ${{ inputs.cache-dependency-glob }}

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -133,7 +133,7 @@ jobs:
           git config --global commit.gpgsign true
           echo "Git configured with signing key: $SIGNING_KEY"
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock


### PR DESCRIPTION
v6 halves install time, adds first-class dependency caching, and removes options deprecated in v5 that will break once runners drop legacy support. Upgrading keeps CI fast and future-proof