### PR TITLE
mpt: enforce embedded subnode RLP size < 32 in branch/extension validation

### DIFF
--- a/python/mpt/src/mpt/utils.cairo
+++ b/python/mpt/src/mpt/utils.cairo
@@ -14,7 +14,7 @@ from ethereum.prague.trie import (
     SubnodesStruct,
     bytes_to_nibble_list,
 )
-from ethereum_rlp.rlp import Extended, ExtendedEnum, ExtendedImpl, decode
+from ethereum_rlp.rlp import Extended, ExtendedEnum, ExtendedImpl, decode, encode
 from ethereum_types.bytes import Bytes, BytesStruct
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.math_cmp import is_le_felt
@@ -184,6 +184,11 @@ func check_branch_node(node: BranchNode) {
         if (x.value.sequence.value.len == 0) {
             raise_ValueError('LTTwoNonNullSubnodes');
         }
+        // Embedded nodes must have RLP encoding size < 32
+        let encoded = encode(x);
+        if (encoded.value.len >= 32) {
+            raise_ValueError('EmbeddedNodeTooLarge');
+        }
     }
 
     // Check that the second subnode is not None and not empty
@@ -200,6 +205,11 @@ func check_branch_node(node: BranchNode) {
     if (cast(y.value.sequence.value, felt) != 0) {
         if (y.value.sequence.value.len == 0) {
             raise_ValueError('LTTwoNonNullSubnodes');
+        }
+        // Embedded nodes must have RLP encoding size < 32
+        let encoded = encode(y);
+        if (encoded.value.len >= 32) {
+            raise_ValueError('EmbeddedNodeTooLarge');
         }
     }
 
@@ -272,6 +282,11 @@ func check_extension_node(node: ExtensionNode, parent_node: OptionalInternalNode
     if (cast(sequence_variant, felt) != 0) {
         if (sequence_variant.len == 0) {
             raise_ValueError('EmptySubnode');
+        }
+        // Embedded node must have RLP encoding size < 32
+        let encoded = encode(subnode);
+        if (encoded.value.len >= 32) {
+            raise_ValueError('EmbeddedNodeTooLarge');
         }
         return ();
     }

--- a/python/mpt/src/mpt/utils.py
+++ b/python/mpt/src/mpt/utils.py
@@ -91,6 +91,15 @@ def check_branch_node(node: BranchNode) -> None:
     if len(non_null_subnodes) < 2:
         raise ValueError("LTTwoNonNullSubnodes")
 
+    # For each embedded subnode (represented as a list), ensure its RLP encoding is < 32 bytes
+    for subnode in node.subnodes:
+        if subnode in (None, b""):
+            continue
+        if isinstance(subnode, list):
+            encoded = rlp.encode(subnode)
+            if len(encoded) >= 32:
+                raise ValueError("EmbeddedNodeTooLarge")
+
 
 def check_leaf_node(path: Bytes, node: LeafNode) -> None:
     """
@@ -121,3 +130,9 @@ def check_extension_node(node: ExtensionNode, parent: Optional[InternalNode]) ->
 
     if parent is not None and isinstance(parent, ExtensionNode):
         raise ValueError("InvalidParent")
+
+    # If subnode is embedded (represented as a list), ensure its RLP encoding is < 32 bytes
+    if isinstance(node.subnode, list):
+        encoded = rlp.encode(node.subnode)
+        if len(encoded) >= 32:
+            raise ValueError("EmbeddedNodeTooLarge")


### PR DESCRIPTION
Enforces the MPT rule that embedded nodes must RLP-encode to fewer than 32 bytes. We now check embedded subnodes in `check_branch_node` and `check_extension_node` and error if their RLP size is ≥ 32. This hardens trie validation without affecting valid tries.

Closes #1376.