### PR TITLE
fix typo: correct `branche` to `branch` in `dictionary.txt`

### DIFF
--- a/dictionary.txt
+++ b/dictionary.txt
@@ -27,7 +27,7 @@ BLOCKHASH
 BLSF
 BLSP
 BLSPBLSP2
-branche
+branch
 bytearray
 bytecodelen
 callcode


### PR DESCRIPTION


**Description:**
This PR fixes a spelling error in `dictionary.txt` by replacing the incorrectly spelled word `branche` with its correct form `branch`. 
