### PR TITLE
fix: load state compatible with EELS to chunk tx processing

### DIFF
--- a/cairo/tests/ethereum/cancun/keth/test_teardown.py
+++ b/cairo/tests/ethereum/cancun/keth/test_teardown.py
@@ -12,7 +12,10 @@ pytestmark = pytest.mark.cairo_file(
 class TestTeardown:
     @pytest.mark.parametrize(
         "zkpi_path",
-        [Path("test_data/22188088.json")],
+        [
+            Path("test_data/22188088.json"),
+            Path("test_data/22188102.json"),
+        ],
     )
     @pytest.mark.slow
     def test_teardown(self, cairo_run, zkpi_path):

--- a/python/keth-types/src/keth_types/types.py
+++ b/python/keth-types/src/keth_types/types.py
@@ -12,9 +12,7 @@ from typing import (
 )
 
 from ethereum.cancun.blocks import Receipt, Withdrawal
-from ethereum.cancun.fork_types import (
-    Address,
-)
+from ethereum.cancun.fork_types import Address
 from ethereum.cancun.state import State, TransientStorage
 from ethereum.cancun.transactions import (
     LegacyTransaction,

--- a/python/mpt/src/mpt/ethereum_tries.py
+++ b/python/mpt/src/mpt/ethereum_tries.py
@@ -417,9 +417,11 @@ class PreState:
             # Note: the ZKPI provides `0` values for empty storage slots instead of null values.
             for storage_key_hex, value in account["storage"].items():
                 storage_key_bytes = Bytes32.fromhex(storage_key_hex[2:])
-                storage_key_int = U256(int(value[2:], 16))
-                storage_key = None if int(storage_key_int) == 0 else storage_key_int
-                pre_state._storage_tries[address]._data[storage_key_bytes] = storage_key
+                storage_value_int = U256(int(value[2:], 16))
+                storage_value = storage_value_int if storage_value_int != 0 else None
+                pre_state._storage_tries[address]._data[
+                    storage_key_bytes
+                ] = storage_value
 
         return pre_state
 

--- a/python/mpt/src/mpt/hash_diff.cairo
+++ b/python/mpt/src/mpt/hash_diff.cairo
@@ -164,9 +164,6 @@ func _accumulate_storage_diff_hashes{poseidon_ptr: PoseidonBuiltin*}(
     }
     let current_diff = storage_diff.value.data[i];
     tempvar key = current_diff.value.key;
-    tempvar new_value = current_diff.value.new_value;
-    tempvar prev_value = current_diff.value.prev_value;
-    %{print(f"[TRIE STORAGE DIFF] At index {ids.i}, key={serialize(ids.key)}, new_value={serialize(ids.new_value)}, prev_value={serialize(ids.prev_value)}")%}
 
     let current_hash = poseidon_storage_diff(current_diff);
     assert buffer[i] = current_hash;
@@ -308,10 +305,6 @@ func _accumulate_state_storage_diff_hashes{poseidon_ptr: PoseidonBuiltin*}(
         return _accumulate_state_storage_diff_hashes(buffer, state_storage_diff, i + 1, len);
     }
 
-    tempvar _key = current_diff_ptr.key;
-    tempvar _prev_value = current_diff_ptr.prev_value;
-    tempvar _new_value = current_diff_ptr.new_value;
-    %{print(f"[STATE STORAGE DIFF] At index {ids.i}, key={serialize(ids._key)}, new_value={serialize(ids._new_value)}, prev_value={serialize(ids._prev_value)}")%}
     tempvar storage_diff_entry = StorageDiffEntry(
         new StorageDiffEntryStruct(
             key=current_diff_ptr.key, prev_value=prev_value, new_value=new_value

--- a/python/mpt/src/mpt/hash_diff.cairo
+++ b/python/mpt/src/mpt/hash_diff.cairo
@@ -164,6 +164,9 @@ func _accumulate_storage_diff_hashes{poseidon_ptr: PoseidonBuiltin*}(
     }
     let current_diff = storage_diff.value.data[i];
     tempvar key = current_diff.value.key;
+    tempvar new_value = current_diff.value.new_value;
+    tempvar prev_value = current_diff.value.prev_value;
+    %{print(f"[TRIE STORAGE DIFF] At index {ids.i}, key={serialize(ids.key)}, new_value={serialize(ids.new_value)}, prev_value={serialize(ids.prev_value)}")%}
 
     let current_hash = poseidon_storage_diff(current_diff);
     assert buffer[i] = current_hash;
@@ -305,6 +308,10 @@ func _accumulate_state_storage_diff_hashes{poseidon_ptr: PoseidonBuiltin*}(
         return _accumulate_state_storage_diff_hashes(buffer, state_storage_diff, i + 1, len);
     }
 
+    tempvar _key = current_diff_ptr.key;
+    tempvar _prev_value = current_diff_ptr.prev_value;
+    tempvar _new_value = current_diff_ptr.new_value;
+    %{print(f"[STATE STORAGE DIFF] At index {ids.i}, key={serialize(ids._key)}, new_value={serialize(ids._new_value)}, prev_value={serialize(ids._prev_value)}")%}
     tempvar storage_diff_entry = StorageDiffEntry(
         new StorageDiffEntryStruct(
             key=current_diff_ptr.key, prev_value=prev_value, new_value=new_value


### PR DESCRIPTION
Closes #1429

## Fix State Compatibility for EELS in Teardown Tests (May 3, 2025)

### Problem

A test failure occurred, particularly noticeable with the
`test_data/22188102.json` fixture, during the execution of the EELS `apply_body`
function within the Python `load_teardown_input` utility
(`cairo/utils/fixture_loader.py`). The issue stemmed from a mismatch between
Keth's internal `State` representation and the format expected by EELS:

1.  Keth's ZKPI loading and internal Python `State` object use `None` to
    represent accounts or storage slots that are absent or empty after being
    touched in a transaction - the reason being that any key accessed during the
    Cairo execution **must** appear in the python object.
2.  The EELS `apply_body` function expects such absent entries to be entirely
    missing from the state trie data structures, not represented as `None`. It
    also expects specific representations for zero/empty values (e.g., `b""` for
    code). Passing a `State` object containing `None` values directly to EELS
    `apply_body` led to incorrect execution or errors (like gas inconsistencies
    or `InvalidBlock` exceptions in direct EELS calls).

### Solution

The fix involved ensuring the `State` object is formatted correctly before being
passed to EELS `apply_body` and handling the ZKPI representation consistently:

1.  **Consistent ZKPI Loading**: Updated `mpt.ethereum_tries.PreState.from_data`
    to correctly interpret storage values of `0` from the ZKPI data as `None` in
    the Python `Trie` structure, representing absence/nullity in the pre-state,
    aligning with the April 22 changes.
2.  **EELS State Formatting**: Introduced a new utility function
    `format_state_for_eels` in `cairo/utils/fixture_loader.py`. This function
    cleans the `State` object by:
    - Removing account entries where the value is `None`.
    - Setting `code` to `b""` for accounts where it's `None`.
    - Removing storage entries where the value is `None`.
    - Removing entire storage tries if they become empty after cleaning.
3.  **Applying Formatting**: Modified `prepare_body_input` and
    `load_teardown_input` to call `format_state_for_eels` on the `State` object
    _before_ passing it to EELS functions like `apply_body`.
4.  **State Restoration**: Ensured that `load_teardown_input` correctly restores
    the `None` representations back into the `State` object _after_ the
    `apply_body` call, maintaining consistency with Keth's internal logic for
    subsequent steps (like teardown).
5.  **Testing**: Added `test_data/22188102.json` to `test_teardown.py` and
    introduced `test_e2e_eels` in `test_e2e.py` to specifically test EELS
    compatibility and verify gas calculations even when full state root
    verification fails due to partial ZKPI state.

### Impact

This change ensures that the `State` object passed to EELS functions conforms to
its expected format, resolving errors previously encountered during the Python
execution phase of teardown tests. It correctly handles the distinction between
absent/null values (`None` in Keth Python) and zero values (`U256(0)`, empty
accounts) when interacting with EELS.