### PR TITLE
docs: update copyright year in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -7,4 +7,4 @@ You may choose to use this software under the terms of either:
 
 The full text of both licenses is included in this repository.
 
-Copyright (c) 2025 KKRT Labs
+Copyright (c) 2026 KKRT Labs

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Kakarot Labs
+Copyright (c) 2026 Kakarot Labs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Updates the copyright year from 2025 to 2026.

Keeping license files current for the new year.