### PR TITLE
Update broken reference to EVM refund_counter calculation in test_storage.py

### DIFF
--- a/cairo/tests/ethereum/prague/vm/instructions/test_storage.py
+++ b/cairo/tests/ethereum/prague/vm/instructions/test_storage.py
@@ -271,7 +271,8 @@ class TestStorage:
         assert int(res) % DEFAULT_PRIME == int(res_cairo)
 
 
-# see https://github.com/ethereum/execution-specs/blob/6e652281164025f1f4227f6e5b0036c1bbd27347/src/ethereum/prague/vm/instructions/storage.py#L104
+# See refund_counter calculation in sstore function:
+# https://github.com/ethereum/execution-specs/blob/master/src/ethereum/prague/vm/instructions/storage.py#L54
 def _calculate_refund_counter_current_eq_new(
     current_refund_counter: Uint,
     original_value: U256,


### PR DESCRIPTION
Replaced the outdated link to the refund_counter calculation with an up-to-date reference to the sstore function in the official execution-specs repository. The comment is now in English and points directly to the relevant line in the current implementation. This improves code clarity and ensures future maintainers can easily find the canonical logic for refund_counter calculation.