### PR TITLE
dev: add rust heap profiling with `dhat`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ dependencies = [
  "proptest",
  "rand 0.8.5",
  "ruint",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde",
  "sha3",
  "tiny-keccak",
@@ -878,6 +878,7 @@ dependencies = [
  "cairo-air",
  "cairo-vm",
  "chrono",
+ "dhat",
  "garaga_rs",
  "lazy_static",
  "num-bigint",
@@ -1263,6 +1264,22 @@ dependencies = [
  "quote",
  "syn 2.0.101",
  "unicode-xid",
+]
+
+[[package]]
+name = "dhat"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cd11d84628e233de0ce467de10b8633f4ddaecafadefc86e13b84b8739b827"
+dependencies = [
+ "backtrace",
+ "lazy_static",
+ "mintex",
+ "parking_lot",
+ "rustc-hash 1.1.0",
+ "serde",
+ "serde_json",
+ "thousands",
 ]
 
 [[package]]
@@ -2153,6 +2170,12 @@ checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
 ]
+
+[[package]]
+name = "mintex"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
 
 [[package]]
 name = "mio"
@@ -3660,6 +3683,12 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
@@ -4478,6 +4507,12 @@ dependencies = [
  "quote",
  "syn 2.0.101",
 ]
+
+[[package]]
+name = "thousands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "thread_local"

--- a/crates/cairo-addons/Cargo.toml
+++ b/crates/cairo-addons/Cargo.toml
@@ -18,6 +18,7 @@ pyo3 = { version = "0.23.3", features = [
   "num-bigint",
   "experimental-inspect",
 ] }
+dhat = "0.3"
 cairo-vm = { workspace = true }
 stwo-cairo-adapter = { workspace = true }
 stwo_cairo_prover = { workspace = true }
@@ -58,3 +59,7 @@ pyo3-build-config = "0.23.3" # Should match pyo3 version
 [features]
 extension-module = ["pyo3/extension-module"]
 default = ["extension-module", "pyo3/experimental-inspect"]
+dhat-heap = []                                              # heap-profiling with dhat
+
+[profile.release]
+debug = true # dhat needs debug symbols

--- a/crates/cairo-addons/src/lib.rs
+++ b/crates/cairo-addons/src/lib.rs
@@ -10,6 +10,10 @@ use tracing_subscriber::{
     fmt, fmt::format::FmtSpan, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter,
 };
 
+#[cfg(feature = "dhat-heap")]
+#[global_allocator]
+static ALLOCATOR: dhat::Alloc = dhat::Alloc;
+
 mod stwo_bindings;
 mod vm;
 

--- a/crates/cairo-addons/src/stwo_bindings.rs
+++ b/crates/cairo-addons/src/stwo_bindings.rs
@@ -30,6 +30,9 @@ fn get_keth_proof_config() -> ProverParameters {
 /// Python binding to generate a proof from prover inputs
 #[pyfunction]
 pub fn prove(prover_input_path: PathBuf, proof_path: PathBuf, serde_cairo: bool) -> PyResult<()> {
+    #[cfg(feature = "dhat-heap")]
+    let _profiler = dhat::Profiler::new_heap();
+
     let _ = setup_logging();
     let prover_input = prover_input_from_vm_output(&prover_input_path).map_err(to_pyerr)?;
     prove_with_stwo(prover_input, proof_path, serde_cairo, false).map_err(to_pyerr)

--- a/crates/cairo-addons/src/vm/runner.rs
+++ b/crates/cairo-addons/src/vm/runner.rs
@@ -753,6 +753,9 @@ pub fn run_end_to_end(
     serde_cairo: bool,
     verify: bool,
 ) -> PyResult<()> {
+    #[cfg(feature = "dhat-heap")]
+    let _profiler = dhat::Profiler::new_heap();
+
     // Initialize logging
     setup_logging().map_err(|e| {
         PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("Failed to setup logging: {}", e))

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -320,3 +320,4 @@ syscall
 scarb
 bootloaders
 tempvar
+dhat

--- a/python/cairo-addons/pyproject.toml
+++ b/python/cairo-addons/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 ]
 
 [tool.maturin]
-features = ["pyo3/extension-module"]
+features = ["pyo3/extension-module"]                   # add dhat-heap to enable heap profiling
 module-name = "cairo_addons.rust_bindings"
 python-packages = ["cairo_addons"]
 python-source = "src"


### PR DESCRIPTION
Adds a feature flag that enables profiling memory usage using `dhat`.