### PR TITLE
Upgrade actions/create-github-app-token to v2

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -73,7 +73,7 @@ jobs:
           echo "$BODY" | envsubst >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@v2
         id: github_token
         with:
           app-id: ${{ secrets.KAKAROT_BOT_APP_ID }}
@@ -166,7 +166,7 @@ jobs:
           </details>" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@v2
         id: github_token
         with:
           app-id: ${{ secrets.KAKAROT_BOT_APP_ID }}


### PR DESCRIPTION
Switch the workflow step from `actions/create-github-app-token@v1` to `@v2`.  
v2 removes deprecated inputs (`app_id`, `private_key`, `skip_token_revoke`) and makes  
`app-id` and `private-key` mandatory.
[Reference](https://github.com/actions/create-github-app-token/releases/tag/v2)